### PR TITLE
Add empty state for details view

### DIFF
--- a/src/components/Explore/TracesByService/DetailsScene.tsx
+++ b/src/components/Explore/TracesByService/DetailsScene.tsx
@@ -7,11 +7,11 @@ import {
   SceneObjectUrlSyncConfig,
   SceneObjectUrlValues,
   SceneFlexItem,
-  SceneCanvasText,
   SceneFlexLayout,
 } from '@grafana/scenes';
 import { getTraceViewPanel } from '../panels/traceViewPanel';
 import { DetailsSceneUpdated } from '../../../utils/shared';
+import { EmptyStateScene } from 'components/emptyState/EmptyStateScene';
 
 export interface DetailsSceneState extends SceneObjectState {
   traceId?: string;
@@ -67,10 +67,10 @@ export class DetailsScene extends SceneObjectBase<DetailsSceneState> {
     } else {
       this.state.body.setState({
         children: [
-          new SceneCanvasText({
-            text: 'No details available',
-            fontSize: 20,
-            align: 'center',
+          new SceneFlexItem({
+            body: new EmptyStateScene({
+              message: "No trace selected" 
+            })
           }),
         ],
       });

--- a/src/components/emptyState/EmptyState.tsx
+++ b/src/components/emptyState/EmptyState.tsx
@@ -29,7 +29,10 @@ EmptyState.displayName = 'EmptyState';
 function getStyles() {
   return {
     container: css({
-      width: '100%'
+      width: '100%',
+      display: 'flex',
+      justifyContent: 'space-evenly',
+      flexDirection: 'column'
     }),
   };
 }


### PR DESCRIPTION
Adds an empty state for the details view.

![Screenshot 2024-04-08 at 15 43 55](https://github.com/grafana/explore-traces/assets/90795735/87a6a2c9-bf63-4be6-9fd4-1d5cd381419b)
