### PR TITLE
Add support for contextualised trace list table

### DIFF
--- a/src/components/Explore/TracesByService/Tabs/Spans/columnsUtil.test.ts
+++ b/src/components/Explore/TracesByService/Tabs/Spans/columnsUtil.test.ts
@@ -1,0 +1,87 @@
+import { processColumns, DEFAULT_HTTP_SPAN_COLUMNS } from './columnsUtil';
+
+describe('columnsUtil', () => {
+  describe('processColumns', () => {
+    it('should add all additional columns when no existing columns', () => {
+      const result = processColumns('', DEFAULT_HTTP_SPAN_COLUMNS);
+      expect(result).toBe(DEFAULT_HTTP_SPAN_COLUMNS.join(', '));
+    });
+
+    it('should remove duplicates when existing columns overlap with additional columns', () => {
+      const existingColumns = 'span.http.method, span.http.path, custom.column';
+      const result = processColumns(existingColumns, DEFAULT_HTTP_SPAN_COLUMNS);
+      
+      const expectedColumns = [
+        'span.http.method',
+        'span.http.path', 
+        'custom.column',
+        'span.http.request.method', 
+        'span.http.route', 
+        'span.http.status_code', 
+        'span.http.response.status_code'
+      ];
+      
+      // Convert both to sets for comparison to ignore order
+      const resultSet = new Set(result.split(', '));
+      const expectedSet = new Set(expectedColumns);
+      
+      expect(resultSet.size).toBe(expectedSet.size);
+      expectedColumns.forEach(col => {
+        expect(resultSet.has(col)).toBe(true);
+      });
+    });
+
+    it('should handle whitespace in existing columns', () => {
+      const existingColumns = ' span.http.method,  custom.column ';
+      const result = processColumns(existingColumns, DEFAULT_HTTP_SPAN_COLUMNS);
+      
+      expect(result.includes(' span.http.method')).toBe(false);
+      expect(result.includes('custom.column ')).toBe(false);
+      expect(result.includes('span.http.method')).toBe(true);
+      expect(result.includes('custom.column')).toBe(true);
+    });
+
+    it('should maintain all DEFAULT_HTTP_SPAN_COLUMNS', () => {
+      const result = processColumns('custom.column', DEFAULT_HTTP_SPAN_COLUMNS);
+      
+      DEFAULT_HTTP_SPAN_COLUMNS.forEach(col => {
+        expect(result.includes(col)).toBe(true);
+      });
+    });
+
+    it('should handle empty string for existing columns', () => {
+      const result = processColumns('', DEFAULT_HTTP_SPAN_COLUMNS);
+      expect(result).toBe(DEFAULT_HTTP_SPAN_COLUMNS.join(', '));
+    });
+
+    it('should handle empty additional columns', () => {
+      const result = processColumns('column1, column2', []);
+      expect(result).toBe('column1, column2');
+    });
+
+    it('should handle null or undefined for existing columns', () => {
+      // @ts-ignore - intentionally testing with null
+      const resultWithNull = processColumns(null, DEFAULT_HTTP_SPAN_COLUMNS);
+      // @ts-ignore - intentionally testing with undefined
+      const resultWithUndefined = processColumns(undefined, DEFAULT_HTTP_SPAN_COLUMNS);
+      
+      expect(resultWithNull).toBe(DEFAULT_HTTP_SPAN_COLUMNS.join(', '));
+      expect(resultWithUndefined).toBe(DEFAULT_HTTP_SPAN_COLUMNS.join(', '));
+    });
+  });
+
+  describe('DEFAULT_HTTP_SPAN_COLUMNS', () => {
+    it('should contain all required HTTP span columns', () => {
+      expect(DEFAULT_HTTP_SPAN_COLUMNS).toContain('span.http.method');
+      expect(DEFAULT_HTTP_SPAN_COLUMNS).toContain('span.http.request.method');
+      expect(DEFAULT_HTTP_SPAN_COLUMNS).toContain('span.http.route');
+      expect(DEFAULT_HTTP_SPAN_COLUMNS).toContain('span.http.path');
+      expect(DEFAULT_HTTP_SPAN_COLUMNS).toContain('span.http.status_code');
+      expect(DEFAULT_HTTP_SPAN_COLUMNS).toContain('span.http.response.status_code');
+    });
+
+    it('should have the correct length', () => {
+      expect(DEFAULT_HTTP_SPAN_COLUMNS.length).toBe(6);
+    });
+  });
+}); 

--- a/src/components/Explore/TracesByService/Tabs/Spans/columnsUtil.ts
+++ b/src/components/Explore/TracesByService/Tabs/Spans/columnsUtil.ts
@@ -1,0 +1,20 @@
+export function processColumns(existingColumns: string, additionalColumns: string[]): string {
+  const columnsSet = new Set<string>();
+  
+  if (existingColumns) {
+    existingColumns.split(',').forEach(col => columnsSet.add(col.trim()));
+  }
+  
+  additionalColumns.forEach(col => columnsSet.add(col));
+  
+  return Array.from(columnsSet).join(', ');
+}
+
+export const DEFAULT_HTTP_SPAN_COLUMNS = [
+  'span.http.method', 
+  'span.http.request.method', 
+  'span.http.route', 
+  'span.http.path', 
+  'span.http.status_code', 
+  'span.http.response.status_code'
+]; 

--- a/src/components/Explore/TracesByService/TracesByServiceScene.tsx
+++ b/src/components/Explore/TracesByService/TracesByServiceScene.tsx
@@ -22,7 +22,6 @@ import {
   SceneObjectUrlValues,
   SceneQueryRunner,
   SceneTimeRange,
-  VariableValue,
 } from '@grafana/scenes';
 
 import { REDPanel } from './REDPanel';
@@ -52,6 +51,7 @@ import { Icon, LinkButton, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { getDefaultSelectionForMetric } from '../../../utils/comparison';
 import { map, Observable } from 'rxjs';
+import { processColumns, DEFAULT_HTTP_SPAN_COLUMNS } from './Tabs/Spans/columnsUtil';
 
 export interface TraceSceneState extends SceneObjectState {
   body: SceneFlexLayout;
@@ -225,13 +225,14 @@ export class TracesByServiceScene extends SceneObjectBase<TraceSceneState> {
 
   private updateQueryRunner(metric: MetricFunction) {
     const selection = this.state.selection;
-    const select = getSpanListColumnsVariable(this).getValue();
+    const existingColumns = getSpanListColumnsVariable(this).getValue()?.toString() ?? '';
+    const columns = processColumns(existingColumns, DEFAULT_HTTP_SPAN_COLUMNS);
 
     this.setState({
       $data: new SceneDataTransformer({
         $data: new SceneQueryRunner({
           datasource: explorationDS,
-          queries: [buildQuery(metric, select, selection)],
+          queries: [buildQuery(metric, columns, selection)],
           $timeRange: timeRangeFromSelection(selection),
         }),
         transformations: [...filterStreamingProgressTransformations, ...spanListTransformations],
@@ -347,8 +348,7 @@ function getStyles(theme: GrafanaTheme2) {
 const MAIN_PANEL_HEIGHT = 240;
 export const MINI_PANEL_HEIGHT = (MAIN_PANEL_HEIGHT - 8) / 2;
 
-export function buildQuery(type: MetricFunction, select: VariableValue, selection?: ComparisonSelection) {
-  const columns = select?.toString();
+export function buildQuery(type: MetricFunction, columns: string, selection?: ComparisonSelection) {
   const selectQuery = columns !== '' ? ` | select(${columns})` : '';
   let typeQuery = '';
   switch (type) {
@@ -495,12 +495,18 @@ const spanListTransformations = [
     id: 'organize',
     options: {
       indexByName: {
-        'Trace Service': 0,
-        'Trace Name': 1,
-        'Span ID': 2,
-        Duration: 3,
-        'Start time': 4,
-        status: 5,
+        'Start time': 0,
+        status: 1,
+        'Trace Service': 2,
+        'Trace Name': 3,
+        Duration: 4,
+        'Span ID': 5,
+        'span.http.method': 6,
+        'span.http.request.method': 7,
+        'span.http.path': 8,
+        'span.http.route': 9,
+        'span.http.status_code': 10,
+        'span.http.response.status_code': 11,
       },
     },
   },


### PR DESCRIPTION
Adds support for a contextualised trace list table.

Note: if the column/data point does not exist in the response data it is not rendered.

Fixes https://github.com/grafana/traces-drilldown/issues/370

![Screenshot 2025-04-10 at 12 38 31](https://github.com/user-attachments/assets/763578c3-9ae9-4b9b-aec7-be19a171d1c3)
