### PR TITLE
Support typed query generation

### DIFF
--- a/src/utils/filters-renderer.test.ts
+++ b/src/utils/filters-renderer.test.ts
@@ -1,0 +1,107 @@
+import { AdHocVariableFilter } from '@grafana/data';
+import { renderTraceQLLabelFilters } from './filters-renderer';
+
+describe('filters-renderer', () => {
+  describe('renderTraceQLLabelFilters', () => {
+    it('should render a single filter correctly', () => {
+      const filters: AdHocVariableFilter[] = [
+        { key: 'service.name', operator: '=', value: 'test' },
+      ];
+      expect(renderTraceQLLabelFilters(filters)).toBe('service.name="test"');
+    });
+
+    it('should join multiple filters with "&&"', () => {
+      const filters: AdHocVariableFilter[] = [
+        { key: 'service.name', operator: '=', value: 'test' },
+        { key: 'duration', operator: '>', value: '100' },
+      ];
+      expect(renderTraceQLLabelFilters(filters)).toBe('service.name="test"&&duration>100');
+    });
+
+    it('should not add quotes to already quoted values', () => {
+      const filters: AdHocVariableFilter[] = [
+        { key: 'tag', operator: '=', value: '"already-quoted"' },
+      ];
+      expect(renderTraceQLLabelFilters(filters)).toBe('tag="already-quoted"');
+    });
+
+    it('should not add quotes to status, kind, duration keys', () => {
+      const filters: AdHocVariableFilter[] = [
+        { key: 'status', operator: '=', value: 'error' },
+        { key: 'kind', operator: '=', value: 'client' },
+        { key: 'span:status', operator: '=', value: 'ok' },
+        { key: 'span:kind', operator: '=', value: 'server' },
+      ];
+      expect(renderTraceQLLabelFilters(filters)).toBe('status=error&&kind=client&&span:status=ok&&span:kind=server');
+    });
+
+    it('should add quotes for partitions and protocol keys', () => {
+      const filters: AdHocVariableFilter[] = [
+        { key: 'span.messaging.destination.partition.id', operator: '=', value: '1' },
+        { key: 'span.network.protocol.version', operator: '=', value: '2' },
+      ];
+      expect(renderTraceQLLabelFilters(filters)).toBe('span.messaging.destination.partition.id="1"&&span.network.protocol.version="2"');
+    });
+
+    it('should handle combined types of filters', () => {
+      const filters: AdHocVariableFilter[] = [
+        { key: 'service.name', operator: '=', value: 'frontend' },
+        { key: 'duration', operator: '>', value: '100' },
+        { key: 'status', operator: '=', value: 'error' },
+      ];
+      expect(renderTraceQLLabelFilters(filters)).toBe('service.name="frontend"&&duration>100&&status=error');
+    });
+
+    it('should handle different operators', () => {
+      const filters: AdHocVariableFilter[] = [
+        { key: 'service.name', operator: '=~', value: 'test' },
+        { key: 'duration', operator: '!=', value: '100' },
+      ];
+      expect(renderTraceQLLabelFilters(filters)).toBe('service.name=~"test"&&duration!=100');
+    });
+
+    describe('number handling', () => {
+      it('should handle integer values without quotes for duration', () => {
+        const filters: AdHocVariableFilter[] = [
+          { key: 'duration', operator: '>', value: '123' },
+        ];
+        expect(renderTraceQLLabelFilters(filters)).toBe('duration>123');
+      });
+
+      it('should handle decimal values without quotes for duration', () => {
+        const filters: AdHocVariableFilter[] = [
+          { key: 'duration', operator: '>', value: '123.45' },
+        ];
+        expect(renderTraceQLLabelFilters(filters)).toBe('duration>123.45');
+      });
+
+      it('should handle negative values without quotes for duration', () => {
+        const filters: AdHocVariableFilter[] = [
+          { key: 'duration', operator: '>', value: '-123' },
+        ];
+        expect(renderTraceQLLabelFilters(filters)).toBe('duration>-123');
+      });
+
+      it('should handle values with whitespace for duration', () => {
+        const filters: AdHocVariableFilter[] = [
+          { key: 'duration', operator: '>', value: ' 123 ' },
+        ];
+        expect(renderTraceQLLabelFilters(filters)).toBe('duration> 123 ');
+      });
+
+      it('should handle numeric strings for non-numeric fields', () => {
+        const filters: AdHocVariableFilter[] = [
+          { key: 'service.id', operator: '=', value: '12345' },
+        ];
+        expect(renderTraceQLLabelFilters(filters)).toBe('service.id=12345');
+      });
+
+      it('should filter out empty string values', () => {
+        const filters: AdHocVariableFilter[] = [
+          { key: 'tag', operator: '=', value: '' },
+        ];
+        expect(renderTraceQLLabelFilters(filters)).toBe('true');
+      });
+    });
+  });
+}); 

--- a/src/utils/filters-renderer.ts
+++ b/src/utils/filters-renderer.ts
@@ -12,7 +12,9 @@ export function renderTraceQLLabelFilters(filters: AdHocVariableFilter[]) {
 
 function renderFilter(filter: AdHocVariableFilter) {
   let val = filter.value;
-  if (!isNumber(val) && !['status', 'kind', 'span:status', 'span:kind'].includes(filter.key)) {
+  if (['span.messaging.destination.partition.id', 'span.network.protocol.version'].includes(filter.key) || 
+    (!isNumber(val) && !['status', 'kind', 'span:status', 'span:kind', 'duration', 'span:duration', 'trace:duration', 'event:timeSinceStart'].includes(filter.key))
+  ) {
     // Add quotes if it's coming from the filter input and it's not already quoted.
     // Adding a filter from a time series graph already has quotes. This should be handled better.
     if (typeof val === 'string' && !val.startsWith('"') && !val.endsWith('"')) {


### PR DESCRIPTION
Properly types

- span.[messaging.destination.partition.id](https://opentelemetry.io/docs/specs/semconv/attributes-registry/messaging/#messaging-destination-partition-id)
- span.[network.protocol.version](https://opentelemetry.io/docs/specs/semconv/attributes-registry/network/#network-protocol-version)
- duration
- span:duration
- trace:duration
- event:timeSinceStart

when rendering TraceQL label filters.

Fixes https://github.com/grafana/traces-drilldown/issues/33 & https://github.com/grafana/traces-drilldown/issues/403

<img width="1407" alt="Screenshot 2025-04-11 at 11 56 16" src="https://github.com/user-attachments/assets/68f27f72-596c-41ef-a9b6-09b36cba5763" />
<img width="1302" alt="Screenshot 2025-04-11 at 11 57 40" src="https://github.com/user-attachments/assets/a8785840-0b38-4027-8ca8-68e6b4c3d1a7" />
