### PR TITLE
Investigations: add `fieldConfig` to investigations context

### DIFF
--- a/src/components/Explore/actions/AddToInvestigationButton.tsx
+++ b/src/components/Explore/actions/AddToInvestigationButton.tsx
@@ -1,9 +1,10 @@
-import { TimeRange } from '@grafana/data';
-import { sceneGraph, SceneObject, SceneObjectBase, SceneObjectState, SceneQueryRunner } from '@grafana/scenes';
+import { TimeRange, FieldConfigSource, FieldConfig } from '@grafana/data';
+import { sceneGraph, SceneObject, SceneObjectBase, SceneObjectState, SceneQueryRunner, VizPanel } from '@grafana/scenes';
 import { DataQuery, DataSourceRef } from '@grafana/schema';
 
 import Logo from '../../../../src/img/logo.svg';
 import { VAR_DATASOURCE_EXPR } from 'utils/shared';
+import { findObjectOfType } from 'utils/utils';
 
 export interface AddToInvestigationButtonState extends SceneObjectState {
   dsUid?: string;
@@ -11,6 +12,7 @@ export interface AddToInvestigationButtonState extends SceneObjectState {
   labelValue?: string;
   context?: ExtensionContext;
   queries: DataQuery[];
+  fieldConfig?: FieldConfigSource;
 }
 
 interface ExtensionContext {
@@ -60,7 +62,48 @@ export class AddToInvestigationButton extends SceneObjectBase<AddToInvestigation
     }
   };
 
+  private readonly getFieldConfig = () => {
+    const panel = findObjectOfType(this, (o) => o instanceof VizPanel, VizPanel);
+    const data = sceneGraph.getData(this);
+    const frames = data?.state.data?.series;
+    let fieldConfig = panel?.state.fieldConfig;
+    if (fieldConfig) {
+      if (frames) {
+        for (const frame of frames) {
+          for (const field of frame.fields) {
+            const configKeys = Object.keys(field.config);
+            const properties = configKeys.map((key) => ({
+              id: key,
+              value: field.config[key as keyof FieldConfig],
+            }));
+
+            // check if the override already exists
+            const existingOverride = fieldConfig.overrides.find(
+              (o) => o.matcher.options === (field.config.displayNameFromDS ?? field.config.displayName ?? field.name) && o.matcher.id === 'byName'
+            );
+            if (!existingOverride) {
+              // add as first override
+              fieldConfig.overrides.unshift({
+                matcher: {
+                  id: 'byName',
+                  options: field.config.displayNameFromDS ?? field.config.displayName ?? field.name,
+                },
+                properties,
+              });
+            }
+
+            if (existingOverride && JSON.stringify(existingOverride.properties) !== JSON.stringify(properties)) {
+              existingOverride.properties = properties;
+            }
+          }
+        }
+      }
+    }
+    return fieldConfig;
+  };
+
   private readonly getContext = () => {
+    const fieldConfig = this.getFieldConfig();
     const { queries, dsUid, labelValue } = this.state;
     const timeRange = sceneGraph.getTimeRange(this);
 
@@ -77,6 +120,7 @@ export class AddToInvestigationButton extends SceneObjectBase<AddToInvestigation
       id: `${JSON.stringify(queries)}`,
       title: `${labelValue}`,
       logoPath: Logo,
+      fieldConfig,
     };
     if (JSON.stringify(ctx) !== JSON.stringify(this.state.context)) {
       this.setState({ context: ctx });

--- a/src/components/Explore/actions/AddToInvestigationButton.tsx
+++ b/src/components/Explore/actions/AddToInvestigationButton.tsx
@@ -1,5 +1,12 @@
 import { TimeRange, FieldConfigSource, FieldConfig } from '@grafana/data';
-import { sceneGraph, SceneObject, SceneObjectBase, SceneObjectState, SceneQueryRunner, VizPanel } from '@grafana/scenes';
+import {
+  sceneGraph,
+  SceneObject,
+  SceneObjectBase,
+  SceneObjectState,
+  SceneQueryRunner,
+  VizPanel,
+} from '@grafana/scenes';
 import { DataQuery, DataSourceRef } from '@grafana/schema';
 
 import Logo from '../../../../src/img/logo.svg';
@@ -61,40 +68,40 @@ export class AddToInvestigationButton extends SceneObjectBase<AddToInvestigation
       }
     }
   };
-
+  
   private readonly getFieldConfig = () => {
     const panel = findObjectOfType(this, (o) => o instanceof VizPanel, VizPanel);
     const data = sceneGraph.getData(this);
     const frames = data?.state.data?.series;
     let fieldConfig = panel?.state.fieldConfig;
-    if (fieldConfig) {
-      if (frames) {
-        for (const frame of frames) {
-          for (const field of frame.fields) {
-            const configKeys = Object.keys(field.config);
-            const properties = configKeys.map((key) => ({
-              id: key,
-              value: field.config[key as keyof FieldConfig],
-            }));
+    if (fieldConfig && frames?.length) {
+      for (const frame of frames) {
+        for (const field of frame.fields) {
+          const configKeys = Object.keys(field.config);
+          const properties = configKeys.map((key) => ({
+            id: key,
+            value: field.config[key as keyof FieldConfig],
+          }));
 
-            // check if the override already exists
-            const existingOverride = fieldConfig.overrides.find(
-              (o) => o.matcher.options === (field.config.displayNameFromDS ?? field.config.displayName ?? field.name) && o.matcher.id === 'byName'
-            );
-            if (!existingOverride) {
-              // add as first override
-              fieldConfig.overrides.unshift({
-                matcher: {
-                  id: 'byName',
-                  options: field.config.displayNameFromDS ?? field.config.displayName ?? field.name,
-                },
-                properties,
-              });
-            }
+          // check if the override already exists
+          const existingOverride = fieldConfig.overrides.find(
+            (o) =>
+              o.matcher.options === (field.config.displayNameFromDS ?? field.config.displayName ?? field.name) &&
+              o.matcher.id === 'byName'
+          );
+          if (!existingOverride) {
+            // add as first override
+            fieldConfig.overrides.unshift({
+              matcher: {
+                id: 'byName',
+                options: field.config.displayNameFromDS ?? field.config.displayName ?? field.name,
+              },
+              properties,
+            });
+          }
 
-            if (existingOverride && JSON.stringify(existingOverride.properties) !== JSON.stringify(properties)) {
-              existingOverride.properties = properties;
-            }
+          if (existingOverride && JSON.stringify(existingOverride.properties) !== JSON.stringify(properties)) {
+            existingOverride.properties = properties;
           }
         }
       }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -213,3 +213,22 @@ export const formatLabelValue = (value: string) => {
   }
   return value;
 };
+
+interface SceneType<T> extends Function {
+  new (...args: never[]): T;
+}
+
+export function findObjectOfType<T extends SceneObject>(
+  scene: SceneObject,
+  check: (obj: SceneObject) => boolean,
+  returnType: SceneType<T>
+) {
+  const obj = sceneGraph.findObject(scene, check);
+  if (obj instanceof returnType) {
+    return obj;
+  } else if (obj !== null) {
+    console.warn(`invalid return type: ${returnType.toString()}`);
+  }
+
+  return null;
+}


### PR DESCRIPTION
Corresponding PR for https://github.com/grafana/investigations-app/pull/229 to pass `fieldConfig` to the investigations app in order to keep same colors, etc of panels.