### PR TITLE
Fix broken links in docs

### DIFF
--- a/docs/sources/access/index.md
+++ b/docs/sources/access/index.md
@@ -19,8 +19,8 @@ refs:
 
 You can access Grafana Traces Drilldown using any of these:
 
- - [Grafana Cloud](access-in-grafana-cloud): The easiest method, since no setup or installation is required.
- - Self-managed [Grafana](#access-in-self-managed-grafana) open source or Enterprise: You must install the Traces Drilldown plugin.
+ - [Grafana Cloud](#set-up-in-grafana-cloud): The easiest method, since no setup or installation is required.
+ - Self-managed [Grafana](#set-up-in-self-managed-grafana) open source or Enterprise: You must install the Traces Drilldown plugin.
 
 Traces Drilldown requires Grafana Tempo 2.6 or later with [TraceQL metrics configured](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/traceql-metrics/).
 
@@ -29,7 +29,7 @@ Traces Drilldown requires Grafana Tempo 2.6 or later with [TraceQL metrics confi
 To use Traces Drilldown with Grafana Cloud, you need the following:
 
 - Grafana Cloud account
-- Grafana stack in Grafana Cloud with a configured [Tempo data source](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/) receiving tracing data
+- Grafana stack in Grafana Cloud receiving tracing data from your stack's default [Hosted Traces](https://grafana.com/docs/grafana-cloud/send-data/traces/) data source or a [Tempo data source](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/)
 
 ## Set up in self-managed Grafana
 
@@ -39,7 +39,7 @@ To use Traces Drilldown with self-managed Grafana open source or Grafana Enterpr
 - Tempo 2.6 or later with [TraceQL metrics configured](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/traceql-metrics/)
 - Configured [Tempo data source](https://grafana.com/docs/grafana/latest/datasources/tempo/configure-tempo-data-source/) receiving tracing data
 
-Next, [access Traces Drilldown](#access-explore-traces).
+Next, [access Traces Drilldown](#access-traces-drilldown).
 
 ### Install the Traces Drilldown plugin
 

--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -4,6 +4,12 @@ canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploratio
 keywords:
   - Traces Drilldown
   - Get started
+refs:
+  drilldown-apps:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/visualizations/simplified-exploration/
 title: Get started with Traces Drilldown
 menuTitle: Get started
 weight: 300
@@ -18,7 +24,7 @@ Investigate using primary signals, RED metrics, filters, and structural or trace
 To learn more, refer to [Concepts](../concepts/).
 
 {{< admonition type="note" >}}
-Expand your observability journey and learn about [the Drilldown apps suite](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/).
+Expand your observability journey and learn about [the Drilldown apps suite](ref:drilldown-apps).
 {{< /admonition >}}
 
 {{< youtube id="a3uB1C2oHA4" >}}

--- a/docs/sources/investigate/_index.md
+++ b/docs/sources/investigate/_index.md
@@ -4,6 +4,27 @@ canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploratio
 keywords:
   - Traces Drilldown
   - Investigate
+refs:
+  choose-span-data:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/traces/investigate/choose-span-data/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/visualizations/explore/simplified-exploration/traces/investigate/choose-span-data/
+  choose-red-metric:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/traces/investigate/choose-red-metric/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/visualizations/explore/simplified-exploration/traces/investigate/choose-red-metric/
+  analyze-tracing-data:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/traces/investigate/analyze-tracing-data/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/visualizations/explore/simplified-exploration/traces/investigate/analyze-tracing-data/
+  add-filters:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/traces/investigate/add-filters/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/visualizations/explore/simplified-exploration/traces/investigate/add-filters/
 title: Investigate trends and spikes
 menuTitle: Investigate trends and spikes
 weight: 600
@@ -15,10 +36,10 @@ Grafana Traces Drilldown provides powerful tools that help you identify and anal
 
 Using these steps, you can use the tracing data to investigate issues.
 
-1. [Select **Root spans** or **All spans**](choose-span-data) to look at either the first span in a trace (the root span) or all span data.
-1. [Choose the metric](choose-red-metric) you want to use: rates, errors, or duration.
-1. [Analyze data](analyze-tracing-data) using **Breakdown**, **Comparison**, **Service structure** (available for rate), **Root cause errors** (available for errors), **Root cause latency** (available for duration), and **Traces** tabs.
-1. [Add filters](add-filters) to refine the view of your data.
+1. [Select **Root spans** or **All spans**](ref:choose-span-data) to look at either the first span in a trace (the root span) or all span data.
+1. [Choose the metric](ref:choose-red-metric) you want to use: rates, errors, or duration.
+1. [Analyze data](ref:analyze-tracing-data) using **Breakdown**, **Comparison**, **Service structure** (available for rate), **Root cause errors** (available for errors), **Root cause latency** (available for duration), and **Traces** tabs.
+1. [Add filters](ref:add-filters) to refine the view of your data.
 
 You can use these steps in any order and move between them as many times as needed.
 Depending on what you find, you may start with root spans, delve into error data, and then select **All spans** to access all of the tracing data.

--- a/docs/sources/investigate/add-filters.md
+++ b/docs/sources/investigate/add-filters.md
@@ -1,9 +1,15 @@
 ---
 description: Investigate trends and spikes to identify issues.
-canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/traces/investigate/
+canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/traces/investigate/add-filters/
 keywords:
   - Traces Drilldown
   - Investigate
+refs:
+  use-dashboards:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/dashboards/use-dashboards/#set-dashboard-time-range
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/visualizations/dashboards/use-dashboards/
 title: Add filters
 menuTitle: Add filters
 weight: 600
@@ -14,7 +20,7 @@ weight: 600
 Use filters to refine your investigation.
 
 Filters are available on the **Breakdown** and **Comparison** views.
-Refer to [Analyze tracing data](analyze-tracing-data) for how to use these views.
+Refer to [Analyze tracing data](../analyze-tracing-data) for how to use these views.
 
 ## Add filters
 
@@ -65,5 +71,5 @@ By default, this time range can be any 24-hour period in your configured trace d
 The default retention period is 30 days.
 Your configuration may vary from these values.
 
-For more information about the time range picker, refer to [Use dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/use-dashboards/#set-dashboard-time-range).
+For more information about the time range picker, refer to [Use dashboards](ref:use-dashboards).
 

--- a/docs/sources/investigate/analyze-tracing-data.md
+++ b/docs/sources/investigate/analyze-tracing-data.md
@@ -1,6 +1,6 @@
 ---
 description: Analyze tracing data using comparison, root cause analysis, and traces view to investigate trends and spikes.
-canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/traces/investigate/
+canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/traces/intigate/analyze-tracing-data/
 keywords:
   - Traces Drilldown
   - Analyze

--- a/docs/sources/investigate/choose-red-metric.md
+++ b/docs/sources/investigate/choose-red-metric.md
@@ -1,6 +1,6 @@
 ---
 description: Choose a rate, error, or duration metric for your investigation.
-canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/traces/investigate/
+canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/traces/investigate/choose-red-metric/
 keywords:
   - Traces Drilldown
   - Investigate
@@ -21,7 +21,7 @@ In this context, RED metrics mean:
 When you select a RED metric, the tabs underneath the metrics selection changes match the context.
 For example, selecting **Duration** displays **Root cause latency** and **Slow traces tabs**.
 Choosing **Errors** changes the tabs to **Root cause errors** and **Errored traces**. Rate provides **Service structure**, and **Traces** tabs.
-These tabs are used when you [analyze tracing data](./analyze-tracing-data).
+These tabs are used when you [analyze tracing data](../analyze-tracing-data).
 
 {{< video-embed src="/media/docs/explore-traces/traces-drilldown-select-metric-type.mp4" >}}
 

--- a/docs/sources/investigate/choose-span-data.md
+++ b/docs/sources/investigate/choose-span-data.md
@@ -1,6 +1,6 @@
 ---
 description: Use root span or full span data for your investigation.
-canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/traces/investigate/
+canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/traces/investigate/choose-span-data/
 keywords:
   - Traces Drilldown
   - Investigate

--- a/docs/sources/investigate/view-exemplars.md
+++ b/docs/sources/investigate/view-exemplars.md
@@ -1,9 +1,15 @@
 ---
 description: View exemplars to explore the links between metrics and spans.
-canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/traces/investigate/
+canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/traces/investigate/view-exemplars/
 keywords:
   - Traces Drilldown
   - Investigate
+refs:
+  intro-exemplars:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/fundamentals/exemplars/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA_VERSION>/fundamentals/exemplars/
 title: View exemplars
 menuTitle: View exemplars
 weight: 600
@@ -16,14 +22,14 @@ Exemplars provide a link between the metrics and the traces themselves.
 An exemplar is a specific trace representative of measurement taken in a given time interval. While metrics excel at giving you an aggregated view of your system, traces give you a fine-grained view of a single request; exemplars are a way to link the two.
 
 Use exemplars to help isolate problems within your data distribution by pinpointing query traces exhibiting high latency within a time interval.
-Once you localize the latency problem to a few exemplar traces, you can combine it with additional system based information or location properties to perform a root cause analysis faster, leading to quick resolutions to performance issues.
+After you localize the latency problem to a few exemplar traces, you can combine it with additional system based information or location properties to perform a root cause analysis faster, leading to quick resolutions to performance issues.
 
-For more information, refer to [Introduction to exemplars](https://grafana.com/docs/grafana/<GRAFANA+VERSION>/fundamentals/exemplars/).
+For more information, refer to [Introduction to exemplars](ref:intro-exemplars).
 
 ## Exemplars in Traces Drilldown
 
 In Traces Drilldown, exemplar data is represented by a small diamond next to the bar graphs.
-You can view the exemplar information by hovering the cursor over over the small diamond.
+You can view the exemplar information by hovering the cursor over the small diamond.
 
 ![A small diamond next to the bar graph indicates that exemplar data is available.](/media/docs/explore-traces/explore-traces-exemplar-v2.4.png)
 

--- a/docs/sources/ui-reference/_index.md
+++ b/docs/sources/ui-reference/_index.md
@@ -1,9 +1,15 @@
 ---
 description: Learn about the user interface for Traces Drilldown.
-canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/traces/investigate/
+canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploration/traces/ui-reference/
 keywords:
   - Traces Drilldown
   - UI reference
+refs:
+  use-dashboards-time:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/dashboards/use-dashboards/#set-dashboard-time-range
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/visualizations/dashboards/use-dashboards/#set-dashboard-time-range
 title: Traces Drilldown UI reference
 menuTitle: UI reference
 weight: 600
@@ -13,7 +19,7 @@ weight: 600
 
 Grafana Traces Drilldown helps you focus your tracing data exploration.
 Some of the screen sections are context sensitive and change depending upon the metric you've chosen.
-Refer to [Analyze tracing data](../analyze-tracing-data) for more information.
+Refer to [Analyze tracing data](../investigate/analyze-tracing-data) for more information.
 
 ![Numbered sections of the Traces Drilldown app](/media/docs/explore-traces/traces-drilldown-screen-ui.png)
 


### PR DESCRIPTION
Fixes a set of broken links and issues with relative links both linking within the docs and to external pages. 

Fixes https://github.com/grafana/traces-drilldown/issues/444