### PR TITLE
feat: Integrate Insights Timeline widget

### DIFF
--- a/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
+++ b/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
@@ -5,7 +5,7 @@ import { usePluginComponent } from '@grafana/runtime';
 import { sceneGraph, SceneObject } from '@grafana/scenes';
 import { css } from '@emotion/css';
 import { useStyles2 } from '@grafana/ui';
-import { getMetricVariable, getTraceExplorationScene } from 'utils/utils';
+import { getMetricVariable } from 'utils/utils';
 import { MetricFunction } from 'utils/shared';
 
 export type AssertionSeverity = 'warning' | 'critical' | 'info';
@@ -16,7 +16,6 @@ interface InsightsTimelineWidgetProps {
   end: string | number;
   filterBySeverity?: AssertionSeverity[];
   filterBySummaryKeywords?: string[];
-  isEmbeddedApp?: boolean;
   label?: ReactElement;
 }
 
@@ -32,8 +31,6 @@ export function InsightsTimelineWidget({ serviceName, model }: Props) {
     'grafana-asserts-app/insights-timeline-widget/v1'
   );
   const styles = useStyles2(getStyles);
-  const traceExploration = getTraceExplorationScene(model);
-  const { embedded } = traceExploration.useState();
   const sceneTimeRange = sceneGraph.getTimeRange(model).useState();
 
   const metric = getMetricVariable(model).state.value as MetricFunction;
@@ -61,7 +58,6 @@ export function InsightsTimelineWidget({ serviceName, model }: Props) {
       filterBySeverity={filterBySeverity}
       filterBySummaryKeywords={filterBySummaryKeywords}
       label={<div className={styles.label}>Insights</div>}
-      isEmbeddedApp={embedded}
     />
   );
 }
@@ -71,7 +67,7 @@ function getStyles(theme: GrafanaTheme2) {
     label: css({
       fontSize: '12px',
       color: theme.colors.text.secondary,
-      marginLeft: '35px',
+      marginLeft: '35px', // we are also passing an axisWidth of 70 to barsPanelConfig()
       marginTop: '-3px',
     }),
   };

--- a/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
+++ b/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
@@ -1,6 +1,6 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { ReactElement } from 'react';
 
-import { GrafanaTheme2, TimeRange } from '@grafana/data';
+import { GrafanaTheme2 } from '@grafana/data';
 import { usePluginComponent } from '@grafana/runtime';
 import { sceneGraph, SceneObject } from '@grafana/scenes';
 import { css } from '@emotion/css';
@@ -39,12 +39,12 @@ export interface Cluster {
 
 interface InsightsTimelineWidgetProps {
   serviceName: string;
-  start: string;
-  end: string;
+  start: string | number;
+  end: string | number;
   filterBySeverity?: AssertionSeverity[];
   filterBySummaryKeywords?: string[];
   isEmbeddedApp?: boolean;
-  dataCallback: (data: Record<string, { healthStates: HealthState[], clusters: Cluster[] }>) => void;
+  label?: ReactElement;
 }
 
 export type InsightsTimelineWidgetExternal = (props: InsightsTimelineWidgetProps) => ReactElement | null;
@@ -58,28 +58,10 @@ export function InsightsTimelineWidget({ serviceName, model }: Props) {
   const { isLoading, component: InsightsTimelineWidgetExternal } = usePluginComponent<InsightsTimelineWidgetProps>(
     'grafana-asserts-app/insights-timeline-widget/v1'
   );
-  const [timeRange, setTimeRange] = useState<TimeRange>();
-  const [showTitle, setShowTitle] = useState(false);
-  const [showInsights, setShowInsights] = useState(true);
   const styles = useStyles2(getStyles);
   const traceExploration = getTraceExplorationScene(model);
   const { embedded } = traceExploration.useState();
   const sceneTimeRange = sceneGraph.getTimeRange(model).useState();
-
-  useEffect(() => {
-    setTimeRange(sceneTimeRange.value);
-    setShowInsights(true);  // reset to true to show insights, which will call checkHasData()
-  }, [sceneTimeRange]);
-
-  const checkHasData = (data: Record<string, { healthStates: HealthState[], clusters: Cluster[] }>) => {
-    const clustersAndHealthStates = Array.isArray(data) ? data : Object.values(data);
-    const hasData = clustersAndHealthStates.some((clustersAndHealthState) => {
-      const healthCount = clustersAndHealthState?.healthStates?.length ?? 0;
-      return healthCount > 0;
-    });
-    setShowTitle(hasData);
-    setShowInsights(hasData);
-  };
 
   const metric = getMetricVariable(model).state.value as MetricFunction;
   let filterBySeverity: AssertionSeverity[] = [];
@@ -94,53 +76,36 @@ export function InsightsTimelineWidget({ serviceName, model }: Props) {
     filterBySummaryKeywords = ['latency'];
   }
   
-  if (isLoading || !InsightsTimelineWidgetExternal || !timeRange) {
+  if (isLoading || !InsightsTimelineWidgetExternal || !sceneTimeRange) {
+    return null;
+  }
+
+  const element = <InsightsTimelineWidgetExternal
+    serviceName={serviceName}
+    start={sceneTimeRange.from.valueOf()}
+    end={sceneTimeRange.to.valueOf()}
+    filterBySeverity={filterBySeverity}
+    filterBySummaryKeywords={filterBySummaryKeywords}
+    label={<div className={styles.label}>Insights</div>}
+    isEmbeddedApp={embedded}
+  />
+
+  if (element === null) {
     return null;
   }
 
   return (
-    <div className={styles.insightsContainer}>
-      {showTitle && (
-        <div className={styles.insightsTitle}>
-          Insights
-        </div>
-      )}
-      {showInsights && (
-        <div className={styles.insightsTimelineContainer}>
-          <InsightsTimelineWidgetExternal
-            serviceName={serviceName}
-            start={timeRange.from.toISOString()}
-            end={timeRange.to.toISOString()}
-            filterBySeverity={filterBySeverity}
-            filterBySummaryKeywords={filterBySummaryKeywords}
-            dataCallback={(data: Record<string, { healthStates: HealthState[], clusters: Cluster[] }>) => checkHasData(data)}
-            isEmbeddedApp={embedded}
-          />
-        </div>
-      )}
-    </div>
+    <>{element}</>
   );
 }
 
 function getStyles(theme: GrafanaTheme2) {
   return {
-    insightsContainer: css({
-      display: 'flex',
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: '8px',
-      marginBottom: '6px',
-    }),
-    insightsTitle: css({
+    label: css({
       fontSize: '12px',
       color: theme.colors.text.secondary,
       marginLeft: '35px',
       marginTop: '-3px',
-    }),
-    insightsTimelineContainer: css({
-      marginLeft: '10px',
-      marginRight: '15px',
-      width: '100%',
     }),
   };
 }

--- a/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
+++ b/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
@@ -46,11 +46,7 @@ export function InsightsTimelineWidget({ serviceName, model }: Props) {
     filterBySummaryKeywords = ['latency'];
   }
 
-  if (isLoading || !InsightsTimelineWidgetExternal || !sceneTimeRange) {
-    return null;
-  }
-
-  if (!serviceName) {
+  if (isLoading || !InsightsTimelineWidgetExternal || !sceneTimeRange || !serviceName) {
     return null;
   }
 

--- a/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
+++ b/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
@@ -5,7 +5,7 @@ import { usePluginComponent } from '@grafana/runtime';
 import { sceneGraph, SceneObject } from '@grafana/scenes';
 import { css } from '@emotion/css';
 import { useStyles2 } from '@grafana/ui';
-import { getMetricVariable } from 'utils/utils';
+import { getMetricVariable, getTraceExplorationScene } from 'utils/utils';
 import { MetricFunction } from 'utils/shared';
 
 export type AssertionSeverity = 'warning' | 'critical' | 'info';
@@ -43,6 +43,7 @@ interface InsightsTimelineWidgetProps {
   end: string;
   filterBySeverity?: AssertionSeverity[];
   filterBySummaryKeywords?: string[];
+  isEmbeddedApp?: boolean;
   dataCallback: (data: Record<string, { healthStates: HealthState[], clusters: Cluster[] }>) => void;
 }
 
@@ -61,6 +62,8 @@ export function InsightsTimelineWidget({ serviceName, model }: Props) {
   const [showTitle, setShowTitle] = useState(false);
   const [showInsights, setShowInsights] = useState(true);
   const styles = useStyles2(getStyles);
+  const traceExploration = getTraceExplorationScene(model);
+  const { embedded } = traceExploration.useState();
 
   useEffect(() => {
     const sceneTimeRange = sceneGraph.getTimeRange(model);
@@ -119,6 +122,7 @@ export function InsightsTimelineWidget({ serviceName, model }: Props) {
             filterBySeverity={filterBySeverity}
             filterBySummaryKeywords={filterBySummaryKeywords}
             dataCallback={(data: Record<string, { healthStates: HealthState[], clusters: Cluster[] }>) => checkHasData(data)}
+            isEmbeddedApp={embedded}
           />
         </div>
       )}

--- a/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
+++ b/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
@@ -1,0 +1,149 @@
+import React, { ReactElement, useEffect, useState } from 'react';
+
+import { GrafanaTheme2, TimeRange } from '@grafana/data';
+import { usePluginComponent } from '@grafana/runtime';
+import { sceneGraph, SceneObject } from '@grafana/scenes';
+import { css } from '@emotion/css';
+import { useStyles2 } from '@grafana/ui';
+import { getMetricVariable } from 'utils/utils';
+import { MetricFunction } from 'utils/shared';
+
+export type AssertionSeverity = 'warning' | 'critical' | 'info';
+
+export interface EntityAssertion {
+  severity?: AssertionSeverity;
+  amend?: boolean;
+  assertions?: Array<{
+    assertionName: string;
+    severity: AssertionSeverity;
+    category: string;
+    entityType: string;
+  }>;
+}
+
+export interface HealthState extends EntityAssertion {
+  start: number;
+  end: number;
+  context: Record<string, string>;
+}
+
+export interface Cluster {
+  start: number;
+  end: number;
+  assertionStates: HealthState[];
+  assertionSummaries: Array<{
+    summary: string;
+    category: string;
+  }>;
+}
+
+interface InsightsTimelineWidgetProps {
+  serviceName: string;
+  start: string;
+  end: string;
+  filterBySeverity?: AssertionSeverity[];
+  filterBySummaryKeywords?: string[];
+  dataCallback: (data: Record<string, { healthStates: HealthState[], clusters: Cluster[] }>) => void;
+}
+
+export type InsightsTimelineWidgetExternal = (props: InsightsTimelineWidgetProps) => ReactElement | null;
+
+interface Props {
+  serviceName: string;
+  model: SceneObject;
+}
+
+export function InsightsTimelineWidget({ serviceName, model }: Props) {
+  const { isLoading, component: InsightsTimelineWidgetExternal } = usePluginComponent<InsightsTimelineWidgetProps>(
+    'grafana-asserts-app/insights-timeline-widget/v1'
+  );
+  const [timeRange, setTimeRange] = useState<TimeRange>();
+  const [showTitle, setShowTitle] = useState(false);
+  const [showInsights, setShowInsights] = useState(true);
+  const styles = useStyles2(getStyles);
+
+  useEffect(() => {
+    const sceneTimeRange = sceneGraph.getTimeRange(model);
+    setTimeRange(sceneTimeRange.state.value);
+
+    const sub = sceneTimeRange.subscribeToState((state) => {
+      setTimeRange(state.value);
+      setShowInsights(true);  // reset to true to show insights, which will call checkHasData()
+    });
+
+    return () => {
+      sub.unsubscribe();
+    };
+  }, [model]);
+
+  const checkHasData = (data: Record<string, { healthStates: HealthState[], clusters: Cluster[] }>) => {
+    const clustersAndHealthStates = Array.isArray(data) ? data : Object.values(data);
+    const hasData = clustersAndHealthStates.some((clustersAndHealthState) => {
+      const healthCount = clustersAndHealthState?.healthStates?.length ?? 0;
+      return healthCount > 0;
+    });
+    setShowTitle(hasData);
+    setShowInsights(hasData);
+  };
+
+  const metric = getMetricVariable(model).state.value as MetricFunction;
+  let filterBySeverity: AssertionSeverity[] = [];
+  if (metric === 'errors') {
+    filterBySeverity = ['critical', 'warning'];
+  } else if (metric === 'rate') {
+    filterBySeverity = ['info'];
+  }
+
+  let filterBySummaryKeywords: string[] = [];
+  if (metric === 'duration') {
+    filterBySummaryKeywords = ['latency'];
+  }
+  
+  if (isLoading || !InsightsTimelineWidgetExternal || !timeRange) {
+    return null;
+  }
+
+  return (
+    <div className={styles.insightsContainer}>
+      {showTitle && (
+        <div className={styles.insightsTitle}>
+          Insights
+        </div>
+      )}
+      {showInsights && (
+        <div className={styles.insightsTimelineContainer}>
+          <InsightsTimelineWidgetExternal
+            serviceName={serviceName}
+            start={timeRange.from.toISOString()}
+            end={timeRange.to.toISOString()}
+            filterBySeverity={filterBySeverity}
+            filterBySummaryKeywords={filterBySummaryKeywords}
+            dataCallback={(data: Record<string, { healthStates: HealthState[], clusters: Cluster[] }>) => checkHasData(data)}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    insightsContainer: css({
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: '8px',
+    }),
+    insightsTitle: css({
+      fontSize: '12px',
+      color: theme.colors.text.secondary,
+      marginLeft: '35px',
+      marginTop: '-3px',
+    }),
+    insightsTimelineContainer: css({
+      marginLeft: '10px',
+      marginRight: '15px',
+      width: '100%',
+    }),
+  };
+}

--- a/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
+++ b/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
@@ -10,33 +10,6 @@ import { MetricFunction } from 'utils/shared';
 
 export type AssertionSeverity = 'warning' | 'critical' | 'info';
 
-export interface EntityAssertion {
-  severity?: AssertionSeverity;
-  amend?: boolean;
-  assertions?: Array<{
-    assertionName: string;
-    severity: AssertionSeverity;
-    category: string;
-    entityType: string;
-  }>;
-}
-
-export interface HealthState extends EntityAssertion {
-  start: number;
-  end: number;
-  context: Record<string, string>;
-}
-
-export interface Cluster {
-  start: number;
-  end: number;
-  assertionStates: HealthState[];
-  assertionSummaries: Array<{
-    summary: string;
-    category: string;
-  }>;
-}
-
 interface InsightsTimelineWidgetProps {
   serviceName: string;
   start: string | number;

--- a/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
+++ b/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
@@ -64,20 +64,12 @@ export function InsightsTimelineWidget({ serviceName, model }: Props) {
   const styles = useStyles2(getStyles);
   const traceExploration = getTraceExplorationScene(model);
   const { embedded } = traceExploration.useState();
+  const sceneTimeRange = sceneGraph.getTimeRange(model).useState();
 
   useEffect(() => {
-    const sceneTimeRange = sceneGraph.getTimeRange(model);
-    setTimeRange(sceneTimeRange.state.value);
-
-    const sub = sceneTimeRange.subscribeToState((state) => {
-      setTimeRange(state.value);
-      setShowInsights(true);  // reset to true to show insights, which will call checkHasData()
-    });
-
-    return () => {
-      sub.unsubscribe();
-    };
-  }, [model]);
+    setTimeRange(sceneTimeRange.value);
+    setShowInsights(true);  // reset to true to show insights, which will call checkHasData()
+  }, [sceneTimeRange]);
 
   const checkHasData = (data: Record<string, { healthStates: HealthState[], clusters: Cluster[] }>) => {
     const clustersAndHealthStates = Array.isArray(data) ? data : Object.values(data);

--- a/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
+++ b/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
@@ -48,27 +48,21 @@ export function InsightsTimelineWidget({ serviceName, model }: Props) {
   if (metric === 'duration') {
     filterBySummaryKeywords = ['latency'];
   }
-  
+
   if (isLoading || !InsightsTimelineWidgetExternal || !sceneTimeRange) {
     return null;
   }
 
-  const element = <InsightsTimelineWidgetExternal
-    serviceName={serviceName}
-    start={sceneTimeRange.from.valueOf()}
-    end={sceneTimeRange.to.valueOf()}
-    filterBySeverity={filterBySeverity}
-    filterBySummaryKeywords={filterBySummaryKeywords}
-    label={<div className={styles.label}>Insights</div>}
-    isEmbeddedApp={embedded}
-  />
-
-  if (element === null) {
-    return null;
-  }
-
   return (
-    <>{element}</>
+    <InsightsTimelineWidgetExternal
+      serviceName={serviceName}
+      start={sceneTimeRange.from.valueOf()}
+      end={sceneTimeRange.to.valueOf()}
+      filterBySeverity={filterBySeverity}
+      filterBySummaryKeywords={filterBySummaryKeywords}
+      label={<div className={styles.label}>Insights</div>}
+      isEmbeddedApp={embedded}
+    />
   );
 }
 

--- a/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
+++ b/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
@@ -133,6 +133,7 @@ function getStyles(theme: GrafanaTheme2) {
       flexDirection: 'row',
       alignItems: 'center',
       gap: '8px',
+      marginBottom: '6px',
     }),
     insightsTitle: css({
       fontSize: '12px',

--- a/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
+++ b/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
@@ -50,6 +50,10 @@ export function InsightsTimelineWidget({ serviceName, model }: Props) {
     return null;
   }
 
+  if (!serviceName) {
+    return null;
+  }
+
   return (
     <InsightsTimelineWidgetExternal
       serviceName={serviceName}

--- a/src/components/Explore/TracesByService/REDPanel.tsx
+++ b/src/components/Explore/TracesByService/REDPanel.tsx
@@ -28,7 +28,6 @@ import {
   getMetricVariable,
   getOpenTrace,
   getTraceByServiceScene,
-  getTraceExplorationScene,
   shouldShowSelection,
 } from '../../../utils/utils';
 import { getHistogramVizPanel, yBucketToDuration } from '../panels/histogram';
@@ -260,7 +259,6 @@ export class REDPanel extends SceneObjectBase<RateMetricsPanelState> {
     const { value: metric } = getMetricVariable(model).useState();
     const styles = useStyles2(getStyles);
     const serviceName = useServiceName(model);
-    const exploration = getTraceExplorationScene(model);
 
     if (!panel) {
       return;
@@ -310,12 +308,10 @@ export class REDPanel extends SceneObjectBase<RateMetricsPanelState> {
           </div>
         </div>
         <panel.Component model={panel} />
-        {!exploration.state.embedded && (
-          <InsightsTimelineWidget
-            serviceName={serviceName || ''}
-            model={model}
-          />
-        )}
+        <InsightsTimelineWidget
+          serviceName={serviceName || ''}
+          model={model}
+        />
       </div>
     );
   };

--- a/src/components/Explore/TracesByService/REDPanel.tsx
+++ b/src/components/Explore/TracesByService/REDPanel.tsx
@@ -28,6 +28,7 @@ import {
   getMetricVariable,
   getOpenTrace,
   getTraceByServiceScene,
+  getTraceExplorationScene,
   shouldShowSelection,
 } from '../../../utils/utils';
 import { getHistogramVizPanel, yBucketToDuration } from '../panels/histogram';
@@ -37,6 +38,8 @@ import { buildHistogramQuery } from '../queries/histogram';
 import { isEqual } from 'lodash';
 import { DurationComparisonControl } from './DurationComparisonControl';
 import { exemplarsTransformations, removeExemplarsTransformation } from '../../../utils/exemplars';
+import { InsightsTimelineWidget } from 'addedComponents/InsightsTimelineWidget/InsightsTimelineWidget';
+import { useServiceName } from 'pages/Explore/TraceExploration';
 
 export interface RateMetricsPanelState extends SceneObjectState {
   panel?: SceneFlexLayout;
@@ -204,7 +207,7 @@ export class REDPanel extends SceneObjectBase<RateMetricsPanelState> {
   }
 
   private getRateOrErrorVizPanel(type: MetricFunction) {
-    const panel = barsPanelConfig(type).setHoverHeader(true).setDisplayMode('transparent');
+    const panel = barsPanelConfig(type, 70).setHoverHeader(true).setDisplayMode('transparent');
     if (type === 'rate') {
       panel.setCustomFieldConfig('axisLabel', 'span/s');
     } else if (type === 'errors') {
@@ -256,6 +259,8 @@ export class REDPanel extends SceneObjectBase<RateMetricsPanelState> {
     const { panel, actions, isStreaming } = model.useState();
     const { value: metric } = getMetricVariable(model).useState();
     const styles = useStyles2(getStyles);
+    const serviceName = useServiceName(model);
+    const exploration = getTraceExplorationScene(model);
 
     if (!panel) {
       return;
@@ -305,6 +310,12 @@ export class REDPanel extends SceneObjectBase<RateMetricsPanelState> {
           </div>
         </div>
         <panel.Component model={panel} />
+        {!exploration.state.embedded && (
+          <InsightsTimelineWidget
+            serviceName={serviceName || ''}
+            model={model}
+          />
+        )}
       </div>
     );
   };

--- a/src/components/Explore/panels/barsPanel.ts
+++ b/src/components/Explore/panels/barsPanel.ts
@@ -2,7 +2,7 @@ import { PanelBuilders } from '@grafana/scenes';
 import { DrawStyle, StackingMode, TooltipDisplayMode } from '@grafana/ui';
 import { MetricFunction } from 'utils/shared';
 
-export const barsPanelConfig = (metric: MetricFunction) => {
+export const barsPanelConfig = (metric: MetricFunction, axisWidth?: number) => {
   const isErrorsMetric = metric === 'errors' || false;
   
   const builder = PanelBuilders.timeseries()
@@ -20,6 +20,10 @@ export const barsPanelConfig = (metric: MetricFunction) => {
       });
     })
     .setOption('tooltip', { mode: TooltipDisplayMode.Multi });
+
+  if (axisWidth !== undefined) {
+    builder.setCustomFieldConfig('axisWidth', axisWidth);
+  }
 
   return builder;
 };

--- a/src/pages/Explore/TraceExploration.tsx
+++ b/src/pages/Explore/TraceExploration.tsx
@@ -301,7 +301,7 @@ export class TraceExplorationScene extends SceneObjectBase {
   };
 }
 
-const useServiceName = (model: SceneObject) => {
+export const useServiceName = (model: SceneObject) => {
   const [serviceName, setServiceName] = React.useState<string>();
   const traceExploration = getTraceExplorationScene(model);
   const filtersVariable = getFiltersVariable(traceExploration);

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -56,7 +56,7 @@
     "grafanaDependency": ">=11.5.0",
     "plugins": [],
     "extensions": {
-      "exposedComponents": ["grafana-asserts-app/entity-assertions-widget/v1"]
+      "exposedComponents": ["grafana-asserts-app/entity-assertions-widget/v1", "grafana-asserts-app/insights-timeline-widget/v1"]
     }
   },
   "extensions": {
@@ -77,6 +77,11 @@
         "targets": ["grafana-asserts-app/entity-assertions-widget/v1"],
         "title": "Asserts widget",
         "description": "A block with assertions for a given service"
+      },
+      {
+        "targets": ["grafana-asserts-app/insights-timeline-widget/v1"],
+        "title": "Insights Timeline Widget",
+        "description": "Widget for displaying insights timeline in other apps"
       }
     ],
     "addedLinks": [


### PR DESCRIPTION
Adds support for the Insights Timeline exposed component from Asserts.

This component allows us to show the insights that correlate to our primary signal in Traces Drilldown, further enhancing our integration with Asserts and strengthening the context available / ease of use for our users.

Accompanying [PR](https://github.com/grafana/asserts-app-plugin/pull/2013) in Asserts.

More details can be found in the [issue](https://github.com/grafana/asserts-app-plugin/issues/1932).

Fixes https://github.com/grafana/asserts-app-plugin/issues/1932

<img width="912" height="628" alt="Screenshot 2025-08-21 at 10 16 57" src="https://github.com/user-attachments/assets/ea766599-7af4-45fb-b191-63a20b232e63" />

<img width="912" height="624" alt="Screenshot 2025-08-21 at 11 05 14" src="https://github.com/user-attachments/assets/4006fcb3-ca51-453e-8d6f-4e2b5d7cf671" />

