### PR TITLE
Switch to userStorage for bookmarks

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@swc/helpers": "^0.5.15",
     "@swc/jest": "^0.2.37",
     "@testing-library/jest-dom": "6.5.0",
+    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^29.5.14",
     "@types/lodash": "^4.17.13",

--- a/src/components/Explore/panels/barsPanel.ts
+++ b/src/components/Explore/panels/barsPanel.ts
@@ -4,11 +4,9 @@ import { DrawStyle, StackingMode, TooltipDisplayMode } from '@grafana/ui';
 export const barsPanelConfig = () => {
   return PanelBuilders.timeseries()
     .setOption('legend', { showLegend: false })
-    .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
+    .setCustomFieldConfig('drawStyle', DrawStyle.Line)
     .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
-    .setCustomFieldConfig('fillOpacity', 100)
-    .setCustomFieldConfig('lineWidth', 0)
-    .setCustomFieldConfig('pointSize', 0)
+    .setCustomFieldConfig('fillOpacity', 15)
     .setCustomFieldConfig('axisLabel', 'Rate')
     .setOverrides((overrides) => {
       overrides.matchFieldsWithNameByRegex('.*"?error"?.*').overrideColor({

--- a/src/components/Explore/panels/barsPanel.ts
+++ b/src/components/Explore/panels/barsPanel.ts
@@ -4,9 +4,11 @@ import { DrawStyle, StackingMode, TooltipDisplayMode } from '@grafana/ui';
 export const barsPanelConfig = () => {
   return PanelBuilders.timeseries()
     .setOption('legend', { showLegend: false })
-    .setCustomFieldConfig('drawStyle', DrawStyle.Line)
+    .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
     .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
-    .setCustomFieldConfig('fillOpacity', 15)
+    .setCustomFieldConfig('fillOpacity', 100)
+    .setCustomFieldConfig('lineWidth', 0)
+    .setCustomFieldConfig('pointSize', 0)
     .setCustomFieldConfig('axisLabel', 'Rate')
     .setOverrides((overrides) => {
       overrides.matchFieldsWithNameByRegex('.*"?error"?.*').overrideColor({

--- a/src/pages/Home/bookmarks/Bookmarks.test.tsx
+++ b/src/pages/Home/bookmarks/Bookmarks.test.tsx
@@ -1,10 +1,8 @@
-import React from 'react';
+import React, { act } from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { act } from 'react';
 import { Bookmarks, Bookmark } from './Bookmarks';
-import { getBookmarkForUrl, goToBookmark } from './utils';
+import { getBookmarkForUrl, goToBookmark, useBookmarksStorage } from './utils';
 import { locationService } from '@grafana/runtime';
-import { useBookmarksStorage } from './utils';
 
 // Mock the BookmarkItem component
 jest.mock('./BookmarkItem', () => ({

--- a/src/pages/Home/bookmarks/Bookmarks.tsx
+++ b/src/pages/Home/bookmarks/Bookmarks.tsx
@@ -1,11 +1,9 @@
 import { css } from "@emotion/css";
 import { GrafanaTheme2 } from "@grafana/data";
-import { locationService } from "@grafana/runtime";
 import { Button, useStyles2, LoadingPlaceholder } from "@grafana/ui";
 import React, { useEffect, useState } from "react";
 import { BookmarkItem } from "./BookmarkItem";
-import { getBookmarkForUrl, useBookmarksStorage } from "./utils";
-import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from "utils/analytics";
+import { useBookmarksStorage, goToBookmark } from "./utils";
 
 export type Bookmark = {
   params: string;
@@ -34,13 +32,6 @@ export const Bookmarks = () => {
     
     fetchBookmarks();
   }, []);
-
-  const goToBookmark = (bookmark: Bookmark) => {
-    reportAppInteraction(USER_EVENTS_PAGES.home, USER_EVENTS_ACTIONS.home.go_to_bookmark_clicked);
-
-    const url = getBookmarkForUrl(bookmark);
-    locationService.push(url);
-  }
 
   const removeBookmarkClicked = async (bookmark: Bookmark, event: React.MouseEvent) => {
     event.stopPropagation();

--- a/src/pages/Home/bookmarks/utils.ts
+++ b/src/pages/Home/bookmarks/utils.ts
@@ -1,6 +1,9 @@
 import { ACTION_VIEW, PRIMARY_SIGNAL, VAR_FILTERS, FILTER_SEPARATOR, BOOKMARKS_LS_KEY, EXPLORATIONS_ROUTE, VAR_LATENCY_PARTIAL_THRESHOLD, VAR_LATENCY_THRESHOLD, SELECTION, VAR_METRIC } from "utils/shared";
 import { Bookmark } from "./Bookmarks";
 import { urlUtil } from "@grafana/data";
+import { usePluginUserStorage } from '@grafana/runtime';
+
+type PluginStorage = ReturnType<typeof usePluginUserStorage>;
 
 const cleanupParams = (params: URLSearchParams) => {
   // Remove selection, latency threshold, and latency partial threshold because
@@ -11,14 +14,16 @@ const cleanupParams = (params: URLSearchParams) => {
   return params;
 }
 
-export const getBookmarks = (): Bookmark[] => {
-  try {
-    return JSON.parse(localStorage.getItem(BOOKMARKS_LS_KEY) || "[]");
-  } catch (e) {
-    console.error("Failed to get bookmarks from localStorage:", e);
-    return [];
-  }
-}
+export const useBookmarksStorage = () => {
+  const storage = usePluginUserStorage();
+  
+  return {
+    getBookmarks: () => getBookmarks(storage),
+    removeBookmark: (bookmark: Bookmark) => removeBookmark(storage, bookmark),
+    bookmarkExists: (bookmark: Bookmark) => bookmarkExists(storage, bookmark),
+    toggleBookmark: () => toggleBookmark(storage),
+  };
+};
 
 export const getBookmarkParams = (bookmark: Bookmark) => {
   if (!bookmark || !bookmark.params) {
@@ -56,35 +61,56 @@ export const getBookmarkForUrl = (bookmark: Bookmark): string => {
   return url;
 }
 
-export const toggleBookmark = (): boolean => {
+const setBookmarks = async (storage: PluginStorage, bookmarks: Bookmark[]): Promise<void> => {
+  try {
+    await storage.setItem(BOOKMARKS_LS_KEY, JSON.stringify(bookmarks));
+  } catch (e) {
+    console.error("Failed to save bookmarks to storage:", e);
+  }
+};
+
+export const getBookmarks = async (storage: PluginStorage): Promise<Bookmark[]> => {
+  try {
+    const value = await storage.getItem(BOOKMARKS_LS_KEY);
+    if (value) {
+      return JSON.parse(value);
+    }
+    return [];
+  } catch (e) {
+    console.error("Failed to get bookmarks from storage:", e);
+    return [];
+  }
+};
+
+export const toggleBookmark = async (storage: PluginStorage): Promise<boolean> => {
   const bookmark = getBookmarkFromURL();
-  const exists = bookmarkExists(bookmark);
+  const exists = await bookmarkExists(storage, bookmark);
   
   if (exists) {
-    removeBookmark(bookmark);
-    return false; 
+    await removeBookmark(storage, bookmark);
+    return false;
   } else {
-    addBookmark(bookmark);
-    return true; 
+    await addBookmark(storage, bookmark);
+    return true;
   }
-}
+};
 
-const addBookmark = (bookmark: Bookmark) => {
-  const bookmarks = getBookmarks();
+const addBookmark = async (storage: PluginStorage, bookmark: Bookmark): Promise<void> => {
+  const bookmarks = await getBookmarks(storage);
   bookmarks.push(bookmark);
-  localStorage.setItem(BOOKMARKS_LS_KEY, JSON.stringify(bookmarks));
-}
+  await setBookmarks(storage, bookmarks);
+};
 
-export const removeBookmark = (bookmark: Bookmark) => {
-  const storedBookmarks = getBookmarks();
-  const filteredBookmarks = storedBookmarks.filter((storedBookmark: Bookmark) => !areBookmarksEqual(bookmark, storedBookmark));  
-  localStorage.setItem(BOOKMARKS_LS_KEY, JSON.stringify(filteredBookmarks));
-}
+export const removeBookmark = async (storage: PluginStorage, bookmark: Bookmark): Promise<void> => {
+  const storedBookmarks = await getBookmarks(storage);
+  const filteredBookmarks = storedBookmarks.filter((storedBookmark) => !areBookmarksEqual(bookmark, storedBookmark));
+  await setBookmarks(storage, filteredBookmarks);
+};
 
-export const bookmarkExists = (bookmark: Bookmark): boolean => {
-  const bookmarks = getBookmarks();
-  return bookmarks.some((b: Bookmark) => areBookmarksEqual(b, bookmark));
-}
+export const bookmarkExists = async (storage: PluginStorage, bookmark: Bookmark): Promise<boolean> => {
+  const bookmarks = await getBookmarks(storage);
+  return bookmarks.some((b) => areBookmarksEqual(bookmark, b));
+};
 
 export const areBookmarksEqual = (bookmark: Bookmark, storedBookmark: Bookmark) => {
   const bookmarkParams = cleanupParams(new URLSearchParams(bookmark.params));

--- a/src/pages/Home/bookmarks/utils.ts
+++ b/src/pages/Home/bookmarks/utils.ts
@@ -1,7 +1,10 @@
 import { ACTION_VIEW, PRIMARY_SIGNAL, VAR_FILTERS, FILTER_SEPARATOR, BOOKMARKS_LS_KEY, EXPLORATIONS_ROUTE, VAR_LATENCY_PARTIAL_THRESHOLD, VAR_LATENCY_THRESHOLD, SELECTION, VAR_METRIC } from "utils/shared";
 import { Bookmark } from "./Bookmarks";
 import { urlUtil } from "@grafana/data";
-import { usePluginUserStorage } from '@grafana/runtime';
+import { locationService, usePluginUserStorage } from '@grafana/runtime';
+import { USER_EVENTS_ACTIONS } from "utils/analytics";
+import { USER_EVENTS_PAGES } from "utils/analytics";
+import { reportAppInteraction } from "utils/analytics";
 
 type PluginStorage = ReturnType<typeof usePluginUserStorage>;
 
@@ -143,4 +146,10 @@ export const areBookmarksEqual = (bookmark: Bookmark, storedBookmark: Bookmark) 
   // Check if every filter in bookmarkFilters exists in storedFilters
   // This handles cases where order might be different
   return bookmarkFilters.every(filter => storedFilters.includes(filter));
+}
+
+export const goToBookmark = (bookmark: Bookmark) => {
+  reportAppInteraction(USER_EVENTS_PAGES.home, USER_EVENTS_ACTIONS.home.go_to_bookmark_clicked);
+  const url = getBookmarkForUrl(bookmark);
+  locationService.push(url);
 }

--- a/src/pages/Home/bookmarks/utils.ts
+++ b/src/pages/Home/bookmarks/utils.ts
@@ -2,9 +2,7 @@ import { ACTION_VIEW, PRIMARY_SIGNAL, VAR_FILTERS, FILTER_SEPARATOR, BOOKMARKS_L
 import { Bookmark } from "./Bookmarks";
 import { urlUtil } from "@grafana/data";
 import { locationService, usePluginUserStorage } from '@grafana/runtime';
-import { USER_EVENTS_ACTIONS } from "utils/analytics";
-import { USER_EVENTS_PAGES } from "utils/analytics";
-import { reportAppInteraction } from "utils/analytics";
+import { USER_EVENTS_ACTIONS, USER_EVENTS_PAGES, reportAppInteraction } from "utils/analytics";
 
 type PluginStorage = ReturnType<typeof usePluginUserStorage>;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3159,6 +3159,14 @@
     lodash "^4.17.21"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^16.0.1":
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-16.2.0.tgz#c96126ee01a49cdb47175721911b4a9432afc601"
@@ -9610,6 +9618,13 @@ react-dropzone@14.3.5:
     file-selector "^2.1.0"
     prop-types "^15.8.1"
 
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-from-dom@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/react-from-dom/-/react-from-dom-0.6.2.tgz#9da903a508c91c013b55afcd59348b8b0a39bdb4"
@@ -10832,7 +10847,16 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10921,7 +10945,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11830,7 +11861,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -11843,6 +11874,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Switches to using Grafana [userStorage](https://grafana.com/developers/plugin-tools/how-to-guides/add-user-storage) for bookmarks, which allows us to benefit from any core API changes and also allows the bookmarks to be used across browsers.