### PR TITLE
chore: Support quotes numeric strings

### DIFF
--- a/src/utils/filters-renderer.test.ts
+++ b/src/utils/filters-renderer.test.ts
@@ -108,6 +108,18 @@ describe('filters-renderer', () => {
       });
     });
 
+    describe('quoted numeric handling', () => {
+      it('should not double-quote numeric values already wrapped in double quotes', () => {
+        const filters: AdHocVariableFilter[] = [{ key: 'service.id', operator: '=', value: '"12345"' }];
+        expect(renderTraceQLLabelFilters(filters)).toBe('service.id="12345"');
+      });
+
+      it('should not double-quote numeric values already wrapped in single quotes', () => {
+        const filters: AdHocVariableFilter[] = [{ key: 'service.id', operator: '=', value: "'123.45'" }];
+        expect(renderTraceQLLabelFilters(filters)).toBe("service.id='123.45'");
+      });
+    });
+
     describe('string handling', () => {
       it('should escape quotes and backslashes in queries', () => {
         const filters: AdHocVariableFilter[] = [{ key: 'name', operator: '=', value: 'some "query" \\ ' }];

--- a/src/utils/filters-renderer.ts
+++ b/src/utils/filters-renderer.ts
@@ -43,5 +43,5 @@ function isNumber(value?: string | number): boolean {
 }
 
 function isQuotedNumericString(value: string): boolean {
-  return typeof value === 'string' && isNumber(value.slice(1, -1)) && (value.startsWith('"') || value.startsWith("'")) && (value.endsWith('"') || value.endsWith("'"));
+  return typeof value === 'string' && value.length >= 2 && isNumber(value.slice(1, -1)) && (value.startsWith('"') || value.startsWith("'")) && (value.endsWith('"') || value.endsWith("'"));
 }

--- a/src/utils/filters-renderer.ts
+++ b/src/utils/filters-renderer.ts
@@ -25,7 +25,8 @@ function renderFilter(filter: AdHocVariableFilter) {
         'trace:duration',
         'event:timeSinceStart',
       ].includes(filter.key) &&
-      !['true', 'false'].includes(val))
+      !['true', 'false'].includes(val)) &&
+      !isQuotedNumericString(val)
   ) {
     if (typeof val === 'string') {
       // Escape " and \ to \" and \\ respectively
@@ -39,4 +40,8 @@ function renderFilter(filter: AdHocVariableFilter) {
 
 function isNumber(value?: string | number): boolean {
   return value != null && value !== '' && !isNaN(Number(value.toString().trim()));
+}
+
+function isQuotedNumericString(value: string): boolean {
+  return typeof value === 'string' && isNumber(value.slice(1, -1)) && (value.startsWith('"') || value.startsWith("'")) && (value.endsWith('"') || value.endsWith("'"));
 }


### PR DESCRIPTION
Allow the user to override of tag number value, by typing the value with quotes and not removing those quotes when building the query.

Fixes https://github.com/grafana/traces-drilldown/issues/546