### PR TITLE
Select custom columns in trace list

### DIFF
--- a/src/components/Explore/TracesByService/Tabs/Spans/SpanListColumnsSelector.test.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Spans/SpanListColumnsSelector.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { SpanListColumnsSelector } from './SpanListColumnsSelector';
+import { SelectableValue } from '@grafana/data';
+
+describe('SpanListColumnsSelector', () => {
+  const mockOptions: Array<SelectableValue<string>> = [
+    { label: 'Duration', value: 'duration' },
+    { label: 'Start Time', value: 'startTime' },
+    { label: 'Tags', value: 'tags' },
+  ];
+
+  const mockOnChange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should display "Show these extra columns" label', () => {
+    render(
+      <SpanListColumnsSelector
+        options={mockOptions}
+        onChange={mockOnChange} 
+      />
+    );
+
+    expect(screen.getByText('Show these extra columns')).toBeInTheDocument();
+  });
+
+  it('should show placeholder text when no value is selected', () => {
+    render(
+      <SpanListColumnsSelector
+        options={mockOptions}
+        onChange={mockOnChange}
+      />
+    );
+
+    expect(screen.getByText('Please select')).toBeInTheDocument();
+  });
+
+  it('should display pre-selected values', async () => {
+    render(
+      <SpanListColumnsSelector
+        options={mockOptions}
+        onChange={mockOnChange}
+        value="Duration,Tags"
+      />
+    );
+
+    expect(screen.getByText('Duration')).toBeInTheDocument();
+    expect(screen.getByText('Tags')).toBeInTheDocument();
+  });
+
+  it('should allow selecting multiple options', async () => {
+    const user = userEvent.setup();
+    
+    render(
+      <SpanListColumnsSelector
+        options={mockOptions}
+        onChange={mockOnChange}
+      />
+    );
+
+    // Open the combobox
+    const combobox = screen.getByRole('combobox');
+    await user.click(combobox);
+
+    // Select first option
+    const durationOption = screen.getByText('Duration');
+    await user.click(durationOption);
+    
+    expect(mockOnChange).toHaveBeenCalledWith('Duration');
+
+    // Select second option
+    await user.click(combobox);
+    const tagsOption = screen.getByText('Tags');
+    await user.click(tagsOption);
+
+    expect(mockOnChange).toHaveBeenCalledWith('Duration,Tags');
+  });
+
+  it('should display all available options when clicking the combobox', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SpanListColumnsSelector
+        options={mockOptions}
+        onChange={mockOnChange}
+      />
+    );
+
+    const combobox = screen.getByRole('combobox');
+    await user.click(combobox);
+
+    mockOptions.forEach((option) => {
+      if (option.label) {
+        expect(screen.getByText(option.label)).toBeInTheDocument();
+      }
+    });
+  });
+}); 

--- a/src/components/Explore/TracesByService/Tabs/Spans/SpanListColumnsSelector.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Spans/SpanListColumnsSelector.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import { SelectableValue } from '@grafana/data';
+import { Select, Field } from '@grafana/ui';
+import { VariableValue } from '@grafana/scenes';
+
+type Props = {
+  options: Array<SelectableValue<string>>;
+  onChange: (columns: string[]) => void;
+  value?: VariableValue;
+};
+
+export function SpanListColumnsSelector({ options, value, onChange }: Props) {
+  return (
+    <Field label="Show these extra columns">
+      <Select
+        value={value?.toString() !== '' ? value?.toString()?.split(',') ?? '' : ''}
+        placeholder={'Please select'}
+        options={options}
+        onChange={(x) => onChange(x.map((x: SelectableValue) => x.label).join(','))}
+        isMulti={true}
+        isClearable
+        virtualized
+        width={'auto'}
+      />
+    </Field>
+  );
+}

--- a/src/components/Explore/TracesByService/TracesByServiceScene.test.tsx
+++ b/src/components/Explore/TracesByService/TracesByServiceScene.test.tsx
@@ -1,0 +1,70 @@
+import { buildQuery } from './TracesByServiceScene';
+import { ComparisonSelection } from '../../../utils/shared';
+
+describe('TracesByServiceScene', () => {
+  describe('buildQuery', () => {
+    it('should build basic query with no selection', () => {
+      const query = buildQuery('rate', '');
+      expect(query).toEqual({
+        refId: 'A',
+        query: '{${filters}}',
+        queryType: 'traceql',
+        tableType: 'spans',
+        limit: 200,
+        spss: 10,
+        filters: [],
+      });
+    });
+
+    it('should add error status for error type', () => {
+      const query = buildQuery('errors', '');
+      expect(query.query).toBe('{${filters} && status = error}');
+    });
+
+    it('should add latency threshold for duration type with no selection', () => {
+      const query = buildQuery('duration', '');
+      expect(query.query).toBe('{${filters}&& duration > ${latencyThreshold}}');
+    });
+
+    it('should handle duration selection range', () => {
+      const selection: ComparisonSelection = {
+        type: 'manual',
+        duration: {
+          from: '100ms',
+          to: '500ms'
+        }
+      };
+      const query = buildQuery('duration', '', selection);
+      expect(query.query).toBe('{${filters}&& duration >= 100ms && duration <= 500ms}');
+    });
+
+    it('should handle duration selection with only from', () => {
+      const selection: ComparisonSelection = {
+        type: 'manual',
+        duration: {
+          from: '100ms',
+          to: ''
+        }
+      };
+      const query = buildQuery('duration', '', selection);
+      expect(query.query).toBe('{${filters}&& duration >= 100ms}');
+    });
+
+    it('should handle duration selection with only to', () => {
+      const selection: ComparisonSelection = {
+        type: 'manual',
+        duration: {
+          from: '',
+          to: '500ms'
+        }
+      };
+      const query = buildQuery('duration', '', selection);
+      expect(query.query).toBe('{${filters}&& duration <= 500ms}');
+    });
+
+    it('should add select columns when provided', () => {
+      const query = buildQuery('rate', 'duration,service.name');
+      expect(query.query).toBe('{${filters}} | select(duration,service.name)');
+    });
+  });
+}); 

--- a/src/components/Explore/TracesByService/TracesByServiceScene.tsx
+++ b/src/components/Explore/TracesByService/TracesByServiceScene.tsx
@@ -328,7 +328,7 @@ function getStyles(theme: GrafanaTheme2) {
 const MAIN_PANEL_HEIGHT = 240;
 export const MINI_PANEL_HEIGHT = (MAIN_PANEL_HEIGHT - 8) / 2;
 
-function buildQuery(type: MetricFunction, select: VariableValue, selection?: ComparisonSelection) {
+export function buildQuery(type: MetricFunction, select: VariableValue, selection?: ComparisonSelection) {
   const columns = select?.toString();
   const selectQuery = columns !== '' ? ` | select(${columns})` : '';
   let typeQuery = '';

--- a/src/components/Explore/TracesByService/TracesByServiceScene.tsx
+++ b/src/components/Explore/TracesByService/TracesByServiceScene.tsx
@@ -22,6 +22,7 @@ import {
   SceneObjectUrlValues,
   SceneQueryRunner,
   SceneTimeRange,
+  VariableValue,
 } from '@grafana/scenes';
 
 import { REDPanel } from './REDPanel';
@@ -39,7 +40,7 @@ import {
 import { getDataSourceSrv } from '@grafana/runtime';
 import { ActionViewType, TabsBarScene, actionViewsDefinitions } from './Tabs/TabsBarScene';
 import { isEqual } from 'lodash';
-import { getDatasourceVariable, getGroupByVariable, getTraceExplorationScene } from 'utils/utils';
+import { getDatasourceVariable, getGroupByVariable, getSpanListColumnsVariable, getTraceExplorationScene } from 'utils/utils';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../../utils/analytics';
 import { MiniREDPanel } from './MiniREDPanel';
 import { Icon, LinkButton, Stack, Tooltip, useStyles2 } from '@grafana/ui';
@@ -107,6 +108,12 @@ export class TracesByServiceScene extends SceneObjectBase<TraceSceneState> {
     this._subs.add(
       getDatasourceVariable(this).subscribeToState(() => {
         this.updateAttributes();
+      })
+    );
+
+    this._subs.add(
+      getSpanListColumnsVariable(this).subscribeToState(() => {
+        this.updateQueryRunner(metricVariable.getValue() as MetricFunction);
       })
     );
 
@@ -201,12 +208,13 @@ export class TracesByServiceScene extends SceneObjectBase<TraceSceneState> {
 
   private updateQueryRunner(metric: MetricFunction) {
     const selection = this.state.selection;
+    const select = getSpanListColumnsVariable(this).getValue();
 
     this.setState({
       $data: new SceneDataTransformer({
         $data: new SceneQueryRunner({
           datasource: explorationDS,
-          queries: [buildQuery(metric, selection)],
+          queries: [buildQuery(metric, select, selection)],
           $timeRange: timeRangeFromSelection(selection),
         }),
         transformations: [...filterStreamingProgressTransformations, ...spanListTransformations],
@@ -320,7 +328,9 @@ function getStyles(theme: GrafanaTheme2) {
 const MAIN_PANEL_HEIGHT = 240;
 export const MINI_PANEL_HEIGHT = (MAIN_PANEL_HEIGHT - 8) / 2;
 
-export function buildQuery(type: MetricFunction, selection?: ComparisonSelection) {
+function buildQuery(type: MetricFunction, select: VariableValue, selection?: ComparisonSelection) {
+  const columns = select?.toString();
+  const selectQuery = columns !== '' ? ` | select(${columns})` : '';
   let typeQuery = '';
   switch (type) {
     case 'errors':
@@ -346,7 +356,7 @@ export function buildQuery(type: MetricFunction, selection?: ComparisonSelection
   }
   return {
     refId: 'A',
-    query: `{${VAR_FILTERS_EXPR}${typeQuery}} | select(status)`,
+    query: `{${VAR_FILTERS_EXPR}${typeQuery}}${selectQuery}`,
     queryType: 'traceql',
     tableType: 'spans',
     limit: 200,

--- a/src/pages/Explore/TraceExploration.tsx
+++ b/src/pages/Explore/TraceExploration.tsx
@@ -29,6 +29,7 @@ import {
   VAR_LATENCY_PARTIAL_THRESHOLD,
   VAR_LATENCY_THRESHOLD,
   VAR_METRIC,
+  VAR_SPAN_LIST_COLUMNS,
 } from '../../utils/shared';
 import { getTraceExplorationScene, getFilterSignature, getFiltersVariable } from '../../utils/utils';
 import { TraceDrawerScene } from '../../components/Explore/TracesByService/TraceDrawerScene';
@@ -291,6 +292,10 @@ function getVariableSet(initialDS?: string, initialFilters?: AdHocVariableFilter
       }),
       new CustomVariable({
         name: VAR_GROUPBY,
+        defaultToAll: false,
+      }),
+      new CustomVariable({
+        name: VAR_SPAN_LIST_COLUMNS,
         defaultToAll: false,
       }),
       new CustomVariable({

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -40,6 +40,7 @@ export const USER_EVENTS_ACTIONS = {
     open_trace: 'open_trace',
     open_in_explore_clicked: 'open_in_explore_clicked',
     add_to_investigation_clicked: 'add_to_investigation_clicked',
+    span_list_columns_changed: 'span_list_columns_changed',
   },
   [USER_EVENTS_PAGES.home]: {
     homepage_initialized: 'homepage_initialized',

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -24,6 +24,7 @@ export const VAR_DATASOURCE_EXPR = '${ds}';
 export const VAR_FILTERS = 'filters';
 export const VAR_FILTERS_EXPR = '${filters}';
 export const VAR_GROUPBY = 'groupBy';
+export const VAR_SPAN_LIST_COLUMNS = 'spanListColumns';
 export const VAR_METRIC = 'metric';
 export const VAR_LATENCY_THRESHOLD = 'latencyThreshold';
 export const VAR_LATENCY_THRESHOLD_EXPR = '${latencyThreshold}';

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -22,6 +22,7 @@ import {
   VAR_LATENCY_PARTIAL_THRESHOLD,
   VAR_LATENCY_THRESHOLD,
   VAR_METRIC,
+  VAR_SPAN_LIST_COLUMNS,
 } from './shared';
 import { primarySignalOptions } from '../pages/Explore/primary-signals';
 import { TracesByServiceScene } from 'components/Explore/TracesByService/TracesByServiceScene';
@@ -109,6 +110,14 @@ export function getGroupByVariable(scene: SceneObject): CustomVariable {
   const variable = sceneGraph.lookupVariable(VAR_GROUPBY, scene);
   if (!(variable instanceof CustomVariable)) {
     throw new Error('Group by variable not found');
+  }
+  return variable;
+}
+
+export function getSpanListColumnsVariable(scene: SceneObject): CustomVariable {
+  const variable = sceneGraph.lookupVariable(VAR_SPAN_LIST_COLUMNS, scene);
+  if (!(variable instanceof CustomVariable)) {
+    throw new Error('Span list columns variable not found');
   }
   return variable;
 }


### PR DESCRIPTION
Allows users to add custom columns to their trace list.

This is useful for users where the current columns do not offer enough context into their data and there is a particular data point they are searching for.

![Screenshot 2025-02-20 at 09 44 53](https://github.com/user-attachments/assets/b8b41a20-ab1c-4768-a753-f89f42bf49d6)
