### PR TITLE
RED Panels: update error panel y-axis labels

### DIFF
--- a/src/components/Explore/TracesByService/MiniREDPanel.tsx
+++ b/src/components/Explore/TracesByService/MiniREDPanel.tsx
@@ -118,7 +118,7 @@ export class MiniREDPanel extends SceneObjectBase<MiniREDPanelState> {
     if (metric === 'rate') {
       panel.setCustomFieldConfig('axisLabel', 'span/s');
     } else if (metric === 'errors') {
-      panel.setTitle('Errors rate').setCustomFieldConfig('axisLabel', 'span/s').setColor({
+      panel.setTitle('Errors rate').setCustomFieldConfig('axisLabel', 'error/s').setColor({
         fixedColor: 'semi-dark-red',
         mode: 'fixed',
       });

--- a/src/components/Explore/TracesByService/REDPanel.tsx
+++ b/src/components/Explore/TracesByService/REDPanel.tsx
@@ -208,7 +208,7 @@ export class REDPanel extends SceneObjectBase<RateMetricsPanelState> {
     if (type === 'rate') {
       panel.setCustomFieldConfig('axisLabel', 'span/s');
     } else if (type === 'errors') {
-      panel.setCustomFieldConfig('axisLabel', 'span/s').setColor({
+      panel.setCustomFieldConfig('axisLabel', 'error/s').setColor({
         fixedColor: 'semi-dark-red',
         mode: 'fixed',
       });


### PR DESCRIPTION
Fixes: #417

<img width="1697" alt="Screenshot 2025-04-11 at 14 31 49" src="https://github.com/user-attachments/assets/7ff90445-92ce-4ba5-8111-8267fb5dca42" />

<img width="1701" alt="Screenshot 2025-04-11 at 14 31 21" src="https://github.com/user-attachments/assets/730c5b82-a7da-47a9-83db-fe27f775962d" />
