### PR TITLE
Add namespace to variables

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -57,6 +57,7 @@
     "localblocks",
     "grafanacloud",
     "OLJCESPC",
-    "contextualised"
+    "contextualised",
+    "Cgrafana"  
   ]
 }

--- a/src/components/Explore/TracesByService/TracesByServiceScene.test.tsx
+++ b/src/components/Explore/TracesByService/TracesByServiceScene.test.tsx
@@ -1,5 +1,5 @@
 import { buildQuery } from './TracesByServiceScene';
-import { ComparisonSelection } from '../../../utils/shared';
+import { ComparisonSelection, VAR_FILTERS, VAR_LATENCY_THRESHOLD, VAR_PRIMARY_SIGNAL } from '../../../utils/shared';
 
 describe('TracesByServiceScene', () => {
   describe('buildQuery', () => {
@@ -7,7 +7,7 @@ describe('TracesByServiceScene', () => {
       const query = buildQuery('rate', '');
       expect(query).toEqual({
         refId: 'A',
-        query: '{${primarySignal} && ${filters}}',
+        query: `{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\}}`,
         queryType: 'traceql',
         tableType: 'spans',
         limit: 200,
@@ -18,12 +18,12 @@ describe('TracesByServiceScene', () => {
 
     it('should add error status for error type', () => {
       const query = buildQuery('errors', '');
-      expect(query.query).toBe('{${primarySignal} && ${filters} && status = error}');
+      expect(query.query).toBe(`{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\} && status = error}`);
     });
 
     it('should add latency threshold for duration type with no selection', () => {
       const query = buildQuery('duration', '');
-      expect(query.query).toBe('{${primarySignal} && ${filters}&& duration > ${latencyThreshold}}');
+      expect(query.query).toBe(`{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\}&& duration > \${${VAR_LATENCY_THRESHOLD}\}}`);
     });
 
     it('should handle duration selection range', () => {
@@ -35,7 +35,7 @@ describe('TracesByServiceScene', () => {
         },
       };
       const query = buildQuery('duration', '', selection);
-      expect(query.query).toBe('{${primarySignal} && ${filters}&& duration >= 100ms && duration <= 500ms}');
+      expect(query.query).toBe(`{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\}&& duration >= 100ms && duration <= 500ms}`);
     });
 
     it('should handle duration selection with only from', () => {
@@ -47,7 +47,7 @@ describe('TracesByServiceScene', () => {
         },
       };
       const query = buildQuery('duration', '', selection);
-      expect(query.query).toBe('{${primarySignal} && ${filters}&& duration >= 100ms}');
+      expect(query.query).toBe(`{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\}&& duration >= 100ms}`);
     });
 
     it('should handle duration selection with only to', () => {
@@ -59,12 +59,12 @@ describe('TracesByServiceScene', () => {
         },
       };
       const query = buildQuery('duration', '', selection);
-      expect(query.query).toBe('{${primarySignal} && ${filters}&& duration <= 500ms}');
+      expect(query.query).toBe(`{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\}&& duration <= 500ms}`);
     });
 
     it('should add select columns when provided', () => {
       const query = buildQuery('rate', 'duration,service.name');
-      expect(query.query).toBe('{${primarySignal} && ${filters}} | select(duration,service.name)');
+      expect(query.query).toBe(`{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\}} | select(duration,service.name)`);
     });
   });
 });

--- a/src/components/Explore/queries/generateMetricsQuery.test.ts
+++ b/src/components/Explore/queries/generateMetricsQuery.test.ts
@@ -1,20 +1,20 @@
 import { generateMetricsQuery, metricByWithStatus } from './generateMetricsQuery';
-import { ALL } from '../../../utils/shared';
+import { ALL, VAR_FILTERS, VAR_PRIMARY_SIGNAL } from '../../../utils/shared';
 
 describe('generateMetricsQuery', () => {
   it('should generate a basic rate query', () => {
     const result = generateMetricsQuery({ metric: 'rate' });
-    expect(result).toEqual('{${primarySignal} && ${filters} && status!=error} | rate() ');
+    expect(result).toEqual(`{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\} && status!=error} | rate() `);
   });
 
   it('should generate an errors query', () => {
     const result = generateMetricsQuery({ metric: 'errors' });
-    expect(result).toEqual('{${primarySignal} && ${filters} && status=error} | rate() ');
+    expect(result).toEqual(`{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\} && status=error} | rate() `);
   });
 
   it('should generate a duration query', () => {
     const result = generateMetricsQuery({ metric: 'duration' });
-    expect(result).toEqual('{${primarySignal} && ${filters}} | quantile_over_time(duration, 0.9) ');
+    expect(result).toEqual(`{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\}} | quantile_over_time(duration, 0.9) `);
   });
 
   it('should add extra filters if provided', () => {
@@ -22,7 +22,7 @@ describe('generateMetricsQuery', () => {
       metric: 'rate', 
       extraFilters: 'name="test"' 
     });
-    expect(result).toEqual('{${primarySignal} && ${filters} && status!=error && name="test"} | rate() ');
+    expect(result).toEqual(`{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\} && status!=error && name="test"} | rate() `);
   });
 
   it('should handle groupByKey when provided', () => {
@@ -30,7 +30,7 @@ describe('generateMetricsQuery', () => {
       metric: 'rate', 
       groupByKey: 'serviceName' 
     });
-    expect(result).toEqual('{${primarySignal} && ${filters} && status!=error && serviceName != nil} | rate() by(serviceName)');
+    expect(result).toEqual(`{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\} && status!=error && serviceName != nil} | rate() by(serviceName)`);
   });
 
   it('should not add groupByKey filter when groupByKey is ALL', () => {
@@ -38,7 +38,7 @@ describe('generateMetricsQuery', () => {
       metric: 'rate', 
       groupByKey: ALL 
     });
-    expect(result).toEqual('{${primarySignal} && ${filters} && status!=error} | rate() ');
+    expect(result).toEqual(`{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\} && status!=error} | rate() `);
   });
 
   it('should add status to groupBy when groupByStatus is true', () => {
@@ -46,7 +46,7 @@ describe('generateMetricsQuery', () => {
       metric: 'rate', 
       groupByStatus: true 
     });
-    expect(result).toEqual('{${primarySignal} && ${filters} && status!=error} | rate() by(status)');
+    expect(result).toEqual(`{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\} && status!=error} | rate() by(status)`);
   });
 
   it('should add both groupByKey and status to groupBy when both are provided', () => {
@@ -55,7 +55,7 @@ describe('generateMetricsQuery', () => {
       groupByKey: 'serviceName',
       groupByStatus: true 
     });
-    expect(result).toEqual('{${primarySignal} && ${filters} && status!=error && serviceName != nil} | rate() by(serviceName, status)');
+    expect(result).toEqual(`{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\} && status!=error && serviceName != nil} | rate() by(serviceName, status)`);
   });
 
   it('should not add status to groupBy for duration metric even if groupByStatus is true', () => {
@@ -64,7 +64,7 @@ describe('generateMetricsQuery', () => {
       groupByKey: 'serviceName',
       groupByStatus: true 
     });
-    expect(result).toEqual('{${primarySignal} && ${filters} && serviceName != nil} | quantile_over_time(duration, 0.9) by(serviceName)');
+    expect(result).toEqual(`{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\} && serviceName != nil} | quantile_over_time(duration, 0.9) by(serviceName)`);
   });
 });
 
@@ -73,7 +73,7 @@ describe('metricByWithStatus', () => {
     const result = metricByWithStatus('rate');
     expect(result).toEqual({
       refId: 'A',
-      query: '{${primarySignal} && ${filters} && status!=error} | rate() ',
+      query: `{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\} && status!=error} | rate() `,
       queryType: 'traceql',
       tableType: 'spans',
       limit: 100,
@@ -86,7 +86,7 @@ describe('metricByWithStatus', () => {
     const result = metricByWithStatus('errors');
     expect(result).toEqual({
       refId: 'A',
-      query: '{${primarySignal} && ${filters} && status=error} | rate() ',
+      query: `{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\} && status=error} | rate() `,
       queryType: 'traceql',
       tableType: 'spans',
       limit: 100,
@@ -99,7 +99,7 @@ describe('metricByWithStatus', () => {
     const result = metricByWithStatus('duration');
     expect(result).toEqual({
       refId: 'A',
-      query: '{${primarySignal} && ${filters}} | quantile_over_time(duration, 0.9) ',
+      query: `{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\}} | quantile_over_time(duration, 0.9) `,
       queryType: 'traceql',
       tableType: 'spans',
       limit: 100,
@@ -112,7 +112,7 @@ describe('metricByWithStatus', () => {
     const result = metricByWithStatus('rate', 'serviceName');
     expect(result).toEqual({
       refId: 'A',
-      query: '{${primarySignal} && ${filters} && status!=error && serviceName != nil} | rate() by(serviceName)',
+      query: `{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\} && status!=error && serviceName != nil} | rate() by(serviceName)`,
       queryType: 'traceql',
       tableType: 'spans',
       limit: 100,

--- a/src/components/Explore/queries/queries.test.ts
+++ b/src/components/Explore/queries/queries.test.ts
@@ -1,6 +1,7 @@
 import { comparisonQuery } from './comparisonQuery';
 import { buildHistogramQuery } from './histogram';
 import { metricByWithStatus } from './generateMetricsQuery';
+import { VAR_FILTERS, VAR_PRIMARY_SIGNAL } from 'utils/shared';
 
 describe('comparisonQuery', () => {
   it('should return correct query for no selection', () => {
@@ -39,7 +40,7 @@ describe('buildHistogramQuery', () => {
     expect(query).toEqual({
       filters: [],
       limit: 1000,
-      query: '{${primarySignal} && ${filters}} | histogram_over_time(duration)',
+      query: `{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}\}} | histogram_over_time(duration)`,
       queryType: 'traceql',
       refId: 'A',
       spss: 10,
@@ -54,7 +55,7 @@ describe('metricByWithStatus', () => {
     expect(query).toEqual({
       filters: [],
       limit: 100,
-      query: '{${primarySignal} && ${filters} && status=error} | rate() ',
+      query: `{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}} && status=error} | rate() `,
       queryType: 'traceql',
       refId: 'A',
       spss: 10,
@@ -67,7 +68,7 @@ describe('metricByWithStatus', () => {
     expect(query).toEqual({
       filters: [],
       limit: 100,
-      query: '{${primarySignal} && ${filters} && status=error && service != nil} | rate() by(service)',
+      query: `{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}} && status=error && service != nil} | rate() by(service)`,
       queryType: 'traceql',
       refId: 'A',
       spss: 10,
@@ -80,7 +81,7 @@ describe('metricByWithStatus', () => {
     expect(query).toEqual({
       filters: [],
       limit: 100,
-      query: '{${primarySignal} && ${filters} && service != nil} | quantile_over_time(duration, 0.9) by(service)',
+      query: `{\${${VAR_PRIMARY_SIGNAL}\} && $\{${VAR_FILTERS}} && service != nil} | quantile_over_time(duration, 0.9) by(service)`,
       queryType: 'traceql',
       refId: 'A',
       spss: 10,

--- a/src/components/Home/ErroredServicesRows.tsx
+++ b/src/components/Home/ErroredServicesRows.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { DataFrame, GrafanaTheme2, urlUtil } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 import React from 'react';
-import { EXPLORATIONS_ROUTE } from 'utils/shared';
+import { EXPLORATIONS_ROUTE, VAR_FILTERS, VAR_METRIC } from 'utils/shared';
 import { AttributePanelRow } from './AttributePanelRow';
 import { HomepagePanelType } from './AttributePanel';
 
@@ -23,8 +23,8 @@ export const ErroredServicesRows = (props: Props) => {
   const getUrl = (df: DataFrame) => {
     const serviceName = getLabel(df);
     const params = {
-      'var-filters': `resource.service.name|=|${serviceName}`,
-      'var-metric': 'errors',
+      [`var-${VAR_FILTERS}`]: `resource.service.name|=|${serviceName}`,
+      [`var-${VAR_METRIC}`]: 'errors',
     };
     return urlUtil.renderUrl(EXPLORATIONS_ROUTE, params);
   };

--- a/src/components/Home/SlowestServicesRows.tsx
+++ b/src/components/Home/SlowestServicesRows.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { DataFrame, GrafanaTheme2, urlUtil } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 import React from 'react';
-import { EXPLORATIONS_ROUTE } from 'utils/shared';
+import { EXPLORATIONS_ROUTE, VAR_FILTERS, VAR_METRIC } from 'utils/shared';
 import { AttributePanelRow } from './AttributePanelRow';
 import { HomepagePanelType } from './AttributePanel';
 import { formatDuration } from '../../utils/dates';
@@ -24,8 +24,8 @@ export const SlowestServicesRows = (props: Props) => {
   const getUrl = (df: DataFrame) => {
     const serviceName = getLabel(df);
     const params = {
-      'var-filters': `resource.service.name|=|${serviceName}`,
-      'var-metric': 'duration',
+      [`var-${VAR_FILTERS}`]: `resource.service.name|=|${serviceName}`,
+      [`var-${VAR_METRIC}`]: 'duration',
     };
     return urlUtil.renderUrl(EXPLORATIONS_ROUTE, params);
   };

--- a/src/components/Home/SlowestTracesRows.tsx
+++ b/src/components/Home/SlowestTracesRows.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { DataFrame, Field, GrafanaTheme2, urlUtil } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 import React from 'react';
-import { EXPLORATIONS_ROUTE, ROUTES } from 'utils/shared';
+import { EXPLORATIONS_ROUTE, ROUTES, VAR_METRIC, VAR_FILTERS } from 'utils/shared';
 import { AttributePanelRow } from './AttributePanelRow';
 import { HomepagePanelType } from './AttributePanel';
 import { formatDuration } from '../../utils/dates';
@@ -53,8 +53,8 @@ export const SlowestTracesRows = (props: Props) => {
       const params = {
         traceId,
         spanId: spanIdField.values[index],
-        'var-filters': `resource.service.name|=|${traceServiceField.values[index]}`,
-        'var-metric': 'duration',
+        [`var-${VAR_FILTERS}`]: `resource.service.name|=|${traceServiceField.values[index]}`,
+        [`var-${VAR_METRIC}`]: 'duration',
       };
 
       return urlUtil.renderUrl(EXPLORATIONS_ROUTE, params);

--- a/src/exposedComponents/OpenInExploreTracesButton/OpenInExploreTracesButton.tsx
+++ b/src/exposedComponents/OpenInExploreTracesButton/OpenInExploreTracesButton.tsx
@@ -3,6 +3,7 @@ import { LinkButton } from '@grafana/ui';
 import React, { useMemo } from 'react';
 import { OpenInExploreTracesButtonProps } from '../types';
 import pluginJson from '../../plugin.json';
+import { VAR_DATASOURCE, VAR_FILTERS, VAR_PRIMARY_SIGNAL } from 'utils/shared';
 
 export default function OpenInExploreTracesButton({
   datasourceUid,
@@ -18,7 +19,7 @@ export default function OpenInExploreTracesButton({
     let params = new URLSearchParams();
 
     if (datasourceUid) {
-      params.append('var-ds', datasourceUid);
+      params.append(`var-${VAR_DATASOURCE}`, datasourceUid);
     }
 
     if (from) {
@@ -30,10 +31,10 @@ export default function OpenInExploreTracesButton({
     }
 
     matchers.forEach((streamSelector) => {
-      params.append('var-filters', `${streamSelector.name}|${streamSelector.operator}|${streamSelector.value}`);
+      params.append(`var-${VAR_FILTERS}`, `${streamSelector.name}|${streamSelector.operator}|${streamSelector.value}`);
     });
 
-    params.append('var-primarySignal', 'true'); // so all spans is selected
+    params.append(`var-${VAR_PRIMARY_SIGNAL}`, 'true'); // so all spans is selected
 
     return `a/${pluginJson.id}/explore?${params.toString()}`;
   }, [datasourceUid, from, to, matchers]);

--- a/src/pages/Home/bookmarks/BookmarkItem.test.tsx
+++ b/src/pages/Home/bookmarks/BookmarkItem.test.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { BookmarkItem } from './BookmarkItem';
 import { Bookmark } from './Bookmarks';
-
+import { VAR_DATASOURCE, VAR_FILTERS, VAR_GROUPBY, VAR_METRIC } from 'utils/shared';
+  
 describe('BookmarkItem', () => {
   const mockBookmark: Bookmark = {
-    params: 'actionView=breakdown&primarySignal=full_traces&var-ds=EBorgLFZ&var-filters=filter1|=|value1&var-groupBy=name&var-metric=rate'
+    params: `actionView=breakdown&primarySignal=full_traces&var-${VAR_DATASOURCE}=EBorgLFZ&var-${VAR_FILTERS}=filter1|=|value1&var-${VAR_GROUPBY}=name&var-${VAR_METRIC}=rate`
   };
 
   test('renders bookmark information correctly', () => {

--- a/src/pages/Home/bookmarks/Bookmarks.test.tsx
+++ b/src/pages/Home/bookmarks/Bookmarks.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { Bookmarks, Bookmark } from './Bookmarks';
 import { getBookmarkForUrl, goToBookmark, useBookmarksStorage } from './utils';
 import { locationService } from '@grafana/runtime';
+import { VAR_DATASOURCE, VAR_FILTERS, VAR_GROUPBY, VAR_METRIC } from 'utils/shared';
 
 // Mock the BookmarkItem component
 jest.mock('./BookmarkItem', () => ({
@@ -34,10 +35,10 @@ jest.mock('@grafana/runtime', () => ({
 describe('Bookmarks', () => {
   const mockBookmarks: Bookmark[] = [
     {
-      params: 'actionView=breakdown&primarySignal=full_traces&var-ds=EBorgLFZ&var-filters=filter1|=|value1&var-groupBy=name&var-metric=rate'
+      params: `actionView=breakdown&primarySignal=full_traces&var-${VAR_DATASOURCE}=EBorgLFZ&var-${VAR_FILTERS}=filter1|=|value1&var-${VAR_GROUPBY}=name&var-${VAR_METRIC}=rate`
     },
     {
-      params: 'actionView=comparison&primarySignal=server_spans&var-ds=loki&var-filters=filter2=value2&var-groupBy=service&var-metric=errors'
+      params: `actionView=comparison&primarySignal=server_spans&var-${VAR_DATASOURCE}=loki&var-${VAR_FILTERS}=filter2=value2&var-${VAR_GROUPBY}=service&var-${VAR_METRIC}=errors`
     }
   ];
 

--- a/src/pages/Home/bookmarks/utils.test.ts
+++ b/src/pages/Home/bookmarks/utils.test.ts
@@ -269,7 +269,7 @@ describe('Bookmark Utils', () => {
       };
 
       const url = getBookmarkForUrl(bookmark);
-      expect(url).toBe(`${EXPLORATIONS_ROUTE}?actionView=breakdown&primarySignal=full_traces&var-ds=EBorgLFZ&var-${VAR_FILTERS}=filter1%7C%3D%7Cvalue1&var-groupBy=name&var-metric=rate`);
+      expect(url).toBe(`${EXPLORATIONS_ROUTE}?actionView=breakdown&primarySignal=full_traces&var-${VAR_DATASOURCE}=EBorgLFZ&var-${VAR_FILTERS}=filter1%7C%3D%7Cvalue1&var-${VAR_GROUPBY}=name&var-${VAR_METRIC}=rate`);
     });
 
     it('should handle multiple filters correctly', () => {
@@ -278,7 +278,7 @@ describe('Bookmark Utils', () => {
       };
 
       const url = getBookmarkForUrl(bookmark);
-      expect(url).toBe(`${EXPLORATIONS_ROUTE}?actionView=breakdown&primarySignal=full_traces&var-ds=EBorgLFZ&var-${VAR_FILTERS}=filter1%7C%3D%7Cvalue1&var-${VAR_FILTERS}=filter2%7C%3D%7Cvalue2&var-groupBy=name&var-metric=rate`);
+      expect(url).toBe(`${EXPLORATIONS_ROUTE}?actionView=breakdown&primarySignal=full_traces&var-${VAR_DATASOURCE}=EBorgLFZ&var-${VAR_FILTERS}=filter1%7C%3D%7Cvalue1&var-${VAR_FILTERS}=filter2%7C%3D%7Cvalue2&var-${VAR_GROUPBY}=name&var-${VAR_METRIC}=rate`);
     });
 
     it('should handle a bookmark with no filters', () => {
@@ -287,7 +287,7 @@ describe('Bookmark Utils', () => {
       };
 
       const url = getBookmarkForUrl(bookmark);
-      expect(url).toBe(`${EXPLORATIONS_ROUTE}?actionView=breakdown&primarySignal=full_traces&var-ds=EBorgLFZ&var-groupBy=name&var-metric=rate`);
+      expect(url).toBe(`${EXPLORATIONS_ROUTE}?actionView=breakdown&primarySignal=full_traces&var-${VAR_DATASOURCE}=EBorgLFZ&var-${VAR_GROUPBY}=name&var-${VAR_METRIC}=rate`);
     });
 
     it('should handle empty parameters', () => {
@@ -296,7 +296,7 @@ describe('Bookmark Utils', () => {
       };
 
       const url = getBookmarkForUrl(bookmark);
-      expect(url).toBe(`${EXPLORATIONS_ROUTE}?actionView=&primarySignal=&var-ds=EBorgLFZ&var-groupBy=&var-metric=`);
+      expect(url).toBe(`${EXPLORATIONS_ROUTE}?actionView=&primarySignal=&var-${VAR_DATASOURCE}=EBorgLFZ&var-${VAR_GROUPBY}=&var-${VAR_METRIC}=`);
     });
   });
 

--- a/src/utils/links.test.ts
+++ b/src/utils/links.test.ts
@@ -1,6 +1,6 @@
 import {dateTime, PluginExtensionPanelContext} from '@grafana/data';
 import { contextToLink, TraceqlFilter } from './links';
-import { RESOURCE, SPAN } from './shared';
+import { RESOURCE, SPAN, VAR_DATASOURCE, VAR_FILTERS, VAR_METRIC, VAR_PRIMARY_SIGNAL } from './shared';
 
 describe('contextToLink', () => {
   it('should return undefined if context is not provided', () => {
@@ -35,15 +35,15 @@ describe('contextToLink', () => {
 
     const result = getLink(mockContext);
     expect(result).toBeDefined();
-    expect(result?.path).toContain('var-primarySignal=true');
-    expect(result?.path).toContain('var-ds=test-uid');
-    expect(result?.path).toContain('var-filters=' + encodeURIComponent('resource.service.name|=|grafana'));
-    expect(result?.path).toContain('var-filters=' + encodeURIComponent('span.http.status_code|=|200'));
+    expect(result?.path).toContain(`var-${VAR_PRIMARY_SIGNAL}=true`);
+    expect(result?.path).toContain(`var-${VAR_DATASOURCE}=test-uid`);
+    expect(result?.path).toContain(`var-${VAR_FILTERS}=resource.service.name%7C%3D%7Cgrafana`);
+    expect(result?.path).toContain(`var-${VAR_FILTERS}=span.http.status_code%7C%3D%7C200`);
     expect(result?.path).toContain('from=' + encodeURIComponent('30m'));
     expect(result?.path).toContain('to=' + encodeURIComponent('1'));
   });
 
-  it('should set var-metric to errors if status filter has value error', () => {
+  it('should set metric var to errors if status filter has value error', () => {
     const mockContext = createMockContext([
       {
         datasource: { type: 'tempo', uid: 'test-uid' },
@@ -52,10 +52,10 @@ describe('contextToLink', () => {
     ]);
 
     const result = getLink(mockContext);
-    expect(result?.path).toContain('var-metric=errors');
+    expect(result?.path).toContain(`var-${VAR_METRIC}=errors`);
   });
 
-  it('should set var-metric to rate if status filter is not error', () => {
+  it('should set metric var to rate if status filter is not error', () => {
     const mockContext = createMockContext([
       {
         datasource: { type: 'tempo', uid: 'test-uid' },
@@ -64,7 +64,7 @@ describe('contextToLink', () => {
     ]);
 
     const result = getLink(mockContext);
-    expect(result?.path).toContain('var-metric=rate');
+    expect(result?.path).toContain(`var-${VAR_METRIC}=rate`);
   });
 });
 

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -6,7 +6,7 @@ import {
 } from '@grafana/data';
 
 import {DataQuery, DataSourceRef} from '@grafana/schema';
-import {EXPLORATIONS_ROUTE, VAR_DATASOURCE, VAR_FILTERS, VAR_METRIC} from './shared';
+import {EXPLORATIONS_ROUTE, VAR_DATASOURCE, VAR_FILTERS, VAR_METRIC, VAR_PRIMARY_SIGNAL} from './shared';
 
 type TempoQuery = {
   filters?: TraceqlFilter[];
@@ -69,7 +69,7 @@ export function contextToLink(context?: PluginExtensionPanelContext | PluginExte
     params.append(`var-${VAR_METRIC}`, statusFilter.value === 'error' ? 'errors' : 'rate');
   }
 
-  params.append('var-primarySignal', 'true');
+  params.append(`var-${VAR_PRIMARY_SIGNAL}`, 'true');
 
   const getFilters = (filters: TraceqlFilter[]) => {
     return filters

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -23,19 +23,20 @@ export const EMPTY_STATE_ERROR_REMEDY_MESSAGE = 'Please try removing some filter
 
 export const FILTER_SEPARATOR = ' && ';
 
-export const VAR_DATASOURCE = 'ds';
-export const VAR_DATASOURCE_EXPR = '${ds}';
-export const VAR_PRIMARY_SIGNAL = 'primarySignal';
-export const VAR_FILTERS = 'filters';
-export const VAR_FILTERS_EXPR = '${primarySignal} && ${filters}';
-export const VAR_HOME_FILTER = 'homeFilter';
-export const VAR_GROUPBY = 'groupBy';
-export const VAR_SPAN_LIST_COLUMNS = 'spanListColumns';
-export const VAR_METRIC = 'metric';
-export const VAR_LATENCY_THRESHOLD = 'latencyThreshold';
-export const VAR_LATENCY_THRESHOLD_EXPR = '${latencyThreshold}';
-export const VAR_LATENCY_PARTIAL_THRESHOLD = 'partialLatencyThreshold';
-export const VAR_LATENCY_PARTIAL_THRESHOLD_EXPR = '${partialLatencyThreshold}';
+const VAR_PREFIX = 'tracesDrilldown';
+export const VAR_DATASOURCE = `${VAR_PREFIX}Ds`;
+export const VAR_DATASOURCE_EXPR = `$\{${VAR_PREFIX}Ds\}`;
+export const VAR_PRIMARY_SIGNAL = `${VAR_PREFIX}PrimarySignal`;
+export const VAR_FILTERS = `${VAR_PREFIX}Filters`;
+export const VAR_FILTERS_EXPR = `$\{${VAR_PREFIX}PrimarySignal\} && $\{${VAR_PREFIX}Filters\}`;
+export const VAR_HOME_FILTER = `${VAR_PREFIX}HomeFilter`;
+export const VAR_GROUPBY = `${VAR_PREFIX}GroupBy`;
+export const VAR_SPAN_LIST_COLUMNS = `${VAR_PREFIX}SpanListColumns`;
+export const VAR_METRIC = `${VAR_PREFIX}Metric`;
+export const VAR_LATENCY_THRESHOLD = `${VAR_PREFIX}LatencyThreshold`;
+export const VAR_LATENCY_THRESHOLD_EXPR = `$\{${VAR_PREFIX}LatencyThreshold\}`;
+export const VAR_LATENCY_PARTIAL_THRESHOLD = `${VAR_PREFIX}PartialLatencyThreshold`;
+export const VAR_LATENCY_PARTIAL_THRESHOLD_EXPR = `$\{${VAR_PREFIX}PartialLatencyThreshold\}`;
 export const explorationDS = { uid: VAR_DATASOURCE_EXPR };
 
 export const ACTION_VIEW = 'actionView';


### PR DESCRIPTION
Added `tracesDrilldown` namespace to prevent variable collisions. See more on this [here](https://github.com/grafana/scenes/pull/1143) and an alternative approach [here](https://github.com/grafana/scenes/pull/1156).

This PR will act as a way to prevent the variable collisions for now, with a more permanent solution being introduced in either of the above linked PR's.