### PR TITLE
fix(open in drilldown button): update tempo matcher type

### DIFF
--- a/src/exposedComponents/types.ts
+++ b/src/exposedComponents/types.ts
@@ -2,7 +2,7 @@
 export type TempoMatcher = {
   name: string;
   value: string;
-  operator: '=' | '!=' | '>' | '<';
+  operator: '=' | '!=' | '>' | '<' | '=~' | '!~';
 };
 
 export interface OpenInExploreTracesButtonProps {


### PR DESCRIPTION
Added regex operators to TempoMatcher type so external plugins pass the correct matchers.