### PR TITLE
Modified options for BreakdownLabelSelector

### DIFF
--- a/src/components/Explore/BreakdownLabelSelector.tsx
+++ b/src/components/Explore/BreakdownLabelSelector.tsx
@@ -13,6 +13,7 @@ type Props = {
 };
 
 const mainAttributes = ['name', 'rootName', 'rootServiceName', 'status', 'span.http.status_code'];
+const hiddenAttributes = ['duration', 'traceDuration'];
 
 export function BreakdownLabelSelector({ options, value, onChange }: Props) {
   const styles = useStyles2(getStyles);
@@ -41,6 +42,13 @@ export function BreakdownLabelSelector({ options, value, onChange }: Props) {
 
   const otherOptions = options.filter((op) => !mainAttributes.includes(op.value?.toString()!));
 
+  const getModifiedOptions = (options: Array<SelectableValue<string>>) => {
+    return options 
+      .filter((op) => !hiddenAttributes.includes(op.value?.toString()!))
+      .filter((op) => 'resource.' !== op.value?.toString()?.substring(0, 9))
+      .map((op) => ({ label: op.label?.replace('span.', ''), value: op.value }));
+  }
+
   useEffect(() => {
     const { fontSize } = theme.typography;
     const text = mainOptions.map((option) => option.label || option.text || '').join(' ');
@@ -59,7 +67,7 @@ export function BreakdownLabelSelector({ options, value, onChange }: Props) {
           <Select
             {...{ value }}
             placeholder={'Other attributes'}
-            options={otherOptions}
+            options={getModifiedOptions(otherOptions)}
             onChange={(selected) => onChange(selected?.value ?? 'All')}
             className={styles.select}
             isClearable={true}
@@ -69,7 +77,7 @@ export function BreakdownLabelSelector({ options, value, onChange }: Props) {
         <Select
           {...{ value }}
           placeholder={'Select attribute'}
-          options={options}
+          options={getModifiedOptions(options)}
           onChange={(selected) => onChange(selected?.value ?? 'All')}
           className={styles.select}
           isClearable={true}


### PR DESCRIPTION
Based on Traces App Improvements doc, [item 6](https://docs.google.com/document/d/1BK3wRppg2SIGsq79ATGRYkher6hF-DK9JBz3HxuC8bY/edit#heading=h.7lp4ypq6etf3).

- duration and traceDuration removed,
- resource-level attributes removed,
- span. attributes displayed without the prefix.
