### PR TITLE
chore: Remove the locked filters

### DIFF
--- a/src/pages/Explore/AttributeFiltersVariable.tsx
+++ b/src/pages/Explore/AttributeFiltersVariable.tsx
@@ -5,15 +5,9 @@ import { renderTraceQLLabelFilters } from 'utils/filters-renderer';
 
 export interface AttributeFiltersVariableProps {
   initialFilters?: AdHocVariableFilter[];
-  embedderName?: string;
-  embedded?: boolean;
 }
 
 export class AttributeFiltersVariable extends AdHocFiltersVariable {
-  private initialFilters?: AdHocVariableFilter[];
-  private embedderName?: string;
-  private embedded?: boolean;
-
   constructor(props: Partial<AttributeFiltersVariableProps>) {
     super({
       addFilterButtonText: 'Add filter',
@@ -21,49 +15,9 @@ export class AttributeFiltersVariable extends AdHocFiltersVariable {
       datasource: explorationDS,
       hide: VariableHide.hideLabel,
       layout: 'combobox',
-      filters: (props.initialFilters ?? []).map((f) => ({
-        ...f,
-        readOnly: props.embedded,
-        origin: props.embedderName,
-      })),
+      filters: props.initialFilters ?? [],
       allowCustomValue: true,
       expressionBuilder: renderTraceQLLabelFilters,
-    });
-
-    this.initialFilters = props.initialFilters;
-    this.embedderName = props.embedderName;
-    this.embedded = props.embedded;
-
-    // Subscribe to state changes to update readOnly and origin for matching filters
-    this.subscribeToState((newState) => {
-      if (newState.filters && this.embedded) {
-        let hasChanges = false;
-        const updatedFilters = newState.filters.map((filter) => {
-          // Check if this filter matches any of the initial filters
-          const matchingInitialFilter = this.initialFilters?.find(
-            (initialFilter) =>
-              initialFilter.key === filter.key &&
-              initialFilter.operator === filter.operator &&
-              initialFilter.value === filter.value
-          );
-
-          if (matchingInitialFilter && !filter.readOnly && filter.origin !== this.embedderName) {
-            hasChanges = true;
-            return {
-              ...filter,
-              readOnly: true,
-              origin: this.embedderName,
-            };
-          }
-
-          return filter;
-        });
-
-        // Only update if there are actual changes
-        if (hasChanges) {
-          this.setState({ filters: updatedFilters });
-        }
-      }
     });
   }
 }

--- a/src/pages/Explore/TraceExploration.tsx
+++ b/src/pages/Explore/TraceExploration.tsx
@@ -491,8 +491,6 @@ function getVariableSet(state: TraceExplorationState) {
       }),
       new AttributeFiltersVariable({
         initialFilters: state.initialFilters,
-        embedderName: state.embedderName,
-        embedded: state.embedded,
       }),
       new CustomVariable({
         name: VAR_METRIC,


### PR DESCRIPTION
Removed the locked filters in asserts so that users can update their filters as sometimes the filters are too specific to see any results or users would like to modify them. 

Before 
<img width="226" height="39" alt="Screenshot 2025-09-24 at 09 00 33" src="https://github.com/user-attachments/assets/bae3dd14-1f91-40d5-89b9-1a7174cdc5b6" />

After
<img width="232" height="50" alt="Screenshot 2025-09-24 at 09 00 37" src="https://github.com/user-attachments/assets/190b0623-da18-4ed7-acb8-8184b163e0c4" />
