### PR TITLE
Fix regex matcher for field names

### DIFF
--- a/src/components/Explore/panels/barsPanel.ts
+++ b/src/components/Explore/panels/barsPanel.ts
@@ -11,15 +11,15 @@ export const barsPanelConfig = () => {
     .setCustomFieldConfig('pointSize', 0)
     .setCustomFieldConfig('axisLabel', 'Rate')
     .setOverrides((overrides) => {
-      overrides.matchFieldsWithNameByRegex('.*"?error"?.*').overrideColor({
+      overrides.matchFieldsWithNameByRegex('(^error$|.*status="error".*)').overrideColor({
         mode: 'fixed',
         fixedColor: 'semi-dark-red',
       });
-      overrides.matchFieldsWithNameByRegex('.*"?unset"?.*').overrideColor({
+      overrides.matchFieldsWithNameByRegex('(^unset$|.*status="unset".*)').overrideColor({
         mode: 'fixed',
         fixedColor: 'green',
       });
-      overrides.matchFieldsWithNameByRegex('.*"?ok"?.*').overrideColor({
+      overrides.matchFieldsWithNameByRegex('(^ok$|.*status="ok".*)').overrideColor({
         mode: 'fixed',
         fixedColor: 'dark-green',
       });


### PR DESCRIPTION
Fixes issue where fields with names like `"{resource.service.name=\"loki-ingester\", status=\"error\"}"` were getting matched as ok.

Now we ensure either the field name has `status="error"` or the entire field name is just set to `error`.

Fixes https://github.com/grafana/traces-drilldown/issues/368