### PR TITLE
PanelMenu: Use `firstValueFrom()` instead of `lastValueFrom()`

### DIFF
--- a/src/components/Explore/panels/PanelMenu.tsx
+++ b/src/components/Explore/panels/PanelMenu.tsx
@@ -15,7 +15,7 @@ import { AddToInvestigationButton } from '../actions/AddToInvestigationButton';
 import { config, getPluginLinkExtensions, getObservablePluginLinks } from '@grafana/runtime';
 import { reportAppInteraction, USER_EVENTS_PAGES, USER_EVENTS_ACTIONS } from 'utils/analytics';
 import { getCurrentStep, getDataSource, getTraceExplorationScene } from 'utils/utils';
-import { lastValueFrom } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
 
 const ADD_TO_INVESTIGATION_MENU_TEXT = 'Add to investigation';
 const extensionPointId = 'grafana-exploretraces-app/investigation/v1';
@@ -128,7 +128,7 @@ const getInvestigationLink = async (addToInvestigations: AddToInvestigationButto
 
   // `getObservablePluginLinks` is introduced in Grafana v12
   if (getObservablePluginLinks !== undefined) {
-    const links: PluginExtensionLink[] = await lastValueFrom(
+    const links: PluginExtensionLink[] = await firstValueFrom(
       getObservablePluginLinks({
         extensionPointId,
         context,


### PR DESCRIPTION
**Related:** https://github.com/grafana/grafana/pull/103367

### Why?
The `lastValueFrom()` was timing out as the observable never gets completed (which actually makes sense). We should use `firstValueFrom()` or `.pipe(first())`. 🤦