### PR TITLE
Fix issue with container height

### DIFF
--- a/src/pages/Explore/TraceExploration.tsx
+++ b/src/pages/Explore/TraceExploration.tsx
@@ -338,8 +338,8 @@ function getStyles(theme: GrafanaTheme2) {
       minHeight: '100%',
       flexDirection: 'column',
       padding: `0 ${theme.spacing(2)} ${theme.spacing(2)} ${theme.spacing(2)}`,
-      overflow: 'auto' /* Needed for sticky positioning */,
-      height: '1px' /* Needed for sticky positioning */,
+      overflow: 'auto', /* Needed for sticky positioning */
+      maxHeight: '100%' /* Needed for sticky positioning */
     }),
     body: css({
       label: 'body',


### PR DESCRIPTION
Fixes an issue with the container height that was set to 1px, causing Traces Drilldown to be almost completely invisible when clicking the `Related Traces` button.

![Screenshot 2025-04-10 at 16 04 09](https://github.com/user-attachments/assets/736e2d01-5174-4761-83dd-39e1bf418457)


Fixes https://github.com/grafana/traces-drilldown/issues/420