### PR TITLE
Explore Logs integration fix for title mismatch and update url

### DIFF
--- a/src/module.tsx
+++ b/src/module.tsx
@@ -20,6 +20,6 @@ export const plugin = new AppPlugin<{}>().setRootPage(App).addConfigPage({
   icon: 'align-left',
   targets: 'grafana-lokiexplore-app/toolbar-open-related/v1',
   onClick: (e, helpers) => {
-    sidecarServiceSingleton_EXPERIMENTAL?.openApp(pluginJson.id, helpers.context);
+    sidecarServiceSingleton_EXPERIMENTAL?.openAppV3({ pluginId: pluginJson.id, path: '/explore' }, helpers.context);
   },
 });

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -60,7 +60,7 @@
     "addedLinks": [
       {
         "targets": ["grafana-lokiexplore-app/toolbar-open-related/v1"],
-        "title": "open traces",
+        "title": "traces",
         "description": "Open traces"
       }
     ],


### PR DESCRIPTION
Fixes a mismatch in plugin title which was preventing the `Related traces` button from being rendered. Also changes the route that the user is taken to when the button is clicked.

<img width="1155" alt="Screenshot 2025-02-19 at 07 08 28" src="https://github.com/user-attachments/assets/06d67c45-4024-423b-a186-a0b9620944ec" />
