### PR TITLE
chore: update bundle-types.yml

### DIFF
--- a/.github/workflows/bundle-types.yml
+++ b/.github/workflows/bundle-types.yml
@@ -21,5 +21,5 @@ jobs:
 
       - uses: grafana/plugin-actions/bundle-types@main
         with:
-          entry-point: ./src/externalComponents/types.ts
+          entry-point: ./src/exposedComponents/types.ts
           ts-config: ./tsconfig-for-bundle-types.json


### PR DESCRIPTION
This PR fixes bundle types workflow config (wrong entry point path)