### PR TITLE
Update publishing workflow

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 jobs:
   sync:
-    if: github.repository == 'grafana/explore-traces'
+    if: github.repository == 'grafana/traces-drilldown'
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
I'm assuming the guard has broken now that the repo has been renamed