### PR TITLE
Ensure Y-axis label matches the data for RED metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "webpack -w -c ./webpack.config.ts --env development",
     "e2e": "playwright test -x --trace on --ui",
     "e2e:fast": "playwright test --retries=2 --workers=3 -x --trace on",
-    "e2e:debug": "playwright test --debug -x --trace on /test",
+    "e2e:debug": "playwright test --debug -x --trace on /e2e",
     "e2e:codegen": "playwright codegen",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --passWithNoTests --maxWorkers 4",

--- a/src/components/Explore/TracesByService/MiniREDPanel.tsx
+++ b/src/components/Explore/TracesByService/MiniREDPanel.tsx
@@ -116,7 +116,7 @@ export class MiniREDPanel extends SceneObjectBase<MiniREDPanelState> {
     if (metric === 'rate') {
       panel.setCustomFieldConfig('axisLabel', 'span/s');
     } else if (metric === 'errors') {
-      panel.setCustomFieldConfig('axisLabel', 'span/s').setColor({
+      panel.setTitle('Errors rate').setCustomFieldConfig('axisLabel', 'span/s').setColor({
         fixedColor: 'semi-dark-red',
         mode: 'fixed',
       });

--- a/src/components/Explore/TracesByService/MiniREDPanel.tsx
+++ b/src/components/Explore/TracesByService/MiniREDPanel.tsx
@@ -113,13 +113,13 @@ export class MiniREDPanel extends SceneObjectBase<MiniREDPanelState> {
 
   private getRateOrErrorPanel(metric: MetricFunction) {
     const panel = barsPanelConfig().setHoverHeader(true).setDisplayMode('transparent');
-    if (metric === 'errors') {
-      panel.setTitle('Errors rate').setCustomFieldConfig('axisLabel', 'Errors').setColor({
+    if (metric === 'rate') {
+      panel.setCustomFieldConfig('axisLabel', 'span/s');
+    } else if (metric === 'errors') {
+      panel.setCustomFieldConfig('axisLabel', 'span/s').setColor({
         fixedColor: 'semi-dark-red',
         mode: 'fixed',
       });
-    } else {
-      panel.setTitle('Span rate');
     }
 
     return panel.build();

--- a/src/components/Explore/TracesByService/REDPanel.tsx
+++ b/src/components/Explore/TracesByService/REDPanel.tsx
@@ -203,8 +203,10 @@ export class REDPanel extends SceneObjectBase<RateMetricsPanelState> {
 
   private getRateOrErrorVizPanel(type: MetricFunction) {
     const panel = barsPanelConfig().setHoverHeader(true).setDisplayMode('transparent');
-    if (type === 'errors') {
-      panel.setCustomFieldConfig('axisLabel', 'Errors').setColor({
+    if (type === 'rate') {
+      panel.setCustomFieldConfig('axisLabel', 'span/s');
+    } else if (type === 'errors') {
+      panel.setCustomFieldConfig('axisLabel', 'span/s').setColor({
         fixedColor: 'semi-dark-red',
         mode: 'fixed',
       });

--- a/src/components/Explore/panels/histogram.ts
+++ b/src/components/Explore/panels/histogram.ts
@@ -64,7 +64,7 @@ export const histogramPanelConfig = () => {
     .setOption('legend', { show: false })
     .setOption('yAxis', {
       unit: 's',
-      axisLabel: 'Duration',
+      axisLabel: 'duration',
     })
     .setOption('color', {
       scheme: 'Blues',


### PR DESCRIPTION
Fixes https://github.com/grafana/traces-drilldown/issues/379

Tried first putting the error text on the y-axis as well but the text is too long in the MiniRedPanel. I don't think the errors text is required anyway as it's already in the title and is quite obvious from the red color.

<img width="752" alt="Screenshot 2025-04-04 at 12 40 39" src="https://github.com/user-attachments/assets/1a4cdcd8-5a48-469d-baa9-d956b6ad7085" />

Looks better with just `span/s`.

<img width="769" alt="Screenshot 2025-04-04 at 12 40 46" src="https://github.com/user-attachments/assets/bf5c9572-dd49-4481-beae-55fc4533feea" />
