### PR TITLE
Add intro to mltp services

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,6 +23,7 @@ services:
     ports:
       - "3200:3200"   # tempo
 
+  # generates uninteresting traces, but is useful for testing
   k6-tracing:
     image: ghcr.io/grafana/xk6-client-tracing:latest
     environment:
@@ -30,3 +31,106 @@ services:
     restart: always
     depends_on:
       - tempo
+
+  # A collection of services designed to generate real telemetry
+  # Two regions are created: eu-east and us-west. Each region has a server and a requester.
+  # eu-east will fail occassionall, but us-west will always succeed to allow for exploration
+  # at the resource level
+  #  See github.com/grafana/intro-to-mltp
+
+  # A RabbitMQ queue used to send message between the requester and the server microservices.
+  mythical-queue:
+    image: rabbitmq:management
+    restart: always
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    healthcheck:
+      test: rabbitmq-diagnostics check_running
+      interval: 5s
+      timeout: 30s
+      retries: 10
+
+  # A postgres DB used to store data by the API server microservice.
+  mythical-database:
+    image: postgres:14.5
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: "mythical"
+    ports:
+      - "5432:5432"
+
+  # A microservice that makes requests to the API server microservice. Requests are also pushed onto the mythical-queue.
+  mythical-requester-A:
+    image: grafana/intro-to-mltp:mythical-beasts-requester-0.3.1
+    restart: always
+    depends_on:
+      mythical-queue:
+        condition: service_healthy
+      mythical-server-A:
+        condition: service_started
+    environment:
+      - MYTHICAL_SERVER_HOST_PORT=mythical-server-A:4000
+      - NAMESPACE=production
+      - TRACING_COLLECTOR_HOST=tempo
+      - TRACING_COLLECTOR_PORT=4317
+      - OTEL_EXPORTER_OTLP_TRACES_INSECURE=true
+      - OTEL_RESOURCE_ATTRIBUTES=ip=1.2.3.4,region=eu-east
+
+  # The API server microservice.
+  mythical-server-A:
+    image: grafana/intro-to-mltp:mythical-beasts-server-0.3.1
+    restart: always
+    depends_on:
+      - mythical-database
+    environment:
+      - NAMESPACE=production
+      - TRACING_COLLECTOR_HOST=tempo
+      - TRACING_COLLECTOR_PORT=4317
+      - OTEL_EXPORTER_OTLP_TRACES_INSECURE=true
+      - OTEL_RESOURCE_ATTRIBUTES=ip=1.2.3.5,region=eu-east
+
+   # A microservice that makes requests to the API server microservice. Requests are also pushed onto the mythical-queue.
+  mythical-requester-B:
+    image: grafana/intro-to-mltp:mythical-beasts-requester-0.3.1
+    restart: always
+    depends_on:
+      mythical-queue:
+        condition: service_healthy
+      mythical-server-B:
+        condition: service_started
+    environment:
+      - MYTHICAL_SERVER_HOST_PORT=mythical-server-B:4000
+      - NAMESPACE=production
+      - TRACING_COLLECTOR_HOST=tempo
+      - TRACING_COLLECTOR_PORT=4317
+      - OTEL_EXPORTER_OTLP_TRACES_INSECURE=true
+      - OTEL_RESOURCE_ATTRIBUTES=ip=1.2.4.4,region=us-west
+
+  # The API server microservice.
+  mythical-server-B:
+    image: grafana/intro-to-mltp:mythical-beasts-server-0.3.1
+    restart: always
+    depends_on:
+      - mythical-database
+    environment:
+      - NAMESPACE=production
+      - ALWAYS_SUCCEED=true
+      - TRACING_COLLECTOR_HOST=tempo
+      - TRACING_COLLECTOR_PORT=4317
+      - OTEL_EXPORTER_OTLP_TRACES_INSECURE=true
+      - OTEL_RESOURCE_ATTRIBUTES=ip=1.2.4.5,region=us-west
+
+  # A microservice that consumes requests from the mythical-queue
+  mythical-recorder:
+    image: grafana/intro-to-mltp:mythical-beasts-recorder-latest
+    restart: always
+    depends_on:
+      mythical-queue:
+        condition: service_healthy
+    environment:
+      - NAMESPACE=production
+      - TRACING_COLLECTOR_HOST=tempo
+      - TRACING_COLLECTOR_PORT=4317
+      - OTEL_EXPORTER_OTLP_TRACES_INSECURE=true
+      - OTEL_RESOURCE_ATTRIBUTES=ip=1.2.3.5


### PR DESCRIPTION
Adds the intro to mltp services to the local docker-compose. The services exist in two "regions": one that is failing and one that is succeeding. This allows exploration at the process/resource level to show value.

Grouped by service name shows the mythical server having errors:

![image](https://github.com/grafana/explore-traces/assets/2272392/9ee69ed6-db97-4cf4-b95d-2996f0a23904)

Grouped by region shows eu-east having errors but not us-west:

![image](https://github.com/grafana/explore-traces/assets/2272392/1939a5d3-a474-4571-8472-1c4e6b1ec191)
 