### PR TITLE
Adds conventional otel resource attributes to the defaults

### DIFF
--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -24,7 +24,10 @@ export const SPAN = 'Span';
 export const RESOURCE_ATTR = 'resource.';
 export const SPAN_ATTR = 'span.';
 
-export const radioAttributesResource = ['resource.service.name', 'resource.cluster', 'resource.environment', 'resource.namespace'];
+export const radioAttributesResource = ['resource.service.name', 'resource.service.namespace', 'resource.service.version',                                 // https://opentelemetry.io/docs/specs/semconv/resource/
+                                        'resource.cluster', 'resource.environment', 'resource.namespace',                                                  // custom
+                                        'resource.deployment.environment',                                                                                 // https://opentelemetry.io/docs/specs/semconv/resource/deployment-environment/
+                                        'resource.k8s.namespace.name', 'resource.k8s.pod.name', 'resource.k8s.container.name', 'resource.k8s.node.name'];  // https://opentelemetry.io/docs/specs/semconv/resource/k8s/
 export const radioAttributesSpan = ['name', 'kind', 'rootName', 'rootServiceName', 'status', 'statusMessage', 'span.http.status_code'];
 export const ignoredAttributes = ['duration', 'event:name', 'nestedSetLeft', 'nestedSetParent', 'nestedSetRight', 'span:id', 'trace:id', 'traceDuration'];
 


### PR DESCRIPTION
Adds OTEL resource attributes to the default list. Code comments indicate where each set of attribute names is sourced from.

This will improve the experience for those with conventional attribute names