### PR TITLE
fix: Fix units overflow for trace durations

### DIFF
--- a/src/utils/dates.test.ts
+++ b/src/utils/dates.test.ts
@@ -27,6 +27,10 @@ describe('formatDuration', () => {
     expect(formatDuration(ONE_SECOND)).toBe('1s');
     expect(formatDuration(ONE_MILLISECOND)).toBe('1ms');
   });
+
+  it('formats durations with a secondary unit that rounds up to a whole primary unit', () => {
+    expect(formatDuration(299898037.75)).toBe('5m');
+  });
 });
 
 describe('getStepForTimeRange', () => {

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -41,11 +41,26 @@ export const formatDuration = (duration: number): string => {
     return `${_round(duration / primaryUnit.microseconds, 2)}${primaryUnit.unit}`;
   }
 
-  const primaryValue = Math.floor(duration / primaryUnit.microseconds);
+  let primaryValue = Math.floor(duration / primaryUnit.microseconds);
+  let secondaryValue = (duration / secondaryUnit.microseconds) % primaryUnit.ofPrevious;
+  const secondaryValueRounded = Math.round(secondaryValue);
+
+  // Handle rollover case before rounding (e.g., 60s should become 1m, not 0m 60s)
+  if (secondaryValueRounded === primaryUnit.ofPrevious) {
+    primaryValue += 1;
+    secondaryValue = 0;
+  } else {
+    secondaryValue = secondaryValueRounded;
+  }
+
   const primaryUnitString = `${primaryValue}${primaryUnit.unit}`;
-  const secondaryValue = Math.round((duration / secondaryUnit.microseconds) % primaryUnit.ofPrevious);
+
+  if (secondaryValue === 0) {
+    return primaryUnitString;
+  }
+
   const secondaryUnitString = `${secondaryValue}${secondaryUnit.unit}`;
-  return secondaryValue === 0 ? primaryUnitString : `${primaryUnitString} ${secondaryUnitString}`;
+  return `${primaryUnitString} ${secondaryUnitString}`;
 }
 
 export const getStepForTimeRange = (scene: SceneObject, dataPoints?: number) => {


### PR DESCRIPTION
- Fix issue where rounded secondary units would not be carried over to the primary unit when they are a whole multiple of that unit (e.g. `"4m 60s"` instead of `"5m"`).
- Avoid formatting `secondaryUnitString` if it's not going to be used.

Equivalent to https://github.com/grafana/grafana/pull/108515.