### PR TITLE
Update query-less to queryless

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Grafana Traces app
+# Grafana Traces Drilldown
 
-Grafana app plugin that allows users for a query-less way to navigate and visualize trace data stored in Explore Traces.
+Grafana app plugin that provides a queryless way for users to navigate and visualize trace data stored in Tempo.
 
 We love accepting contributions!
 If your change is minor, please feel free submit

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -7,7 +7,7 @@
   "autoEnabled": true,
   "info": {
     "keywords": ["app", "tempo", "traces", "explore"],
-    "description": "Grafana app plugin that allows users for a query-less way to navigate and visualize trace data stored in Tempo.",
+    "description": "Grafana app plugin that provides a queryless way for users to navigate and visualize trace data stored in Tempo",
     "author": {
       "name": "Grafana"
     },


### PR DESCRIPTION
👋 Hello friends! Just a small detail I noticed - we mostly use "queryless" (as seen in blog posts, the drilldowns overview, metrics drilldown, and writes toolkit), but I came across "query-less" being used here.

To keep things consistent, I created a quick PR to update it. I also noticed that other apps don’t have a period at the end of their descriptions, so I removed it from Traces Drilldown as well. Additionally, I slightly refined the description to make it clearer.

<img width="1673" alt="image" src="https://github.com/user-attachments/assets/9a21f4ee-d989-49bc-8626-c206cdb22f92" />
https://grafana.com/blog/2024/09/24/queryless-metrics-logs-traces-profiles/
<img width="819" alt="image" src="https://github.com/user-attachments/assets/7132d76f-c0d7-45c2-8be4-c42415636d34" />
