### PR TITLE
Default to all spans when pressing Open in Traces Drilldown button

### DIFF
--- a/src/exposedComponents/OpenInExploreTracesButton/OpenInExploreTracesButton.tsx
+++ b/src/exposedComponents/OpenInExploreTracesButton/OpenInExploreTracesButton.tsx
@@ -33,6 +33,8 @@ export default function OpenInExploreTracesButton({
       params.append('var-filters', `${streamSelector.name}|${streamSelector.operator}|${streamSelector.value}`);
     });
 
+    params.append('var-primarySignal', 'true'); // so all spans is selected
+
     return `a/${pluginJson.id}/explore?${params.toString()}`;
   }, [datasourceUid, from, to, matchers]);
 


### PR DESCRIPTION
When clicking the Open in Traces Drilldown button, we were defaulting to root spans which sometimes results in no data being shown in the graphs as we are essentially coming from a context of all spans in asserts.

This PR ensures all spans is selected by default.

![Screenshot 2025-04-25 at 09 19 21](https://github.com/user-attachments/assets/237a41ff-c9e8-4df9-8252-e9df8bafd541)
