### PR TITLE
Work around `ref` URIs bug

### DIFF
--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -4,12 +4,6 @@ canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploratio
 keywords:
   - Traces Drilldown
   - Get started
-refs:
-  drilldown-apps:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/visualizations/simplified-exploration/
 title: Get started with Traces Drilldown
 menuTitle: Get started
 weight: 300
@@ -24,7 +18,7 @@ Investigate using primary signals, RED metrics, filters, and structural or trace
 To learn more, refer to [Concepts](../concepts/).
 
 {{< admonition type="note" >}}
-Expand your observability journey and learn about [the Drilldown apps suite](ref:drilldown-apps).
+Expand your observability journey and learn about [the Drilldown apps suite](../../).
 {{< /admonition >}}
 
 {{< youtube id="a3uB1C2oHA4" >}}
@@ -80,7 +74,7 @@ You can see here that 99.34% of the time, the span name was equal to `HTTP GET /
 ### Inspect the problem
 
 To dig deeper, select **Inspect** to focus in on the problem.
-It's easy to spot the problem: the tall, red bar indicates that the problems are happening with  `HTTP GET /api/datasources/proxy/uid/:uid/*`.
+It's easy to spot the problem: the tall, red bar indicates that the problems are happening with `HTTP GET /api/datasources/proxy/uid/:uid/*`.
 Next, use **Add to filters** to focus just on the erroring API call.
 
 ![Add to filters to focus on the API call](../images/explore-traces-errors-add-filters-flow.png)

--- a/docs/sources/investigate/_index.md
+++ b/docs/sources/investigate/_index.md
@@ -4,27 +4,6 @@ canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploratio
 keywords:
   - Traces Drilldown
   - Investigate
-refs:
-  choose-span-data:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/traces/investigate/choose-span-data/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/visualizations/explore/simplified-exploration/traces/investigate/choose-span-data/
-  choose-red-metric:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/traces/investigate/choose-red-metric/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/visualizations/explore/simplified-exploration/traces/investigate/choose-red-metric/
-  analyze-tracing-data:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/traces/investigate/analyze-tracing-data/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/visualizations/explore/simplified-exploration/traces/investigate/analyze-tracing-data/
-  add-filters:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/traces/investigate/add-filters/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/visualizations/explore/simplified-exploration/traces/investigate/add-filters/
 title: Investigate trends and spikes
 menuTitle: Investigate trends and spikes
 weight: 600
@@ -36,10 +15,10 @@ Grafana Traces Drilldown provides powerful tools that help you identify and anal
 
 Using these steps, you can use the tracing data to investigate issues.
 
-1. [Select **Root spans** or **All spans**](ref:choose-span-data) to look at either the first span in a trace (the root span) or all span data.
-1. [Choose the metric](ref:choose-red-metric) you want to use: rates, errors, or duration.
-1. [Analyze data](ref:analyze-tracing-data) using **Breakdown**, **Comparison**, **Service structure** (available for rate), **Root cause errors** (available for errors), **Root cause latency** (available for duration), and **Traces** tabs.
-1. [Add filters](ref:add-filters) to refine the view of your data.
+1. [Select **Root spans** or **All spans**](./choose-span-data/) to look at either the first span in a trace (the root span) or all span data.
+1. [Choose the metric](./choose-red-metric/) you want to use: rates, errors, or duration.
+1. [Analyze data](./analyze-tracing-data/) using **Breakdown**, **Comparison**, **Service structure** (available for rate), **Root cause errors** (available for errors), **Root cause latency** (available for duration), and **Traces** tabs.
+1. [Add filters](./add-filters/) to refine the view of your data.
 
 You can use these steps in any order and move between them as many times as needed.
 Depending on what you find, you may start with root spans, delve into error data, and then select **All spans** to access all of the tracing data.

--- a/docs/sources/investigate/view-exemplars.md
+++ b/docs/sources/investigate/view-exemplars.md
@@ -4,12 +4,6 @@ canonical: https://grafana.com/docs/grafana/latest/explore/simplified-exploratio
 keywords:
   - Traces Drilldown
   - Investigate
-refs:
-  intro-exemplars:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/fundamentals/exemplars/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA_VERSION>/fundamentals/exemplars/
 title: View exemplars
 menuTitle: View exemplars
 weight: 600
@@ -24,7 +18,7 @@ An exemplar is a specific trace representative of measurement taken in a given t
 Use exemplars to help isolate problems within your data distribution by pinpointing query traces exhibiting high latency within a time interval.
 After you localize the latency problem to a few exemplar traces, you can combine it with additional system based information or location properties to perform a root cause analysis faster, leading to quick resolutions to performance issues.
 
-For more information, refer to [Introduction to exemplars](ref:intro-exemplars).
+For more information, refer to [Introduction to exemplars](/docs/grafana/<GRAFANA_VERSION>/fundamentals/exemplars/).
 
 ## Exemplars in Traces Drilldown
 


### PR DESCRIPTION
All ref URIs are resolving to the Grafana Cloud destination.

I think it's a bug arising from the interaction of `ref` URIs and automatic mount links. Will investigate further tomorrow.