### PR TITLE
Make exemplars more distinguishable

### DIFF
--- a/src/components/Explore/TracesByService/MiniREDPanel.tsx
+++ b/src/components/Explore/TracesByService/MiniREDPanel.tsx
@@ -14,7 +14,7 @@ import { explorationDS, MetricFunction } from 'utils/shared';
 import { EmptyStateScene } from 'components/states/EmptyState/EmptyStateScene';
 import { LoadingStateScene } from 'components/states/LoadingState/LoadingStateScene';
 import { SkeletonComponent } from '../ByFrameRepeater';
-import { barsPanelConfig } from '../panels/barsPanel';
+import { panelConfig } from '../panels/panel';
 import { metricByWithStatus } from '../queries/generateMetricsQuery';
 import { StepQueryRunner } from '../queries/StepQueryRunner';
 import { RadioButtonList, useStyles2 } from '@grafana/ui';
@@ -107,7 +107,7 @@ export class MiniREDPanel extends SceneObjectBase<MiniREDPanelState> {
   }
 
   private getRateOrErrorPanel(metric: MetricFunction) {
-    const panel = barsPanelConfig().setHoverHeader(true).setDisplayMode('transparent');
+    const panel = panelConfig().setHoverHeader(true).setDisplayMode('transparent');
     if (metric === 'errors') {
       panel.setTitle('Errors rate').setCustomFieldConfig('axisLabel', 'Errors').setColor({
         fixedColor: 'semi-dark-red',

--- a/src/components/Explore/TracesByService/REDPanel.tsx
+++ b/src/components/Explore/TracesByService/REDPanel.tsx
@@ -15,7 +15,7 @@ import { ComparisonSelection, EMPTY_STATE_ERROR_MESSAGE, explorationDS, MetricFu
 import { EmptyStateScene } from 'components/states/EmptyState/EmptyStateScene';
 import { LoadingStateScene } from 'components/states/LoadingState/LoadingStateScene';
 import { SkeletonComponent } from '../ByFrameRepeater';
-import { barsPanelConfig } from '../panels/barsPanel';
+import { panelConfig } from '../panels/panel';
 import { metricByWithStatus } from '../queries/generateMetricsQuery';
 import { StepQueryRunner } from '../queries/StepQueryRunner';
 import { css } from '@emotion/css';
@@ -197,7 +197,7 @@ export class REDPanel extends SceneObjectBase<RateMetricsPanelState> {
   }
 
   private getRateOrErrorVizPanel(type: MetricFunction) {
-    const panel = barsPanelConfig().setHoverHeader(true).setDisplayMode('transparent');
+    const panel = panelConfig().setHoverHeader(true).setDisplayMode('transparent');
     if (type === 'errors') {
       panel.setCustomFieldConfig('axisLabel', 'Errors').setColor({
         fixedColor: 'semi-dark-red',

--- a/src/components/Explore/layouts/attributeBreakdown.ts
+++ b/src/components/Explore/layouts/attributeBreakdown.ts
@@ -17,7 +17,7 @@ import { formatLabelValue, getLabelValue, getTraceExplorationScene } from '../..
 import { map, Observable } from 'rxjs';
 import { DataFrame, PanelData, reduceField, ReducerID } from '@grafana/data';
 import { generateMetricsQuery, metricByWithStatus } from '../queries/generateMetricsQuery';
-import { barsPanelConfig } from '../panels/barsPanel';
+import { panelConfig } from '../panels/panel';
 import { linesPanelConfig } from '../panels/linesPanel';
 import { StepQueryRunner } from '../queries/StepQueryRunner';
 import { syncYAxis } from '../behaviors/syncYaxis';
@@ -133,7 +133,7 @@ export function getLayoutChild(
       })
     );
 
-    const panel = (metric === 'duration' ? linesPanelConfig().setUnit('s') : barsPanelConfig())
+    const panel = (metric === 'duration' ? linesPanelConfig().setUnit('s') : panelConfig())
       .setTitle(getTitle(frame, variable.getValueText()))
       .setMenu(new PanelMenu({ query, labelValue: getLabelValue(frame) }))
       .setData(dataNode);

--- a/src/components/Explore/panels/panel.ts
+++ b/src/components/Explore/panels/panel.ts
@@ -1,14 +1,12 @@
 import { PanelBuilders } from '@grafana/scenes';
 import { DrawStyle, StackingMode, TooltipDisplayMode } from '@grafana/ui';
 
-export const barsPanelConfig = () => {
+export const panelConfig = () => {
   return PanelBuilders.timeseries()
     .setOption('legend', { showLegend: false })
-    .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
+    .setCustomFieldConfig('drawStyle', DrawStyle.Line)
     .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
-    .setCustomFieldConfig('fillOpacity', 100)
-    .setCustomFieldConfig('lineWidth', 0)
-    .setCustomFieldConfig('pointSize', 0)
+    .setCustomFieldConfig('fillOpacity', 15)
     .setCustomFieldConfig('axisLabel', 'Rate')
     .setOverrides((overrides) => {
       overrides.matchFieldsWithNameByRegex('.*"?error"?.*').overrideColor({


### PR DESCRIPTION
Switches to using a line draw style, with a fill opacity of 15% which makes it much easier to see the exemplars.

![Screenshot 2025-03-25 at 15 24 20](https://github.com/user-attachments/assets/e7d7c567-9ff0-4073-aa49-499d0a55982c)
