### PR TITLE
Only show valid intrinsics

### DIFF
--- a/src/components/Explore/filters/FilterRenderer.tsx
+++ b/src/components/Explore/filters/FilterRenderer.tsx
@@ -54,6 +54,7 @@ export function FilterRenderer({ filter, model, isWip }: Props) {
     const intrinsicAttributes = keys.filter(
       (k) => { 
         let checks = !k.value?.includes(RESOURCE_ATTR) && !k.value?.includes(SPAN_ATTR) && ignoredAttributes.indexOf(k.value!) === -1;
+
         // if filters (primary signal) has kind key selected, then don't add kind to intrinsicAttributes 
         // as you would overwrite it in the query if it's selected in the drop down
         if (filters.find((f) => f.key === 'kind')) {


### PR DESCRIPTION
e.g. if filters (primary signal) has kind key selected, then don't add kind to intrinsicAttributes as you would overwrite it in the query if it's selected in the drop down.

https://docs.google.com/document/d/1qqF78IT1U66WKk7Ms5mpi7vi1duWvu5kjYGqj8HKT-U/edit