### PR TITLE
Order radio options and dropdown by frequently used

### DIFF
--- a/src/components/Explore/GroupBySelector.tsx
+++ b/src/components/Explore/GroupBySelector.tsx
@@ -3,7 +3,7 @@ import { useResizeObserver } from '@react-aria/utils';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
-import { Select, RadioButtonGroup, useStyles2, useTheme2, measureText, Field, InputActionMeta } from '@grafana/ui';
+import { Select, RadioButtonGroup, useStyles2, useTheme2, measureText, Field, InputActionMeta, Tooltip, Icon } from '@grafana/ui';
 import { usePluginUserStorage } from '@grafana/runtime';
 import { ALL, GROUP_BY_CLICK_COUNTS_STORAGE_KEY, ignoredAttributes, maxOptions, MetricFunction, RESOURCE_ATTR, SPAN_ATTR } from 'utils/shared';
 import { AttributesBreakdownScene } from './TracesByService/Tabs/Breakdown/AttributesBreakdownScene';
@@ -228,8 +228,24 @@ export function GroupBySelector({ options, radioAttributes, value, onChange, sho
   const showAllOption = showAll ? [{ label: ALL, value: ALL }] : [];
   const defaultOnChangeValue = showAll ? ALL : '';
 
+  const tooltipContent = (
+    <div className={styles.tooltip}>
+      <p>Attributes are ordered by frequency of use. Most frequently used attributes appear first in the radio buttons and dropdown menu.</p>
+      <p>Traces Drilldown tracks your selections and automatically prioritizes the attributes you use most often.</p>
+    </div>
+  );
+
   return (
-    <Field label="Group by">
+    <Field 
+      label={
+        <div className={styles.labelWithTooltip}>
+          Group by
+          <Tooltip content={tooltipContent} placement="right" theme="info">
+            <Icon name="info-circle" className={styles.infoIcon} />
+          </Tooltip>
+        </div>
+      }
+    >
       <div ref={controlsContainer} className={styles.container}>
         {radioOptions.length > 0 && (
           <RadioButtonGroup 
@@ -269,6 +285,23 @@ function getStyles(theme: GrafanaTheme2) {
     container: css({
       display: 'flex',
       gap: theme.spacing(1),
+    }),
+    labelWithTooltip: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(0.5),
+    }),
+    infoIcon: css({
+      cursor: 'pointer',
+    }),
+    tooltip: css({
+      maxWidth: '300px',
+      p: {
+        margin: theme.spacing(0, 0, 1, 0),
+        '&:last-child': {
+          marginBottom: 0,
+        },
+      },
     }),
   };
 }

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -15,6 +15,7 @@ export const EXPLORATIONS_ROUTE = `${PLUGIN_BASE_URL}/${ROUTES.Explore}`;
 export const DATASOURCE_LS_KEY = 'grafana.drilldown.traces.datasource';
 export const HOMEPAGE_FILTERS_LS_KEY = 'grafana.drilldown.traces.homepage.filters';
 export const BOOKMARKS_LS_KEY = 'grafana.drilldown.traces.bookmarks';
+export const GROUP_BY_CLICK_COUNTS_STORAGE_KEY = 'grafana.drilldown.traces.groupByClickCounts';
 
 export const GRID_TEMPLATE_COLUMNS = 'repeat(auto-fit, minmax(400px, 1fr))';
 


### PR DESCRIPTION
Orders the `GroupBySelector` radio options and the dropdown next to it by attribute clicks. The attributes with the most clicks will move towards the far left for the radio options and the top of the frequently used option group in the dropdown.

Fixes https://github.com/grafana/traces-drilldown/issues/302

https://github.com/user-attachments/assets/2c905952-6700-44c6-8e82-ed5ffb93f62b

