### PR TITLE
chore: remove extension link from logs drilldown

### DIFF
--- a/src/module.tsx
+++ b/src/module.tsx
@@ -1,9 +1,6 @@
 import { lazy } from 'react';
 import { AppPlugin } from '@grafana/data';
 
-// @ts-ignore new API that is not yet in stable release
-import { sidecarServiceSingleton_EXPERIMENTAL } from '@grafana/runtime';
-import pluginJson from './plugin.json';
 import { exposedComponents } from 'exposedComponents';
 import { linkConfigs } from 'utils/links';
 
@@ -15,15 +12,6 @@ export const plugin = new AppPlugin<{}>().setRootPage(App).addConfigPage({
   icon: 'cog',
   body: AppConfig,
   id: 'configuration',
-})
-.addLink({
-  title: 'traces drilldown',
-  description: 'Open in Traces Drilldown',
-  icon: 'align-left',
-  targets: 'grafana-lokiexplore-app/toolbar-open-related/v1',
-  onClick: () => {
-    sidecarServiceSingleton_EXPERIMENTAL?.openAppV3({ pluginId: pluginJson.id, path: '/explore' });
-  },
 });
 
 for (const linkConfig of linkConfigs) {

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -66,11 +66,6 @@
     ],
     "addedLinks": [
       {
-        "targets": ["grafana-lokiexplore-app/toolbar-open-related/v1"],
-        "title": "traces drilldown",
-        "description": "Open in Traces Drilldown"
-      },
-      {
         "targets": ["grafana/dashboard/panel/menu"],
         "title": "Open in Explore Traces",
         "description": "Open current query in the Explore Traces app"


### PR DESCRIPTION
https://github.com/grafana/logs-drilldown/pull/1187 removes the extensionlink that was used by traces drilldown.