### PR TITLE
Add namespace to embedded app

### DIFF
--- a/src/exposedComponents/EmbeddedTraceExploration/EmbeddedTraceExploration.tsx
+++ b/src/exposedComponents/EmbeddedTraceExploration/EmbeddedTraceExploration.tsx
@@ -37,7 +37,7 @@ export default function EmbeddedTraceExploration(props: EmbeddedTraceExploration
   }
 
   return (
-    <UrlSyncContextProvider scene={exploration} updateUrlOnInit={false} createBrowserHistorySteps={true}>
+    <UrlSyncContextProvider namespace='td' scene={exploration} updateUrlOnInit={false} createBrowserHistorySteps={true}>
       <exploration.Component model={exploration} />
     </UrlSyncContextProvider>
   );


### PR DESCRIPTION
Adds a namespace to the embedded app to prevent variable collisions with other scenes apps.