### PR TITLE
Primary SIgnals: Remove http endpoints

### DIFF
--- a/src/pages/Explore/primary-signals.ts
+++ b/src/pages/Explore/primary-signals.ts
@@ -20,12 +20,6 @@ export const primarySignalOptions: Array<SelectableValue<string>> = [
     description: 'Analyze interactions initiated by consumer services',
   },
   {
-    label: 'HTTP endpoints',
-    value: 'http_endpoints',
-    filter: { key: 'span.http.path', operator: '!=', value: '""' },
-    description: 'Analyze activities at specific HTTP service points',
-  },
-  {
     label: 'Database calls',
     value: 'database_calls',
     filter: { key: 'span.db.name', operator: '!=', value: '""' },


### PR DESCRIPTION
This is a proposal to remove http endpoint from the list of options in the primary signal. For most orgs it will be essentially the same as server spans.

Also, in our data we have found that the metadata of http calls tends to be less consistent than the simple `kind = server` check of server spans.