### PR TITLE
fix(500): Use db.system.name instead of db.name attribute for the "Database calls" filter

### DIFF
--- a/src/components/Explore/actions/AddToFiltersAction.test.tsx
+++ b/src/components/Explore/actions/AddToFiltersAction.test.tsx
@@ -99,14 +99,14 @@ describe('addToFilters', () => {
     });
   });
 
-  it('should keep span.db.name filter intact', () => {
-    variable.state.filters.push({ key: 'span.db.name', operator: '=', value: 'value3' });
+  it('should keep span.db.system.name filter intact', () => {
+    variable.state.filters.push({ key: 'span.db.system.name', operator: '=', value: 'value3' });
     addToFilters(variable, 'newKey', 'newValue');
 
     expect(variable.setState).toHaveBeenCalledWith({
       filters: [
         { key: 'otherKey', operator: '=', value: 'value2' },
-        { key: 'span.db.name', operator: '=', value: 'value3' },
+        { key: 'span.db.system.name', operator: '=', value: 'value3' },
         { key: 'newKey', operator: '=', value: 'newValue' },
       ],
     });

--- a/src/components/Explore/actions/AddToFiltersAction.tsx
+++ b/src/components/Explore/actions/AddToFiltersAction.tsx
@@ -55,7 +55,7 @@ export class AddToFiltersAction extends SceneObjectBase<AddToFiltersActionState>
 export const addToFilters = (variable: AdHocFiltersVariable, label: string, value: string) => {
   // ensure we set the new filter with latest value
   // and remove any existing filter for the same key
-  // and also keep span.db.name as it is a primary filter
+  // and also keep span.db.system.name as it is a primary filter
   const filtersWithoutNew = variable.state.filters.filter((f) => f.key === DATABASE_CALLS_KEY || f.key !== label);
 
   // TODO: Replace it with new API introduced in https://github.com/grafana/scenes/issues/1103

--- a/src/pages/Explore/primary-signals.ts
+++ b/src/pages/Explore/primary-signals.ts
@@ -1,6 +1,6 @@
 import { SelectableValue } from '@grafana/data';
 
-export const DATABASE_CALLS_KEY = 'span.db.name';
+export const DATABASE_CALLS_KEY = 'span.db.system.name';
 
 export const primarySignalOptions: Array<SelectableValue<string>> = [
   {


### PR DESCRIPTION
Closes https://github.com/grafana/traces-drilldown/issues/500