### PR TITLE
Add support for adding a trace to investigations

### DIFF
--- a/src/components/Explore/TracesByService/TraceDrawerScene.tsx
+++ b/src/components/Explore/TracesByService/TraceDrawerScene.tsx
@@ -5,8 +5,6 @@ import { EmptyStateScene } from 'components/states/EmptyState/EmptyStateScene';
 import { TraceViewPanelScene } from '../panels/TraceViewPanelScene';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../../utils/analytics';
 import { getTraceExplorationScene } from '../../../utils/utils';
-import { useStyles2 } from '@grafana/ui';
-import { css } from '@emotion/css';
 
 export interface DetailsSceneState extends SceneObjectState {
   body?: SceneObject;
@@ -39,12 +37,11 @@ export class TraceDrawerScene extends SceneObjectBase<DetailsSceneState> {
 
   private updateBody() {
     const traceExploration = getTraceExplorationScene(this);
-    const traceId = traceExploration.state.traceId;
 
-    if (traceId) {
+    if (traceExploration.state.traceId) {
       this.setState({
         body: new TraceViewPanelScene({
-          traceId,
+          traceId: traceExploration.state.traceId,
           spanId: traceExploration.state.spanId,
         }),
       });
@@ -58,24 +55,7 @@ export class TraceDrawerScene extends SceneObjectBase<DetailsSceneState> {
   }
 
   public static Component = ({ model }: SceneComponentProps<TraceDrawerScene>) => {
-    const { body } = model.useState();
-    const styles = useStyles2(getStyles);
-   
-    return (
-      <div className={styles.container}>
-        {body && <body.Component model={body} />}
-      </div>
-    );
-  };
-}
-
-function getStyles() {
-  return {
-    container: css({
-      display: 'flex',
-      flexDirection: 'column',
-      height: '100%',
-      width: '100%',
-    }),
+    const { body } = model.useState();   
+    return body && <body.Component model={body} />;
   };
 }

--- a/src/components/Explore/TracesByService/TraceDrawerScene.tsx
+++ b/src/components/Explore/TracesByService/TraceDrawerScene.tsx
@@ -1,20 +1,15 @@
 import React from 'react';
 
-import { SceneObjectState, SceneObjectBase, SceneComponentProps, SceneObject, SceneQueryRunner } from '@grafana/scenes';
+import { SceneObjectState, SceneObjectBase, SceneComponentProps, SceneObject } from '@grafana/scenes';
 import { EmptyStateScene } from 'components/states/EmptyState/EmptyStateScene';
 import { TraceViewPanelScene } from '../panels/TraceViewPanelScene';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../../utils/analytics';
-import { getDataSource, getTraceExplorationScene } from '../../../utils/utils';
-import { AddToInvestigationButton } from '../actions/AddToInvestigationButton';
-import { Button, useStyles2 } from '@grafana/ui';
+import { getTraceExplorationScene } from '../../../utils/utils';
+import { useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
-import { GrafanaTheme2, PluginExtensionLink, LoadingState } from '@grafana/data';
-import { ADD_TO_INVESTIGATION_MENU_TEXT, getInvestigationLink } from '../panels/PanelMenu';
 
 export interface DetailsSceneState extends SceneObjectState {
   body?: SceneObject;
-  addToInvestigationButton?: AddToInvestigationButton;
-  investigationLink?: PluginExtensionLink;
 }
 
 export class TraceDrawerScene extends SceneObjectBase<DetailsSceneState> {
@@ -53,8 +48,6 @@ export class TraceDrawerScene extends SceneObjectBase<DetailsSceneState> {
           spanId: traceExploration.state.spanId,
         }),
       });
-
-      this.setupInvestigationButton(traceId);
     } else {
       this.setState({
         body: new EmptyStateScene({
@@ -64,128 +57,25 @@ export class TraceDrawerScene extends SceneObjectBase<DetailsSceneState> {
     }
   }
 
-  private setupInvestigationButton(traceId: string) {
-    const traceExploration = getTraceExplorationScene(this);
-    const dsUid = getDataSource(traceExploration);
-
-    const queryRunner = new SceneQueryRunner({
-      datasource: { uid: dsUid },
-      queries: [{ 
-        refId: 'A', 
-        query: traceId, 
-        queryType: 'traceql',
-      }],
-    });
-
-    const addToInvestigationButton = new AddToInvestigationButton({
-      query: traceId,
-      type: 'trace',
-      dsUid,
-      $data: queryRunner,
-    });
-    
-    addToInvestigationButton.activate();
-    this.setState({ addToInvestigationButton });
-    this._subs.add(
-      addToInvestigationButton.subscribeToState(() => {
-        this.updateInvestigationLink();
-      })
-    );
-        
-    queryRunner.activate();
-    
-    this._subs.add(
-      queryRunner.subscribeToState((state) => {
-        if (state.data?.state === LoadingState.Done && state.data?.series?.length > 0) {
-          const serviceNameField = state.data.series[0]?.fields?.find((f) => f.name === 'serviceName');
-          
-          if (serviceNameField && serviceNameField.values[0]) {
-            addToInvestigationButton.setState({
-              ...addToInvestigationButton.state,
-              labelValue: `${serviceNameField.values[0]}`,
-            });
-          }
-        }
-      })
-    );
-    
-    addToInvestigationButton.setState({
-      ...addToInvestigationButton.state,
-      labelValue: traceId,
-    });
-  }
-
-  private async updateInvestigationLink() {
-    const { addToInvestigationButton } = this.state;
-    if (!addToInvestigationButton) { 
-      return;
-    }
-
-    const link = await getInvestigationLink(addToInvestigationButton);
-    if (link) {
-      this.setState({ investigationLink: link });
-    }
-  }
-
   public static Component = ({ model }: SceneComponentProps<TraceDrawerScene>) => {
-    const { body, investigationLink, addToInvestigationButton } = model.useState();
+    const { body } = model.useState();
     const styles = useStyles2(getStyles);
    
-    const closeDrawer = () => {
-      const traceExploration = getTraceExplorationScene(model);
-      traceExploration.setState({
-        ...traceExploration.state,
-        traceId: undefined,
-        spanId: undefined,
-      });
-    };
-    
-    const addToInvestigationClicked = (e: React.MouseEvent) => {
-      if (investigationLink?.onClick) {
-        investigationLink.onClick(e);
-      }
-      
-      reportAppInteraction(
-        USER_EVENTS_PAGES.analyse_traces,
-        USER_EVENTS_ACTIONS.analyse_traces.add_to_investigation_trace_view_clicked
-      );
-      
-      setTimeout(() => closeDrawer(), 100);
-    };
-    
     return (
       <div className={styles.container}>
-        {addToInvestigationButton && investigationLink && (
-          <div className={styles.buttonContainer}>
-            <Button
-              variant='primary'
-              size='md'
-              icon='plus-square'
-              onClick={addToInvestigationClicked}
-            >
-              {ADD_TO_INVESTIGATION_MENU_TEXT}
-            </Button>
-          </div>
-        )}
-        
         {body && <body.Component model={body} />}
       </div>
     );
   };
 }
 
-function getStyles(theme: GrafanaTheme2) {
+function getStyles() {
   return {
     container: css({
       display: 'flex',
       flexDirection: 'column',
       height: '100%',
       width: '100%',
-    }),
-    buttonContainer: css({
-      display: 'flex',
-      justifyContent: 'flex-end',
-      padding: `0 0 ${theme.spacing(1)} 0`,
     }),
   };
 }

--- a/src/components/Explore/TracesByService/TraceDrawerScene.tsx
+++ b/src/components/Explore/TracesByService/TraceDrawerScene.tsx
@@ -8,9 +8,8 @@ import { getDataSource, getTraceExplorationScene } from '../../../utils/utils';
 import { AddToInvestigationButton } from '../actions/AddToInvestigationButton';
 import { Button, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
-import { GrafanaTheme2, PluginExtensionLink } from '@grafana/data';
+import { GrafanaTheme2, PluginExtensionLink, LoadingState } from '@grafana/data';
 import { ADD_TO_INVESTIGATION_MENU_TEXT, getInvestigationLink } from '../panels/PanelMenu';
-import { LoadingState } from '@grafana/data';
 
 export interface DetailsSceneState extends SceneObjectState {
   body?: SceneObject;

--- a/src/components/Explore/TracesByService/TraceDrawerScene.tsx
+++ b/src/components/Explore/TracesByService/TraceDrawerScene.tsx
@@ -1,13 +1,21 @@
 import React from 'react';
 
-import { SceneObjectState, SceneObjectBase, SceneComponentProps, SceneObject } from '@grafana/scenes';
+import { SceneObjectState, SceneObjectBase, SceneComponentProps, SceneObject, SceneQueryRunner } from '@grafana/scenes';
 import { EmptyStateScene } from 'components/states/EmptyState/EmptyStateScene';
 import { TraceViewPanelScene } from '../panels/TraceViewPanelScene';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../../utils/analytics';
-import { getTraceExplorationScene } from '../../../utils/utils';
+import { getDataSource, getTraceExplorationScene } from '../../../utils/utils';
+import { AddToInvestigationButton } from '../actions/AddToInvestigationButton';
+import { Button, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+import { GrafanaTheme2, PluginExtensionLink } from '@grafana/data';
+import { ADD_TO_INVESTIGATION_MENU_TEXT, getInvestigationLink } from '../panels/PanelMenu';
+import { LoadingState } from '@grafana/data';
 
 export interface DetailsSceneState extends SceneObjectState {
   body?: SceneObject;
+  addToInvestigationButton?: AddToInvestigationButton;
+  investigationLink?: PluginExtensionLink;
 }
 
 export class TraceDrawerScene extends SceneObjectBase<DetailsSceneState> {
@@ -37,14 +45,17 @@ export class TraceDrawerScene extends SceneObjectBase<DetailsSceneState> {
 
   private updateBody() {
     const traceExploration = getTraceExplorationScene(this);
+    const traceId = traceExploration.state.traceId;
 
-    if (traceExploration.state.traceId) {
+    if (traceId) {
       this.setState({
         body: new TraceViewPanelScene({
-          traceId: traceExploration.state.traceId,
+          traceId,
           spanId: traceExploration.state.spanId,
         }),
       });
+
+      this.setupInvestigationButton(traceId);
     } else {
       this.setState({
         body: new EmptyStateScene({
@@ -54,8 +65,126 @@ export class TraceDrawerScene extends SceneObjectBase<DetailsSceneState> {
     }
   }
 
+  private setupInvestigationButton(traceId: string) {
+    const traceExploration = getTraceExplorationScene(this);
+    const dsUid = getDataSource(traceExploration);
+
+    const queryRunner = new SceneQueryRunner({
+      datasource: { uid: dsUid },
+      queries: [{ 
+        refId: 'A', 
+        query: traceId, 
+        queryType: 'traceql',
+      }],
+    });
+
+    const addToInvestigationButton = new AddToInvestigationButton({
+      query: traceId,
+      type: 'trace',
+      dsUid,
+      $data: queryRunner,
+    });
+    
+    addToInvestigationButton.activate();
+    this.setState({ addToInvestigationButton });
+    this._subs.add(
+      addToInvestigationButton.subscribeToState(() => {
+        this.updateInvestigationLink();
+      })
+    );
+        
+    queryRunner.activate();
+    
+    this._subs.add(
+      queryRunner.subscribeToState((state) => {
+        if (state.data?.state === LoadingState.Done && state.data?.series?.length > 0) {
+          const serviceNameField = state.data.series[0]?.fields?.find((f) => f.name === 'serviceName');
+          
+          if (serviceNameField && serviceNameField.values[0]) {
+            addToInvestigationButton.setState({
+              ...addToInvestigationButton.state,
+              labelValue: `${serviceNameField.values[0]}`,
+            });
+          }
+        }
+      })
+    );
+    
+    addToInvestigationButton.setState({
+      ...addToInvestigationButton.state,
+      labelValue: traceId,
+    });
+  }
+
+  private async updateInvestigationLink() {
+    const { addToInvestigationButton } = this.state;
+    if (!addToInvestigationButton) return;
+
+    const link = await getInvestigationLink(addToInvestigationButton);
+    if (link) {
+      this.setState({ investigationLink: link });
+    }
+  }
+
   public static Component = ({ model }: SceneComponentProps<TraceDrawerScene>) => {
-    const { body } = model.useState();
-    return body && <body.Component model={body} />;
+    const { body, investigationLink, addToInvestigationButton } = model.useState();
+    const styles = useStyles2(getStyles);
+   
+    const closeDrawer = () => {
+      const traceExploration = getTraceExplorationScene(model);
+      traceExploration.setState({
+        ...traceExploration.state,
+        traceId: undefined,
+        spanId: undefined,
+      });
+    };
+    
+    const addToInvestigationClicked = (e: React.MouseEvent) => {
+      if (investigationLink?.onClick) {
+        investigationLink.onClick(e);
+      }
+      
+      reportAppInteraction(
+        USER_EVENTS_PAGES.analyse_traces,
+        USER_EVENTS_ACTIONS.analyse_traces.add_to_investigation_trace_view_clicked
+      );
+      
+      setTimeout(() => closeDrawer(), 100);
+    };
+    
+    return (
+      <div className={styles.container}>
+        {addToInvestigationButton && (
+          <div className={styles.buttonContainer}>
+            <Button
+              variant='primary'
+              size='md'
+              icon='plus-square'
+              onClick={addToInvestigationClicked}
+            >
+              {ADD_TO_INVESTIGATION_MENU_TEXT}
+            </Button>
+          </div>
+        )}
+        
+        {body && <body.Component model={body} />}
+      </div>
+    );
+  };
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    container: css({
+      display: 'flex',
+      flexDirection: 'column',
+      height: '100%',
+      width: '100%',
+    }),
+    buttonContainer: css({
+      display: 'flex',
+      justifyContent: 'flex-end',
+      padding: `0 0 ${theme.spacing(1)} 0`,
+    }),
   };
 }

--- a/src/components/Explore/TracesByService/TraceDrawerScene.tsx
+++ b/src/components/Explore/TracesByService/TraceDrawerScene.tsx
@@ -155,7 +155,7 @@ export class TraceDrawerScene extends SceneObjectBase<DetailsSceneState> {
     
     return (
       <div className={styles.container}>
-        {addToInvestigationButton && (
+        {addToInvestigationButton && investigationLink && (
           <div className={styles.buttonContainer}>
             <Button
               variant='primary'

--- a/src/components/Explore/TracesByService/TraceDrawerScene.tsx
+++ b/src/components/Explore/TracesByService/TraceDrawerScene.tsx
@@ -117,7 +117,9 @@ export class TraceDrawerScene extends SceneObjectBase<DetailsSceneState> {
 
   private async updateInvestigationLink() {
     const { addToInvestigationButton } = this.state;
-    if (!addToInvestigationButton) return;
+    if (!addToInvestigationButton) { 
+      return;
+    }
 
     const link = await getInvestigationLink(addToInvestigationButton);
     if (link) {

--- a/src/components/Explore/actions/AddToInvestigationButton.tsx
+++ b/src/components/Explore/actions/AddToInvestigationButton.tsx
@@ -3,12 +3,12 @@ import { sceneGraph, SceneObject, SceneObjectBase, SceneObjectState, SceneQueryR
 import { DataQuery, DataSourceRef } from '@grafana/schema';
 
 import Logo from '../../../../src/img/logo.svg';
-import { VAR_DATASOURCE_EXPR } from 'utils/shared';
 
 export interface AddToInvestigationButtonState extends SceneObjectState {
   dsUid?: string;
   query?: string;
   labelValue?: string;
+  type?: string;
   context?: ExtensionContext;
   queries: DataQuery[];
 }
@@ -39,9 +39,6 @@ export class AddToInvestigationButton extends SceneObjectBase<AddToInvestigation
         this.getContext();
       })
     );
-
-    const datasourceUid = sceneGraph.interpolate(this, VAR_DATASOURCE_EXPR);
-    this.setState({ dsUid: datasourceUid });
   };
 
   private readonly getQueries = () => {
@@ -61,7 +58,7 @@ export class AddToInvestigationButton extends SceneObjectBase<AddToInvestigation
   };
 
   private readonly getContext = () => {
-    const { queries, dsUid, labelValue } = this.state;
+    const { queries, dsUid, labelValue, type = 'traceMetrics' } = this.state;
     const timeRange = sceneGraph.getTimeRange(this);
 
     if (!timeRange || !queries || !dsUid) {
@@ -69,7 +66,7 @@ export class AddToInvestigationButton extends SceneObjectBase<AddToInvestigation
     }
     const ctx = {
       origin: 'Explore Traces',
-      type: 'traces',
+      type,
       queries,
       timeRange: { ...timeRange.state.value },
       datasource: { uid: dsUid },

--- a/src/components/Explore/panels/PanelMenu.tsx
+++ b/src/components/Explore/panels/PanelMenu.tsx
@@ -17,7 +17,7 @@ import { reportAppInteraction, USER_EVENTS_PAGES, USER_EVENTS_ACTIONS } from 'ut
 import { getCurrentStep, getDataSource, getTraceExplorationScene } from 'utils/utils';
 import { firstValueFrom } from 'rxjs';
 
-const ADD_TO_INVESTIGATION_MENU_TEXT = 'Add to investigation';
+export const ADD_TO_INVESTIGATION_MENU_TEXT = 'Add to investigation';
 const extensionPointId = 'grafana-exploretraces-app/investigation/v1';
 const ADD_TO_INVESTIGATION_MENU_DIVIDER_TEXT = 'investigations_divider'; // Text won't be visible
 const ADD_TO_INVESTIGATION_MENU_GROUP_TEXT = 'Investigations';
@@ -52,20 +52,26 @@ export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPan
         }),
       });
 
+      const traceExploration = getTraceExplorationScene(this);
+      const dsUid = getDataSource(traceExploration);
+
       const addToInvestigationButton = new AddToInvestigationButton({
         query: this.state.query,
-        labelValue: this.state.labelValue,
+        dsUid,
       });
+
+      addToInvestigationButton.activate();
+      this.setState({ addToInvestigationButton });
       this._subs.add(
         addToInvestigationButton?.subscribeToState(() => {
           subscribeToAddToInvestigation(this);
         })
       );
-      this.setState({
-        addToInvestigationButton: addToInvestigationButton,
+    
+      addToInvestigationButton.setState({
+        ...addToInvestigationButton.state,
+        labelValue: this.state.labelValue,
       });
-
-      this.state.addToInvestigationButton?.activate();
     });
   }
 
@@ -113,7 +119,7 @@ const onExploreClick = () => {
   reportAppInteraction(USER_EVENTS_PAGES.analyse_traces, USER_EVENTS_ACTIONS.analyse_traces.open_in_explore_clicked);
 };
 
-const getInvestigationLink = async (addToInvestigations: AddToInvestigationButton) => {
+export const getInvestigationLink = async (addToInvestigations: AddToInvestigationButton) => {
   const context = addToInvestigations.state.context;
 
   // `getPluginLinkExtensions` is removed in Grafana v12

--- a/src/pages/Explore/TraceExploration.tsx
+++ b/src/pages/Explore/TraceExploration.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import React from 'react';
 
-import { AdHocVariableFilter, GrafanaTheme2 } from '@grafana/data';
+import { AdHocVariableFilter, GrafanaTheme2, LoadingState, PluginExtensionLink } from '@grafana/data';
 import {
   AdHocFiltersVariable,
   CustomVariable,
@@ -13,13 +13,14 @@ import {
   SceneObjectState,
   SceneObjectUrlSyncConfig,
   SceneObjectUrlValues,
+  SceneQueryRunner,
   SceneRefreshPicker,
   SceneTimePicker,
   SceneTimeRange,
   SceneVariableSet,
 } from '@grafana/scenes';
 import { config } from '@grafana/runtime';
-import { Badge, Button, Drawer, Dropdown, Icon, Menu, Stack, Tooltip, useStyles2 } from '@grafana/ui';
+import { Badge, Button, Drawer, Dropdown, Icon, IconButton, Menu, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { TracesByServiceScene } from '../../components/Explore/TracesByService/TracesByServiceScene';
 import {
@@ -36,7 +37,7 @@ import {
   VAR_PRIMARY_SIGNAL,
   VAR_SPAN_LIST_COLUMNS,
 } from '../../utils/shared';
-import { getTraceExplorationScene, getFiltersVariable, getPrimarySignalVariable } from '../../utils/utils';
+import { getTraceExplorationScene, getFiltersVariable, getPrimarySignalVariable, getDataSource } from '../../utils/utils';
 import { TraceDrawerScene } from '../../components/Explore/TracesByService/TraceDrawerScene';
 import { primarySignalOptions } from './primary-signals';
 import { VariableHide } from '@grafana/schema';
@@ -44,6 +45,8 @@ import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'ut
 import { PrimarySignalVariable } from './PrimarySignalVariable';
 import { renderTraceQLLabelFilters } from 'utils/filters-renderer';
 import { TraceQLIssueDetector, TraceQLConfigWarning } from '../../components/Explore/TraceQLIssueDetector';
+import { AddToInvestigationButton } from 'components/Explore/actions/AddToInvestigationButton';
+import { ADD_TO_INVESTIGATION_MENU_TEXT, getInvestigationLink } from 'components/Explore/panels/PanelMenu';
 
 export interface TraceExplorationState extends SceneObjectState {
   topScene?: SceneObject;
@@ -62,6 +65,9 @@ export interface TraceExplorationState extends SceneObjectState {
   initialFilters?: AdHocVariableFilter[];
 
   issueDetector?: TraceQLIssueDetector;
+
+  investigationLink?: PluginExtensionLink;
+  addToInvestigationButton?: AddToInvestigationButton;
 }
 
 const version = process.env.VERSION;
@@ -93,9 +99,14 @@ export class TraceExploration extends SceneObjectBase<TraceExplorationState> {
 
     this._subs.add(
       this.subscribeToEvent(EventTraceOpened, (event) => {
+        this.setupInvestigationButton(event.payload.traceId);
         this.setState({ traceId: event.payload.traceId, spanId: event.payload.spanId });
       })
     );
+
+    if (this.state.traceId) {
+      this.setupInvestigationButton(this.state.traceId);
+    }
 
     const datasourceVar = sceneGraph.lookupVariable(VAR_DATASOURCE, this) as DataSourceVariable;
     datasourceVar.subscribeToState((newState) => {
@@ -156,6 +167,69 @@ export class TraceExploration extends SceneObjectBase<TraceExplorationState> {
     this.setState({ traceId: undefined, spanId: undefined });
   }
 
+  private setupInvestigationButton(traceId: string) {
+    const traceExploration = getTraceExplorationScene(this);
+    const dsUid = getDataSource(traceExploration);
+
+    const queryRunner = new SceneQueryRunner({
+      datasource: { uid: dsUid },
+      queries: [{ 
+        refId: 'A', 
+        query: traceId, 
+        queryType: 'traceql',
+      }],
+    });
+
+    const addToInvestigationButton = new AddToInvestigationButton({
+      query: traceId,
+      type: 'trace',
+      dsUid,
+      $data: queryRunner,
+    });
+    
+    addToInvestigationButton.activate();
+    this.setState({ addToInvestigationButton });
+    this._subs.add(
+      addToInvestigationButton.subscribeToState(() => {
+        this.updateInvestigationLink();
+      })
+    );
+        
+    queryRunner.activate();
+    
+    this._subs.add(
+      queryRunner.subscribeToState((state) => {
+        if (state.data?.state === LoadingState.Done && state.data?.series?.length > 0) {
+          const serviceNameField = state.data.series[0]?.fields?.find((f) => f.name === 'serviceName');
+          
+          if (serviceNameField && serviceNameField.values[0]) {
+            addToInvestigationButton.setState({
+              ...addToInvestigationButton.state,
+              labelValue: `${serviceNameField.values[0]}`,
+            });
+          }
+        }
+      })
+    );
+    
+    addToInvestigationButton.setState({
+      ...addToInvestigationButton.state,
+      labelValue: traceId,
+    });
+  }
+
+  private async updateInvestigationLink() {
+    const { addToInvestigationButton } = this.state;
+    if (!addToInvestigationButton) { 
+      return;
+    }
+
+    const link = await getInvestigationLink(addToInvestigationButton);
+    if (link) {
+      this.setState({ investigationLink: link });
+    }
+  }
+
   static Component = ({ model }: SceneComponentProps<TraceExploration>) => {
     const { body } = model.useState();
     const styles = useStyles2(getStyles);
@@ -167,7 +241,7 @@ export class TraceExploration extends SceneObjectBase<TraceExplorationState> {
 export class TraceExplorationScene extends SceneObjectBase {
   static Component = ({ model }: SceneComponentProps<TraceExplorationScene>) => {
     const traceExploration = getTraceExplorationScene(model);
-    const { controls, topScene, drawerScene, traceId, issueDetector } = traceExploration.useState();
+    const { controls, topScene, drawerScene, traceId, issueDetector, investigationLink, addToInvestigationButton } = traceExploration.useState();
     const { hasIssue } = issueDetector?.useState() || {
       hasIssue: false,
     };
@@ -206,6 +280,19 @@ export class TraceExplorationScene extends SceneObjectBase {
         </div>
       </Menu>
     );
+
+    const addToInvestigationClicked = (e: React.MouseEvent) => {
+      if (investigationLink?.onClick) {
+        investigationLink.onClick(e);
+      }
+      
+      reportAppInteraction(
+        USER_EVENTS_PAGES.analyse_traces,
+        USER_EVENTS_ACTIONS.analyse_traces.add_to_investigation_trace_view_clicked
+      );
+      
+      setTimeout(() => traceExploration.closeDrawer(), 100);
+    };
 
     return (
       <>
@@ -254,7 +341,27 @@ export class TraceExplorationScene extends SceneObjectBase {
           <div className={styles.body}>{topScene && <topScene.Component model={topScene} />}</div>
         </div>
         {drawerScene && traceId && (
-          <Drawer title={`View trace ${traceId}`} size={'lg'} onClose={() => traceExploration.closeDrawer()}>
+          <Drawer size={'lg'} onClose={() => traceExploration.closeDrawer()}>
+            <div className={styles.drawerHeader}>
+              <h3>View trace {traceId}</h3>
+                <div className={styles.drawerHeaderButtons}>
+                  {addToInvestigationButton && investigationLink && (
+                    <Button
+                      variant='secondary'
+                      size='sm'
+                      icon='plus-square'
+                      onClick={addToInvestigationClicked}
+                    >
+                      {ADD_TO_INVESTIGATION_MENU_TEXT}
+                    </Button>
+                  )}
+                  <IconButton 
+                    name='times' 
+                    onClick={() => traceExploration.closeDrawer()} 
+                    tooltip='Close drawer'
+                  />
+                </div>
+            </div>
             <drawerScene.Component model={drawerScene} />
           </Drawer>
         )}
@@ -345,6 +452,20 @@ function getStyles(theme: GrafanaTheme2) {
       padding: `0 ${theme.spacing(2)} ${theme.spacing(2)} ${theme.spacing(2)}`,
       overflow: 'auto', /* Needed for sticky positioning */
       maxHeight: '100%' /* Needed for sticky positioning */
+    }),
+    drawerHeader: css({
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
+      paddingBottom: theme.spacing(2),
+      marginBottom: theme.spacing(2),
+    }),
+    drawerHeaderButtons: css({
+      display: 'flex',
+      justifyContent: 'flex-end',
+      gap: theme.spacing(1.5),
+      padding: `0 0 ${theme.spacing(1)} 0`,
     }),
     body: css({
       label: 'body',

--- a/src/pages/Explore/TraceExploration.tsx
+++ b/src/pages/Explore/TraceExploration.tsx
@@ -359,6 +359,7 @@ export class TraceExplorationScene extends SceneObjectBase {
                     name='times' 
                     onClick={() => traceExploration.closeDrawer()} 
                     tooltip='Close drawer'
+                    size='lg'
                   />
                 </div>
             </div>

--- a/src/pages/Explore/TraceExploration.tsx
+++ b/src/pages/Explore/TraceExploration.tsx
@@ -461,12 +461,15 @@ function getStyles(theme: GrafanaTheme2) {
       borderBottom: `1px solid ${theme.colors.border.weak}`,
       paddingBottom: theme.spacing(2),
       marginBottom: theme.spacing(2),
+
+      'h3': {
+        margin: 0,
+      },
     }),
     drawerHeaderButtons: css({
       display: 'flex',
       justifyContent: 'flex-end',
       gap: theme.spacing(1.5),
-      padding: `0 0 ${theme.spacing(1)} 0`,
     }),
     body: css({
       label: 'body',

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -40,6 +40,7 @@ export const USER_EVENTS_ACTIONS = {
     open_trace: 'open_trace',
     open_in_explore_clicked: 'open_in_explore_clicked',
     add_to_investigation_clicked: 'add_to_investigation_clicked',
+    add_to_investigation_trace_view_clicked: 'add_to_investigation_trace_view_clicked',
     span_list_columns_changed: 'span_list_columns_changed',
     toggle_bookmark_clicked: 'toggle_bookmark_clicked',
   },


### PR DESCRIPTION
Allows a trace to be added to an investigation.

Equivalent investigations [PR](https://github.com/grafana/investigations-app/pull/235).

![Screenshot 2025-04-10 at 10 19 20](https://github.com/user-attachments/assets/9e312029-6882-4ec6-bf9f-b378ae34262b)
![Screenshot 2025-04-10 at 10 20 19](https://github.com/user-attachments/assets/87f75aa9-628a-4a5b-87e5-a7097e04a5d9)
