### PR TITLE
Add more spacing between panels in comparison view

### DIFF
--- a/src/components/Explore/layouts/HighestDifferencePanel.tsx
+++ b/src/components/Explore/layouts/HighestDifferencePanel.tsx
@@ -94,6 +94,7 @@ function getStyles(theme: GrafanaTheme2) {
       border: `1px solid ${theme.colors.secondary.border}`,
       background: theme.colors.background.primary,
       padding: '8px',
+      marginBottom: theme.spacing(2),
       fontSize: '12px',
     }),
     differenceValue: css({

--- a/src/components/Explore/layouts/allComparison.ts
+++ b/src/components/Explore/layouts/allComparison.ts
@@ -16,7 +16,7 @@ export function buildAllComparisonLayout(
   return new ByFrameRepeater({
     body: new SceneCSSGridLayout({
       templateColumns: GRID_TEMPLATE_COLUMNS,
-      autoRows: '300px',
+      autoRows: '320px',
       children: [],
     }),
     getLayoutChild: getLayoutChild(getFrameName, actionsFn, metric),


### PR DESCRIPTION
Fixes https://github.com/grafana/explore-traces/issues/159

Note: I'm using 16px for the bottom margin, which looks more like the Figma design in the linked issue than 24px does :)

![Screenshot 2024-08-28 at 11 45 27](https://github.com/user-attachments/assets/81548643-dafe-4102-88b6-87d8ef1e9496)
