### PR TITLE
Update docker-compose: New grafana version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       context: ./.config
       args:
         grafana_image: ${GRAFANA_IMAGE:-grafana-dev}
-        grafana_version: ${GRAFANA_VERSION:-11.2.0-184141}
+        grafana_version: ${GRAFANA_VERSION:-11.3.0-196950}
     ports:
       - 3000:3000/tcp
     volumes:


### PR DESCRIPTION
Due to changes unknown to me the docker-compose no longer worked with the named grafana version.

Previously I was seeing this, but with the help of a few frontend dev wizards we updated the dev version to the one in this PR and it worked.
![image](https://github.com/user-attachments/assets/8fbbc7f3-7a6f-4374-94e9-6fcefc20b2da)
