### PR TITLE
Improve select performance

### DIFF
--- a/src/components/Explore/filters/FilterRenderer.tsx
+++ b/src/components/Explore/filters/FilterRenderer.tsx
@@ -162,7 +162,7 @@ export function FilterRenderer({ filter, model, isWip }: Props) {
         }
       }}
       onCloseMenu={() => setKeyQuery('')}
-      virtualized={true}
+      virtualized
     />
   );
 
@@ -187,7 +187,7 @@ export function FilterRenderer({ filter, model, isWip }: Props) {
         }
       }}
       onCloseMenu={() => setValueQuery('')}
-      virtualized={true}
+      virtualized
     />
   );
 


### PR DESCRIPTION
Limits the amount of values in the select drop down to 10,000 for performance and rendering.

When a user searches, they will be searching through all keys / values but will also limit to 10,000 items in the drop down.