### PR TITLE
Update workflows to use actions that don't need organization secrets

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -10,29 +10,12 @@ on:
 jobs:
   sync:
     if: github.repository == 'grafana/explore-traces'
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Clone website-sync Action
-        # WEBSITE_SYNC_TOKEN is a fine-grained GitHub Personal Access Token that expires.
-        # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
-        # GitHub administrator to update the organization secret.
-        # The IT helpdesk can update the organization secret.
-        run: git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync
-
-      - name: Publish to website repository (next)
-        uses: ./.github/actions/website-sync
-        id: publish-next
+      - uses: grafana/writers-toolkit/publish-technical-documentation@publish-technical-documentation/v1
         with:
-          repository: grafana/website
-          branch: master
-          host: github.com
-          # PUBLISH_TO_WEBSITE_TOKEN is a fine-grained GitHub Personal Access Token that expires.
-          # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
-          # GitHub administrator to update the organization secret.
-          # The IT helpdesk can update the organization secret.
-          github_pat: grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TOKEN }}
-          source_folder: docs/sources
-          target_folder: content/docs/explore-traces/next
-
+          website_directory: content/docs/explore-traces/next


### PR DESCRIPTION
Each repository can only have 100 organization secrets and there are now more than 100 in our organization which causes inconsistent behavior.

Some repositories don't have the secrets they need assigned.

These composite actions use secrets stored in Vault that are available to all repositories.

- `publish-technical-documentation-next.yml` has been tested with https://github.com/grafana/writers-toolkit/blob/main/.github/workflows/publish-technical-documentation.yml.

**Special notes for your reviewer**:

There is some copy-paste involved in the creation of these workflows. Please check:

For `publish-technical-documentation-next.yml`:

- [x] The `on.push` `branches` and `paths` filters are correct for your repository.
- [ ] The `jobs.sync.if` repository matches your repository.
- [ ] The `jobs.sync.steps[1].with.website_directory` matches the directory you publish to in the website repository.