### PR TITLE
Fix for exemplars with two different styles

### DIFF
--- a/src/components/Explore/queries/generateMetricsQuery.test.ts
+++ b/src/components/Explore/queries/generateMetricsQuery.test.ts
@@ -1,0 +1,123 @@
+import { generateMetricsQuery, metricByWithStatus } from './generateMetricsQuery';
+import { ALL } from '../../../utils/shared';
+
+describe('generateMetricsQuery', () => {
+  it('should generate a basic rate query', () => {
+    const result = generateMetricsQuery({ metric: 'rate' });
+    expect(result).toEqual('${primarySignal} && ${filters} && status!=error | rate() ');
+  });
+
+  it('should generate an errors query', () => {
+    const result = generateMetricsQuery({ metric: 'errors' });
+    expect(result).toEqual('${primarySignal} && ${filters} && status=error | rate() ');
+  });
+
+  it('should generate a duration query', () => {
+    const result = generateMetricsQuery({ metric: 'duration' });
+    expect(result).toEqual('${primarySignal} && ${filters} | quantile_over_time(duration, 0.9) ');
+  });
+
+  it('should add extra filters if provided', () => {
+    const result = generateMetricsQuery({ 
+      metric: 'rate', 
+      extraFilters: 'name="test"' 
+    });
+    expect(result).toEqual('${primarySignal} && ${filters} && status!=error && name="test" | rate() ');
+  });
+
+  it('should handle groupByKey when provided', () => {
+    const result = generateMetricsQuery({ 
+      metric: 'rate', 
+      groupByKey: 'serviceName' 
+    });
+    expect(result).toEqual('${primarySignal} && ${filters} && status!=error && serviceName != nil | rate() by(serviceName)');
+  });
+
+  it('should not add groupByKey filter when groupByKey is ALL', () => {
+    const result = generateMetricsQuery({ 
+      metric: 'rate', 
+      groupByKey: ALL 
+    });
+    expect(result).toEqual('${primarySignal} && ${filters} && status!=error | rate() ');
+  });
+
+  it('should add status to groupBy when groupByStatus is true', () => {
+    const result = generateMetricsQuery({ 
+      metric: 'rate', 
+      groupByStatus: true 
+    });
+    expect(result).toEqual('${primarySignal} && ${filters} && status!=error | rate() by(status)');
+  });
+
+  it('should add both groupByKey and status to groupBy when both are provided', () => {
+    const result = generateMetricsQuery({ 
+      metric: 'rate', 
+      groupByKey: 'serviceName',
+      groupByStatus: true 
+    });
+    expect(result).toEqual('${primarySignal} && ${filters} && status!=error && serviceName != nil | rate() by(serviceName, status)');
+  });
+
+  it('should not add status to groupBy for duration metric even if groupByStatus is true', () => {
+    const result = generateMetricsQuery({ 
+      metric: 'duration', 
+      groupByKey: 'serviceName',
+      groupByStatus: true 
+    });
+    expect(result).toEqual('${primarySignal} && ${filters} && serviceName != nil | quantile_over_time(duration, 0.9) by(serviceName)');
+  });
+});
+
+describe('metricByWithStatus', () => {
+  it('should return correct configuration for rate metric', () => {
+    const result = metricByWithStatus('rate');
+    expect(result).toEqual({
+      refId: 'A',
+      query: '${primarySignal} && ${filters} && status!=error | rate() by(status)',
+      queryType: 'traceql',
+      tableType: 'spans',
+      limit: 100,
+      spss: 10,
+      filters: [],
+    });
+  });
+
+  it('should return correct configuration for errors metric', () => {
+    const result = metricByWithStatus('errors');
+    expect(result).toEqual({
+      refId: 'A',
+      query: '${primarySignal} && ${filters} && status=error | rate() by(status)',
+      queryType: 'traceql',
+      tableType: 'spans',
+      limit: 100,
+      spss: 10,
+      filters: [],
+    });
+  });
+
+  it('should return correct configuration for duration metric', () => {
+    const result = metricByWithStatus('duration');
+    expect(result).toEqual({
+      refId: 'A',
+      query: '${primarySignal} && ${filters} | quantile_over_time(duration, 0.9) by()',
+      queryType: 'traceql',
+      tableType: 'spans',
+      limit: 100,
+      spss: 10,
+      filters: [],
+    });
+  });
+
+  it('should include tagKey in the query when provided', () => {
+    const result = metricByWithStatus('rate', 'serviceName');
+    expect(result).toEqual({
+      refId: 'A',
+      query: '${primarySignal} && ${filters} && status!=error && serviceName != nil | rate() by(serviceName, status)',
+      queryType: 'traceql',
+      tableType: 'spans',
+      limit: 100,
+      spss: 10,
+      filters: [],
+    });
+  });
+}); 

--- a/src/components/Explore/queries/generateMetricsQuery.test.ts
+++ b/src/components/Explore/queries/generateMetricsQuery.test.ts
@@ -4,17 +4,17 @@ import { ALL } from '../../../utils/shared';
 describe('generateMetricsQuery', () => {
   it('should generate a basic rate query', () => {
     const result = generateMetricsQuery({ metric: 'rate' });
-    expect(result).toEqual('${primarySignal} && ${filters} && status!=error | rate() ');
+    expect(result).toEqual('{${primarySignal} && ${filters} && status!=error} | rate() ');
   });
 
   it('should generate an errors query', () => {
     const result = generateMetricsQuery({ metric: 'errors' });
-    expect(result).toEqual('${primarySignal} && ${filters} && status=error | rate() ');
+    expect(result).toEqual('{${primarySignal} && ${filters} && status=error} | rate() ');
   });
 
   it('should generate a duration query', () => {
     const result = generateMetricsQuery({ metric: 'duration' });
-    expect(result).toEqual('${primarySignal} && ${filters} | quantile_over_time(duration, 0.9) ');
+    expect(result).toEqual('{${primarySignal} && ${filters}} | quantile_over_time(duration, 0.9) ');
   });
 
   it('should add extra filters if provided', () => {
@@ -22,7 +22,7 @@ describe('generateMetricsQuery', () => {
       metric: 'rate', 
       extraFilters: 'name="test"' 
     });
-    expect(result).toEqual('${primarySignal} && ${filters} && status!=error && name="test" | rate() ');
+    expect(result).toEqual('{${primarySignal} && ${filters} && status!=error && name="test"} | rate() ');
   });
 
   it('should handle groupByKey when provided', () => {
@@ -30,7 +30,7 @@ describe('generateMetricsQuery', () => {
       metric: 'rate', 
       groupByKey: 'serviceName' 
     });
-    expect(result).toEqual('${primarySignal} && ${filters} && status!=error && serviceName != nil | rate() by(serviceName)');
+    expect(result).toEqual('{${primarySignal} && ${filters} && status!=error && serviceName != nil} | rate() by(serviceName)');
   });
 
   it('should not add groupByKey filter when groupByKey is ALL', () => {
@@ -38,7 +38,7 @@ describe('generateMetricsQuery', () => {
       metric: 'rate', 
       groupByKey: ALL 
     });
-    expect(result).toEqual('${primarySignal} && ${filters} && status!=error | rate() ');
+    expect(result).toEqual('{${primarySignal} && ${filters} && status!=error} | rate() ');
   });
 
   it('should add status to groupBy when groupByStatus is true', () => {
@@ -46,7 +46,7 @@ describe('generateMetricsQuery', () => {
       metric: 'rate', 
       groupByStatus: true 
     });
-    expect(result).toEqual('${primarySignal} && ${filters} && status!=error | rate() by(status)');
+    expect(result).toEqual('{${primarySignal} && ${filters} && status!=error} | rate() by(status)');
   });
 
   it('should add both groupByKey and status to groupBy when both are provided', () => {
@@ -55,7 +55,7 @@ describe('generateMetricsQuery', () => {
       groupByKey: 'serviceName',
       groupByStatus: true 
     });
-    expect(result).toEqual('${primarySignal} && ${filters} && status!=error && serviceName != nil | rate() by(serviceName, status)');
+    expect(result).toEqual('{${primarySignal} && ${filters} && status!=error && serviceName != nil} | rate() by(serviceName, status)');
   });
 
   it('should not add status to groupBy for duration metric even if groupByStatus is true', () => {
@@ -64,7 +64,7 @@ describe('generateMetricsQuery', () => {
       groupByKey: 'serviceName',
       groupByStatus: true 
     });
-    expect(result).toEqual('${primarySignal} && ${filters} && serviceName != nil | quantile_over_time(duration, 0.9) by(serviceName)');
+    expect(result).toEqual('{${primarySignal} && ${filters} && serviceName != nil} | quantile_over_time(duration, 0.9) by(serviceName)');
   });
 });
 
@@ -73,7 +73,7 @@ describe('metricByWithStatus', () => {
     const result = metricByWithStatus('rate');
     expect(result).toEqual({
       refId: 'A',
-      query: '${primarySignal} && ${filters} && status!=error | rate() by(status)',
+      query: '{${primarySignal} && ${filters} && status!=error} | rate() by(status)',
       queryType: 'traceql',
       tableType: 'spans',
       limit: 100,
@@ -86,7 +86,7 @@ describe('metricByWithStatus', () => {
     const result = metricByWithStatus('errors');
     expect(result).toEqual({
       refId: 'A',
-      query: '${primarySignal} && ${filters} && status=error | rate() by(status)',
+      query: '{${primarySignal} && ${filters} && status=error} | rate() by(status)',
       queryType: 'traceql',
       tableType: 'spans',
       limit: 100,
@@ -99,7 +99,7 @@ describe('metricByWithStatus', () => {
     const result = metricByWithStatus('duration');
     expect(result).toEqual({
       refId: 'A',
-      query: '${primarySignal} && ${filters} | quantile_over_time(duration, 0.9) by()',
+      query: '{${primarySignal} && ${filters}} | quantile_over_time(duration, 0.9) ',
       queryType: 'traceql',
       tableType: 'spans',
       limit: 100,
@@ -112,7 +112,7 @@ describe('metricByWithStatus', () => {
     const result = metricByWithStatus('rate', 'serviceName');
     expect(result).toEqual({
       refId: 'A',
-      query: '${primarySignal} && ${filters} && status!=error && serviceName != nil | rate() by(serviceName, status)',
+      query: '{${primarySignal} && ${filters} && status!=error && serviceName != nil} | rate() by(serviceName, status)',
       queryType: 'traceql',
       tableType: 'spans',
       limit: 100,

--- a/src/components/Explore/queries/generateMetricsQuery.test.ts
+++ b/src/components/Explore/queries/generateMetricsQuery.test.ts
@@ -73,7 +73,7 @@ describe('metricByWithStatus', () => {
     const result = metricByWithStatus('rate');
     expect(result).toEqual({
       refId: 'A',
-      query: '{${primarySignal} && ${filters} && status!=error} | rate() by(status)',
+      query: '{${primarySignal} && ${filters} && status!=error} | rate() ',
       queryType: 'traceql',
       tableType: 'spans',
       limit: 100,
@@ -86,7 +86,7 @@ describe('metricByWithStatus', () => {
     const result = metricByWithStatus('errors');
     expect(result).toEqual({
       refId: 'A',
-      query: '{${primarySignal} && ${filters} && status=error} | rate() by(status)',
+      query: '{${primarySignal} && ${filters} && status=error} | rate() ',
       queryType: 'traceql',
       tableType: 'spans',
       limit: 100,
@@ -112,7 +112,7 @@ describe('metricByWithStatus', () => {
     const result = metricByWithStatus('rate', 'serviceName');
     expect(result).toEqual({
       refId: 'A',
-      query: '{${primarySignal} && ${filters} && status!=error && serviceName != nil} | rate() by(serviceName, status)',
+      query: '{${primarySignal} && ${filters} && status!=error && serviceName != nil} | rate() by(serviceName)',
       queryType: 'traceql',
       tableType: 'spans',
       limit: 100,

--- a/src/components/Explore/queries/generateMetricsQuery.ts
+++ b/src/components/Explore/queries/generateMetricsQuery.ts
@@ -11,7 +11,9 @@ export function generateMetricsQuery({ metric, groupByKey, extraFilters, groupBy
   // Generate span set filters
   let filters = `${VAR_FILTERS_EXPR}`;
 
-  if (metric === 'errors') {
+  if (metric === 'rate') {
+    filters += ' && status!=error';
+  } else if (metric === 'errors') {
     filters += ' && status=error';
   }
 

--- a/src/components/Explore/queries/generateMetricsQuery.ts
+++ b/src/components/Explore/queries/generateMetricsQuery.ts
@@ -54,7 +54,7 @@ export function generateMetricsQuery({ metric, groupByKey, extraFilters, groupBy
 export function metricByWithStatus(metric: MetricFunction, tagKey?: string) {
   return {
     refId: 'A',
-    query: generateMetricsQuery({ metric, groupByKey: tagKey, groupByStatus: true }),
+    query: generateMetricsQuery({ metric, groupByKey: tagKey, groupByStatus: false }),
     queryType: 'traceql',
     tableType: 'spans',
     limit: 100,

--- a/src/components/Explore/queries/queries.test.ts
+++ b/src/components/Explore/queries/queries.test.ts
@@ -54,7 +54,7 @@ describe('metricByWithStatus', () => {
     expect(query).toEqual({
       filters: [],
       limit: 100,
-      query: '{${primarySignal} && ${filters} && status=error} | rate() by(status)',
+      query: '{${primarySignal} && ${filters} && status=error} | rate() ',
       queryType: 'traceql',
       refId: 'A',
       spss: 10,
@@ -67,7 +67,7 @@ describe('metricByWithStatus', () => {
     expect(query).toEqual({
       filters: [],
       limit: 100,
-      query: '{${primarySignal} && ${filters} && status=error && service != nil} | rate() by(service, status)',
+      query: '{${primarySignal} && ${filters} && status=error && service != nil} | rate() by(service)',
       queryType: 'traceql',
       refId: 'A',
       spss: 10,


### PR DESCRIPTION
We were seeing exemplars with two different styles as this is actually how exemplars work when they are receiving two different sets of labels. 

In our case, our metrics rate query was also returning series with error labels and so the exemplar code was showing the diamond for the one exemplar field and the cross for the other exemplar field.

I've updated the query so that we don't return error series when we run a rate query.

Bonus: we will no longer see red in our rate query graphs! 🥳 

Fixes https://github.com/grafana/traces-drilldown/issues/385