### PR TITLE
Fix padding in filters

### DIFF
--- a/src/components/Explore/filters/MetricSelect.tsx
+++ b/src/components/Explore/filters/MetricSelect.tsx
@@ -58,8 +58,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     boxSizing: 'border-box',
     boxShadow: 'none',
 
-    '& > div': {
-      paddingLeft: '8px',
+    'svg': {
+      marginRight: '-4px',
     },
   }),
 });

--- a/src/components/Explore/filters/PrimarySignalRenderer.tsx
+++ b/src/components/Explore/filters/PrimarySignalRenderer.tsx
@@ -48,8 +48,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     boxSizing: 'border-box',
     boxShadow: 'none',
 
-    '& > div': {
-      paddingLeft: '8px',
+    'svg': {
+      marginRight: '-4px',
     },
   }),
 });


### PR DESCRIPTION
Note: did not add dropdown to the other attributes in the filters bar as it looks a bit too busy with all the icons. We should discuss this UX.

![Screenshot 2024-07-24 at 14 32 03](https://github.com/user-attachments/assets/78cf2d49-d4ab-4951-8eeb-44fdcef1e5c7)
