### PR TITLE
Add a tooltip to the comparison control button explaining what it does

### DIFF
--- a/src/components/Explore/TracesByService/ComparisonControl.tsx
+++ b/src/components/Explore/TracesByService/ComparisonControl.tsx
@@ -9,13 +9,14 @@ import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '..
 import { ComparisonSelection } from '../../../utils/shared';
 
 export interface ComparisonControlState extends SceneObjectState {
-  selection?: ComparisonSelection;
-  buttonLabel?: string;
+  selection: ComparisonSelection;
+  buttonLabel: string;
+  buttonTooltip: string;
 }
 
 export class ComparisonControl extends SceneObjectBase<ComparisonControlState> {
-  public constructor({ selection, buttonLabel }: ComparisonControlState) {
-    super({ selection, buttonLabel });
+  public constructor({ selection, buttonLabel, buttonTooltip }: ComparisonControlState) {
+    super({ selection, buttonLabel, buttonTooltip });
   }
 
   public startInvestigation = () => {
@@ -34,7 +35,7 @@ export class ComparisonControl extends SceneObjectBase<ComparisonControlState> {
   };
 
   public static Component = ({ model }: SceneComponentProps<ComparisonControl>) => {
-    const { buttonLabel } = model.useState();
+    const { buttonLabel, buttonTooltip } = model.useState();
     const { selection } = getTraceByServiceScene(model).useState();
     const styles = useStyles2(getStyles);
 
@@ -46,6 +47,7 @@ export class ComparisonControl extends SceneObjectBase<ComparisonControlState> {
           fill="solid"
           icon={selection ? 'times' : 'bolt'}
           onClick={selection ? model.stopInvestigation : model.startInvestigation}
+          tooltip={buttonTooltip}
         >
           {selection ? 'Clear investigation' : buttonLabel}
         </Button>

--- a/src/components/Explore/TracesByService/REDPanel.tsx
+++ b/src/components/Explore/TracesByService/REDPanel.tsx
@@ -133,7 +133,7 @@ export class REDPanel extends SceneObjectBase<RateMetricsPanelState> {
                     new ComparisonControl({
                       selection: { query: 'status = error' },
                       buttonLabel: 'Investigate errors',
-                      buttonTooltip: `Compares ${tooltipSignal} with errors (selection) to ${tooltipSignal} without errors (baseline)`,
+                      buttonTooltip: `Compares errored ${tooltipSignal} (selection) with non-errored ${tooltipSignal} (baseline)`,
                     })
                   ],
                 });

--- a/src/pages/Explore/primary-signals.ts
+++ b/src/pages/Explore/primary-signals.ts
@@ -1,11 +1,12 @@
 import { SelectableValue } from '@grafana/data';
 
+export const FULL_TRACES_VALUE = 'full_traces';
 export const DATABASE_CALLS_KEY = 'span.db.name';
 
 export const primarySignalOptions: Array<SelectableValue<string>> = [
   {
     label: 'Full traces',
-    value: 'full_traces',
+    value: FULL_TRACES_VALUE,
     filter: { key: 'nestedSetParent', operator: '<', value: '0' },
     description: 'Inspect full journeys of requests across services',
   },


### PR DESCRIPTION
Fixes https://github.com/grafana/explore-traces/issues/136

Small tweak with a big impact. See linked issue as there have been several users/customers who appreciated more explanation.

I'm not 100% happy with the tooltip aligning left, where only one word is on the second line. We can improve this if we don't go with the tabs. IMO the explanation is too helpful to leave out.