### PR TITLE
chore: Import types for InsightsTimelineWidget & EntityAssertionsWidget

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@grafana/eslint-config": "^8.0.0",
     "@grafana/plugin-e2e": "^2.1.7",
     "@grafana/tsconfig": "^2.0.0",
+    "@grafana/plugin-types": "0.0.39",
     "@playwright/test": "^1.52.0",
     "@stylistic/eslint-plugin-ts": "^4.2.0",
     "@swc/core": "^1.9.2",

--- a/src/addedComponents/EntityAssertionsWidget/EntityAssertionsWidget.tsx
+++ b/src/addedComponents/EntityAssertionsWidget/EntityAssertionsWidget.tsx
@@ -1,21 +1,9 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 
 import { TimeRange } from '@grafana/data';
-import { ComponentSize } from '@grafana/ui';
+import { EntityAssertionsWidgetProps } from "@grafana/plugin-types/grafana-asserts-app/"
 import { usePluginComponent } from '@grafana/runtime';
 import { sceneGraph, SceneObject } from '@grafana/scenes';
-
-interface EntityAssertionsWidgetProps {
-  query: {
-    entityName?: string;
-    entityType?: string;
-    start: number;
-    end: number;
-  };
-  size: ComponentSize;
-  source?: string;
-  returnToPrevious?: boolean;
-}
 
 export type EntityAssertionsWidgetExternal = (props: EntityAssertionsWidgetProps) => ReactElement | null;
 
@@ -56,6 +44,7 @@ export function EntityAssertionsWidget({ serviceName, model }: Props) {
         end: timeRange.to.valueOf(),
         entityName: serviceName,
         entityType: 'Service',
+        enabled: true,
       }}
       returnToPrevious={true}
     />

--- a/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
+++ b/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
@@ -3,21 +3,13 @@ import React, { ReactElement } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { usePluginComponent } from '@grafana/runtime';
 import { sceneGraph, SceneObject } from '@grafana/scenes';
+import { InsightsTimelineWidgetProps } from "@grafana/plugin-types/grafana-asserts-app/"
 import { css } from '@emotion/css';
 import { useStyles2 } from '@grafana/ui';
 import { getMetricVariable } from 'utils/utils';
 import { MetricFunction } from 'utils/shared';
 
 export type AssertionSeverity = 'warning' | 'critical' | 'info';
-
-interface InsightsTimelineWidgetProps {
-  serviceName: string;
-  start: string | number;
-  end: string | number;
-  filterBySeverity?: AssertionSeverity[];
-  filterBySummaryKeywords?: string[];
-  label?: ReactElement;
-}
 
 export type InsightsTimelineWidgetExternal = (props: InsightsTimelineWidgetProps) => ReactElement | null;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1195,6 +1195,11 @@
     uuid "^11.0.2"
     yaml "^2.3.4"
 
+"@grafana/plugin-types@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@grafana/plugin-types/-/plugin-types-0.0.39.tgz#ef76e2f2bc27e3ab9e66d66dc60eff80bdbaab91"
+  integrity sha512-OeSTqFFPQtdGdeRWbTMlvGz2J6VWEhOdv+WiqMTaa7AjHWahmEE3aB6AJL6zlDd8MqFW7M8qNGkui/s1tnlUFQ==
+
 "@grafana/runtime@^12.1.0":
   version "12.1.0"
   resolved "https://registry.yarnpkg.com/@grafana/runtime/-/runtime-12.1.0.tgz#f8c28fc508a286a1425a0c38bc827cf8fe29baee"


### PR DESCRIPTION
Export types from this https://github.com/grafana/asserts-app-plugin/pull/2013 and import for component added in this https://github.com/grafana/traces-drilldown/pull/543 so that we do not have duplicated types defined in two places.

Fixes https://github.com/grafana/traces-drilldown/issues/551

