### PR TITLE
Breakdown: create a new history item when a filter is added from the breakdown

### DIFF
--- a/src/components/Explore/actions/AddToFiltersAction.tsx
+++ b/src/components/Explore/actions/AddToFiltersAction.tsx
@@ -58,6 +58,10 @@ export const addToFilters = (variable: AdHocFiltersVariable, label: string, valu
   // and also keep span.db.name as it is a primary filter
   const filtersWithoutNew = variable.state.filters.filter((f) => f.key === DATABASE_CALLS_KEY || f.key !== label);
 
+  // TODO: Replace it with new API introduced in https://github.com/grafana/scenes/issues/1103
+  // At the moment AdHocFiltersVariable doesn't support pushing new history entry on change
+  history.pushState(null, '');
+
   variable.setState({
     filters: [
       ...filtersWithoutNew,


### PR DESCRIPTION
Fixes #419

AdHocFiltersVariable doesn't support creating new history entry like other variables (using `.changeValueTo(..., ..., true)`). We can wait for it to be added to scenes in https://github.com/grafana/scenes/issues/1103 or add a workaround.

The workaround is to do a similar thing as we've done for Profiles Drilldown:
- create an empty history entry manually
- UrlSyncManager replaces that history with current URL while syncing 