### PR TITLE
chore(ci): Stop using secrets

### DIFF
--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -1,0 +1,25 @@
+name: Bundle Stats
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: grafana/plugin-actions/bundle-size@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
 
-env:
-  BUNDLEWATCH_GITHUB_TOKEN: ${{secrets.BUNDLEWATCH_GITHUB_TOKEN}}
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,21 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Get secrets
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b
+        with:
+          vault_instance: ops
+          common_secrets: |
+            token=plugins/sign-plugin-access-policy-token:token
+          export_env: false
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - uses: grafana/plugin-actions/build-plugin@main
         id: build-release
         with:
-          policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
+          policy_token: ${{ fromJSON(steps.get-secrets.outputs.secrets).token }}
       - name: Get plugin metadata
         id: metadata
         run: |

--- a/.github/workflows/update-main.yml
+++ b/.github/workflows/update-main.yml
@@ -17,13 +17,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Get secrets
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b
+        with:
+          vault_instance: ops
+          common_secrets: |
+            token=plugins/sign-plugin-access-policy-token:token
+          export_env: false
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Call shared build action
         uses: ./.github/actions/build
         with:
-          policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
+          policy_token: ${{ fromJSON(steps.get-secrets.outputs.secrets).token }}
   upload:
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
- Use Vault for getting signing token policy
- Use a separate action for bundle stats and remove unused secret 