### PR TITLE
chore: isolate types imports for exposed component

### DIFF
--- a/src/components/Explore/TracesByService/Tabs/TabsBarScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/TabsBarScene.tsx
@@ -11,6 +11,7 @@ import { buildBreakdownScene } from './Breakdown/BreakdownScene';
 import { MetricFunction } from 'utils/shared';
 import { buildComparisonScene } from './Comparison/ComparisonScene';
 import { useMount } from 'react-use';
+import { ActionViewType } from 'exposedComponents/types';
 
 interface ActionViewDefinition {
   displayName: (metric: MetricFunction) => string;
@@ -18,7 +19,6 @@ interface ActionViewDefinition {
   getScene: (metric: MetricFunction) => SceneObject;
 }
 
-export type ActionViewType = 'traceList' | 'breakdown' | 'structure' | 'comparison';
 export const actionViewsDefinitions: ActionViewDefinition[] = [
   { displayName: breakdownDisplayName, value: 'breakdown', getScene: buildBreakdownScene },
   { displayName: structureDisplayName, value: 'structure', getScene: buildStructureScene },

--- a/src/exposedComponents/types.ts
+++ b/src/exposedComponents/types.ts
@@ -1,6 +1,5 @@
 import { SceneTimeRangeState } from '@grafana/scenes';
 import { AdHocVariableFilter, TimeRange } from '@grafana/data';
-import { ActionViewType } from 'components/Explore/TracesByService/Tabs/TabsBarScene';
 
 export type TempoMatcher = {
   name: string;
@@ -8,6 +7,7 @@ export type TempoMatcher = {
   operator: '=' | '!=' | '>' | '<' | '=~' | '!~';
 };
 
+export type ActionViewType = 'traceList' | 'breakdown' | 'structure' | 'comparison';
 export interface OpenInExploreTracesButtonProps {
   datasourceUid?: string;
   matchers: TempoMatcher[];


### PR DESCRIPTION
since bundle-types action is failed we need to isolate types for exposed components