### PR TITLE
Style error panels according to metric

### DIFF
--- a/src/components/Explore/TracesByService/MiniREDPanel.tsx
+++ b/src/components/Explore/TracesByService/MiniREDPanel.tsx
@@ -114,7 +114,7 @@ export class MiniREDPanel extends SceneObjectBase<MiniREDPanelState> {
   }
 
   private getRateOrErrorPanel(metric: MetricFunction) {
-    const panel = barsPanelConfig().setHoverHeader(true).setDisplayMode('transparent');
+    const panel = barsPanelConfig(metric).setHoverHeader(true).setDisplayMode('transparent');
     if (metric === 'rate') {
       panel.setCustomFieldConfig('axisLabel', 'span/s');
     } else if (metric === 'errors') {

--- a/src/components/Explore/TracesByService/REDPanel.tsx
+++ b/src/components/Explore/TracesByService/REDPanel.tsx
@@ -204,7 +204,7 @@ export class REDPanel extends SceneObjectBase<RateMetricsPanelState> {
   }
 
   private getRateOrErrorVizPanel(type: MetricFunction) {
-    const panel = barsPanelConfig().setHoverHeader(true).setDisplayMode('transparent');
+    const panel = barsPanelConfig(type).setHoverHeader(true).setDisplayMode('transparent');
     if (type === 'rate') {
       panel.setCustomFieldConfig('axisLabel', 'span/s');
     } else if (type === 'errors') {

--- a/src/components/Explore/layouts/attributeBreakdown.ts
+++ b/src/components/Explore/layouts/attributeBreakdown.ts
@@ -133,7 +133,7 @@ export function getLayoutChild(
       })
     );
 
-    const panel = (metric === 'duration' ? linesPanelConfig().setUnit('s') : barsPanelConfig())
+    const panel = (metric === 'duration' ? linesPanelConfig().setUnit('s') : barsPanelConfig(metric))
       .setTitle(getTitle(frame, variable.getValueText()))
       .setMenu(new PanelMenu({ query, labelValue: getLabelValue(frame) }))
       .setData(dataNode);

--- a/src/components/Explore/panels/barsPanel.ts
+++ b/src/components/Explore/panels/barsPanel.ts
@@ -1,8 +1,11 @@
 import { PanelBuilders } from '@grafana/scenes';
 import { DrawStyle, StackingMode, TooltipDisplayMode } from '@grafana/ui';
+import { MetricFunction } from 'utils/shared';
 
-export const barsPanelConfig = () => {
-  return PanelBuilders.timeseries()
+export const barsPanelConfig = (metric: MetricFunction) => {
+  const hasErrors = metric === 'errors' || false;
+  
+  const builder = PanelBuilders.timeseries()
     .setOption('legend', { showLegend: false })
     .setCustomFieldConfig('drawStyle', DrawStyle.Bars)
     .setCustomFieldConfig('stacking', { mode: StackingMode.Normal })
@@ -11,18 +14,28 @@ export const barsPanelConfig = () => {
     .setCustomFieldConfig('pointSize', 0)
     .setCustomFieldConfig('axisLabel', 'Rate')
     .setOverrides((overrides) => {
-      overrides.matchFieldsWithNameByRegex('(^error$|.*status="error".*)').overrideColor({
-        mode: 'fixed',
-        fixedColor: 'semi-dark-red',
-      });
-      overrides.matchFieldsWithNameByRegex('(^unset$|.*status="unset".*)').overrideColor({
-        mode: 'fixed',
-        fixedColor: 'green',
-      });
-      overrides.matchFieldsWithNameByRegex('(^ok$|.*status="ok".*)').overrideColor({
-        mode: 'fixed',
-        fixedColor: 'dark-green',
-      });
+      if (hasErrors) {
+        overrides.matchFieldsWithNameByRegex('.*').overrideColor({
+          mode: 'fixed',
+          fixedColor: 'semi-dark-red',
+        });
+      } else {
+        // Regular styling based on status
+        overrides.matchFieldsWithNameByRegex('(^error$|.*status="error".*)').overrideColor({
+          mode: 'fixed',
+          fixedColor: 'semi-dark-red',
+        });
+        overrides.matchFieldsWithNameByRegex('(^unset$|.*status="unset".*)').overrideColor({
+          mode: 'fixed',
+          fixedColor: 'green',
+        });
+        overrides.matchFieldsWithNameByRegex('(^ok$|.*status="ok".*)').overrideColor({
+          mode: 'fixed',
+          fixedColor: 'dark-green',
+        });
+      }
     })
     .setOption('tooltip', { mode: TooltipDisplayMode.Multi });
+
+  return builder;
 };

--- a/src/components/Explore/panels/barsPanel.ts
+++ b/src/components/Explore/panels/barsPanel.ts
@@ -3,7 +3,7 @@ import { DrawStyle, StackingMode, TooltipDisplayMode } from '@grafana/ui';
 import { MetricFunction } from 'utils/shared';
 
 export const barsPanelConfig = (metric: MetricFunction) => {
-  const hasErrors = metric === 'errors' || false;
+  const isErrorsMetric = metric === 'errors' || false;
   
   const builder = PanelBuilders.timeseries()
     .setOption('legend', { showLegend: false })
@@ -14,7 +14,7 @@ export const barsPanelConfig = (metric: MetricFunction) => {
     .setCustomFieldConfig('pointSize', 0)
     .setCustomFieldConfig('axisLabel', 'Rate')
     .setOverrides((overrides) => {
-      if (hasErrors) {
+      if (isErrorsMetric) {
         overrides.matchFieldsWithNameByRegex('.*').overrideColor({
           mode: 'fixed',
           fixedColor: 'semi-dark-red',

--- a/src/components/Explore/panels/barsPanel.ts
+++ b/src/components/Explore/panels/barsPanel.ts
@@ -20,11 +20,6 @@ export const barsPanelConfig = (metric: MetricFunction) => {
           fixedColor: 'semi-dark-red',
         });
       } else {
-        // Regular styling based on status
-        overrides.matchFieldsWithNameByRegex('(^error$|.*status="error".*)').overrideColor({
-          mode: 'fixed',
-          fixedColor: 'semi-dark-red',
-        });
         overrides.matchFieldsWithNameByRegex('(^unset$|.*status="unset".*)').overrideColor({
           mode: 'fixed',
           fixedColor: 'green',

--- a/src/components/Explore/panels/barsPanel.ts
+++ b/src/components/Explore/panels/barsPanel.ts
@@ -14,17 +14,10 @@ export const barsPanelConfig = (metric: MetricFunction) => {
     .setCustomFieldConfig('pointSize', 0)
     .setCustomFieldConfig('axisLabel', 'Rate')
     .setOverrides((overrides) => {
-      if (isErrorsMetric) {
-        overrides.matchFieldsWithNameByRegex('.*').overrideColor({
-          mode: 'fixed',
-          fixedColor: 'semi-dark-red',
-        });
-      } else {
-        overrides.matchFieldsWithNameByRegex('.*').overrideColor({
-          mode: 'fixed',
-          fixedColor: 'green',
-        });
-      }
+      overrides.matchFieldsWithNameByRegex('.*').overrideColor({
+        mode: 'fixed',
+        fixedColor: isErrorsMetric ? 'semi-dark-red' : 'green',
+      });
     })
     .setOption('tooltip', { mode: TooltipDisplayMode.Multi });
 

--- a/src/components/Explore/panels/barsPanel.ts
+++ b/src/components/Explore/panels/barsPanel.ts
@@ -20,13 +20,9 @@ export const barsPanelConfig = (metric: MetricFunction) => {
           fixedColor: 'semi-dark-red',
         });
       } else {
-        overrides.matchFieldsWithNameByRegex('(^unset$|.*status="unset".*)').overrideColor({
+        overrides.matchFieldsWithNameByRegex('.*').overrideColor({
           mode: 'fixed',
           fixedColor: 'green',
-        });
-        overrides.matchFieldsWithNameByRegex('(^ok$|.*status="ok".*)').overrideColor({
-          mode: 'fixed',
-          fixedColor: 'dark-green',
         });
       }
     })

--- a/src/components/Explore/queries/generateMetricsQuery.test.ts
+++ b/src/components/Explore/queries/generateMetricsQuery.test.ts
@@ -73,7 +73,7 @@ describe('metricByWithStatus', () => {
     const result = metricByWithStatus('rate');
     expect(result).toEqual({
       refId: 'A',
-      query: '{${primarySignal} && ${filters} && status!=error} | rate() by(status)',
+      query: '{${primarySignal} && ${filters} && status!=error} | rate() ',
       queryType: 'traceql',
       tableType: 'spans',
       limit: 100,
@@ -86,7 +86,7 @@ describe('metricByWithStatus', () => {
     const result = metricByWithStatus('errors');
     expect(result).toEqual({
       refId: 'A',
-      query: '{${primarySignal} && ${filters} && status=error} | rate() by(status)',
+      query: '{${primarySignal} && ${filters} && status=error} | rate() ',
       queryType: 'traceql',
       tableType: 'spans',
       limit: 100,
@@ -112,7 +112,7 @@ describe('metricByWithStatus', () => {
     const result = metricByWithStatus('rate', 'serviceName');
     expect(result).toEqual({
       refId: 'A',
-      query: '{${primarySignal} && ${filters} && status!=error && serviceName != nil} | rate() by(serviceName, status)',
+      query: '{${primarySignal} && ${filters} && status!=error && serviceName != nil} | rate() by(serviceName)',
       queryType: 'traceql',
       tableType: 'spans',
       limit: 100,

--- a/src/components/Explore/queries/generateMetricsQuery.ts
+++ b/src/components/Explore/queries/generateMetricsQuery.ts
@@ -54,7 +54,7 @@ export function generateMetricsQuery({ metric, groupByKey, extraFilters, groupBy
 export function metricByWithStatus(metric: MetricFunction, tagKey?: string) {
   return {
     refId: 'A',
-    query: generateMetricsQuery({ metric, groupByKey: tagKey, groupByStatus: true }),
+    query: generateMetricsQuery({ metric, groupByKey: tagKey, groupByStatus: false }),
     queryType: 'traceql',
     tableType: 'spans',
     limit: 100,

--- a/src/components/Explore/queries/queries.test.ts
+++ b/src/components/Explore/queries/queries.test.ts
@@ -54,7 +54,7 @@ describe('metricByWithStatus', () => {
     expect(query).toEqual({
       filters: [],
       limit: 100,
-      query: '{${primarySignal} && ${filters} && status=error} | rate() by(status)',
+      query: '{${primarySignal} && ${filters} && status=error} | rate() ',
       queryType: 'traceql',
       refId: 'A',
       spss: 10,
@@ -67,7 +67,7 @@ describe('metricByWithStatus', () => {
     expect(query).toEqual({
       filters: [],
       limit: 100,
-      query: '{${primarySignal} && ${filters} && status=error && service != nil} | rate() by(service, status)',
+      query: '{${primarySignal} && ${filters} && status=error && service != nil} | rate() by(service)',
       queryType: 'traceql',
       refId: 'A',
       spss: 10,


### PR DESCRIPTION
Previously we were only using the label to style the graphs in the barsPanel. This PR adds a change that checks the metric to determine how we style the graphs.