### PR TITLE
Make full traces default. Move raw span data to the end

### DIFF
--- a/src/pages/Explore/primary-signals.ts
+++ b/src/pages/Explore/primary-signals.ts
@@ -2,10 +2,10 @@ import { SelectableValue } from '@grafana/data';
 
 export const primarySignalOptions: Array<SelectableValue<string>> = [
   {
-    label: 'All spans',
-    value: 'all_spans',
-    filter: { key: '', operator: '', value: true },
-    text: 'View and analyze raw span data',
+    label: 'Full traces',
+    value: 'full_traces',
+    filter: { key: 'nestedSetParent', operator: '<', value: '0' },
+    text: 'Inspect full journeys of requests across services',
   },
   {
     label: 'Server spans',
@@ -32,10 +32,10 @@ export const primarySignalOptions: Array<SelectableValue<string>> = [
     text: 'Evaluate the performance issues in database interactions',
   },
   {
-    label: 'Full traces',
-    value: 'full_traces',
-    filter: { key: 'nestedSetParent', operator: '<', value: '0' },
-    text: 'Inspect full journeys of requests across services',
+    label: 'All spans',
+    value: 'all_spans',
+    filter: { key: '', operator: '', value: true },
+    text: 'View and analyze raw span data',
   },
 ];
 


### PR DESCRIPTION
Per discussions in the weekly, let's promote "full traces" to the default option and move raw spans to the end. This accomplishes two things:

- Full traces are easier to understand when looking at the breakdowns on the second screen. When viewing full traces (aka root spans) there are no hidden dependencies on the second screen. All graphs are independent and explorable separately.
- Full traces results in better and more compelling structural information.
- Full traces is cheaper to count and will result in a more performant default experience.

![image](https://github.com/grafana/explore-traces/assets/2272392/757a2014-5a57-43e9-ace7-2e8da8fc022b)
