### PR TITLE
Type string booleans as booleans unless user has put them in quotes

### DIFF
--- a/src/utils/filters-renderer.test.ts
+++ b/src/utils/filters-renderer.test.ts
@@ -60,6 +60,24 @@ describe('filters-renderer', () => {
       expect(renderTraceQLLabelFilters(filters)).toBe('service.name=~"test"&&duration!=100');
     });
 
+    describe('boolean value handling', () => {
+      it('should not add quotes to true/false values', () => {
+        const filters: AdHocVariableFilter[] = [
+          { key: 'span.debug', operator: '=', value: 'true' },
+          { key: 'span.error', operator: '=', value: 'false' },
+        ];
+        expect(renderTraceQLLabelFilters(filters)).toBe('span.debug=true&&span.error=false');
+      });
+
+      it('should add quotes to string values that look like booleans', () => {
+        const filters: AdHocVariableFilter[] = [
+          { key: 'service.name', operator: '=', value: '"true"' },
+          { key: 'service.type', operator: '=', value: '"false"' },
+        ];
+        expect(renderTraceQLLabelFilters(filters)).toBe('service.name="true"&&service.type="false"');
+      });
+    });
+
     describe('number handling', () => {
       it('should handle integer values without quotes for duration', () => {
         const filters: AdHocVariableFilter[] = [

--- a/src/utils/filters-renderer.ts
+++ b/src/utils/filters-renderer.ts
@@ -13,7 +13,8 @@ export function renderTraceQLLabelFilters(filters: AdHocVariableFilter[]) {
 function renderFilter(filter: AdHocVariableFilter) {
   let val = filter.value;
   if (['span.messaging.destination.partition.id', 'span.network.protocol.version'].includes(filter.key) || 
-    (!isNumber(val) && !['status', 'kind', 'span:status', 'span:kind', 'duration', 'span:duration', 'trace:duration', 'event:timeSinceStart'].includes(filter.key))
+    (!isNumber(val) && !['status', 'kind', 'span:status', 'span:kind', 'duration', 'span:duration', 'trace:duration', 'event:timeSinceStart'].includes(filter.key)
+    && !['true', 'false'].includes(val))
   ) {
     // Add quotes if it's coming from the filter input and it's not already quoted.
     // Adding a filter from a time series graph already has quotes. This should be handled better.


### PR DESCRIPTION
Types string booleans as booleans in the filters renderer and in queries unless user has put them in quotes.

![Screenshot 2025-06-17 at 11 17 48](https://github.com/user-attachments/assets/5b50fe2e-44b0-4184-bd61-b1351403696d)
