### PR TITLE
Chore: Create cspell.config.json

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -1,10 +1,13 @@
 {
   "ignorePaths": [
+    "src",
+    "provisioning",
     "node_modules",
     "dist",
     "CHANGELOG.md",
     "package.json",
-    "*.test.*"
+    "*.test.*",
+    "*.yaml"
   ],
   "ignoreRegExpList": [],
   "words": []


### PR DESCRIPTION
Stubbing an empty spell check for the CI. 