### PR TITLE
Structural Tab Updates

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       - ./provisioning:/etc/grafana/provisioning
 
   tempo:
-    image: grafana/tempo:main-5e26604
+    image: grafana/tempo:main-496b450
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ./devenv/tempo.yaml:/etc/tempo.yaml

--- a/src/components/Explore/TracesByService/Tabs/Structure/StructureScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Structure/StructureScene.tsx
@@ -153,7 +153,7 @@ function getVariablesSet() {
 function buildQuery() {
   return {
     refId: 'A',
-    query: `{${VAR_FILTERS_EXPR}} >> { ${VAR_STRUCTURE_FILTER_EXPR} } | select(status, resource.service.name, name, nestedSetParent, nestedSetLeft, nestedSetRight)`,
+    query: `{${VAR_FILTERS_EXPR}} &>> { ${VAR_STRUCTURE_FILTER_EXPR} } | select(status, resource.service.name, name, nestedSetParent, nestedSetLeft, nestedSetRight)`,
     queryType: 'traceql',
     tableType: 'raw',
     limit: 200,

--- a/src/components/Explore/TracesByService/Tabs/Structure/StructureTree.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Structure/StructureTree.tsx
@@ -53,7 +53,9 @@ interface TreeLineProps {
 const TreeLine = ({ node, depth, maxDuration }: TreeLineProps) => {
   const styles = useStyles2(getStyles);
 
-  const nodeAvgDuration = node.spans.reduce((acc, c) => acc + parseInt(c.durationNanos, 10), 0) / node.spans.length;
+  // parse and sum up all span durations
+  // nodeAvgDuration is in nanos, but formatDuration expects micros so divide by 1000
+  const nodeAvgDuration = (node.spans.reduce((acc, c) => acc + parseInt(c.durationNanos, 10), 0) / node.spans.length) / 1000;
   const erroredSpans = node.spans.reduce(
     (acc, c) => (c.attributes?.find((a) => a.key === 'status')?.value.stringValue === 'error' ? acc + 1 : acc),
     0


### PR DESCRIPTION
- Use the new union descendant operator `&>>`. This is available in dev/ops and produces better results than just `>>`.
- Fix the duration display (was off by a factor of 1000)
- Update the local Tempo to support structural operators.