### PR TITLE
chore: add annotation topic to annotation frame

### DIFF
--- a/src/components/Explore/TracesByService/REDPanel.tsx
+++ b/src/components/Explore/TracesByService/REDPanel.tsx
@@ -10,17 +10,17 @@ import {
   SceneObjectBase,
   SceneObjectState,
 } from '@grafana/scenes';
-import {arrayToDataFrame, DataFrame, DataTopic, GrafanaTheme2, LoadingState} from '@grafana/data';
-import {ComparisonSelection, EMPTY_STATE_ERROR_MESSAGE, explorationDS, MetricFunction} from 'utils/shared';
-import {EmptyStateScene} from 'components/states/EmptyState/EmptyStateScene';
-import {LoadingStateScene} from 'components/states/LoadingState/LoadingStateScene';
-import {SkeletonComponent} from '../ByFrameRepeater';
-import {barsPanelConfig} from '../panels/barsPanel';
-import {getMetricsTempoQuery} from '../queries/generateMetricsQuery';
-import {StepQueryRunner} from '../queries/StepQueryRunner';
-import {css} from '@emotion/css';
-import {RadioButtonList, useStyles2} from '@grafana/ui';
-import {StreamingIndicator} from '../StreamingIndicator';
+import { arrayToDataFrame, DataFrame, GrafanaTheme2, LoadingState, DataTopic } from '@grafana/data';
+import { ComparisonSelection, EMPTY_STATE_ERROR_MESSAGE, explorationDS, MetricFunction } from 'utils/shared';
+import { EmptyStateScene } from 'components/states/EmptyState/EmptyStateScene';
+import { LoadingStateScene } from 'components/states/LoadingState/LoadingStateScene';
+import { SkeletonComponent } from '../ByFrameRepeater';
+import { barsPanelConfig } from '../panels/barsPanel';
+import { getMetricsTempoQuery } from '../queries/generateMetricsQuery';
+import { StepQueryRunner } from '../queries/StepQueryRunner';
+import { css } from '@emotion/css';
+import { RadioButtonList, useStyles2 } from '@grafana/ui';
+import { StreamingIndicator } from '../StreamingIndicator';
 import {
   fieldHasEmptyValues,
   getLatencyPartialThresholdVariable,
@@ -30,15 +30,15 @@ import {
   getTraceByServiceScene,
   shouldShowSelection,
 } from '../../../utils/utils';
-import {getHistogramVizPanel, yBucketToDuration} from '../panels/histogram';
-import {TraceSceneState} from './TracesByServiceScene';
-import {SelectionColor} from '../layouts/allComparison';
-import {buildHistogramQuery} from '../queries/histogram';
-import {isEqual} from 'lodash';
-import {DurationComparisonControl} from './DurationComparisonControl';
-import {exemplarsTransformations, removeExemplarsTransformation} from '../../../utils/exemplars';
-import {InsightsTimelineWidget} from 'addedComponents/InsightsTimelineWidget/InsightsTimelineWidget';
-import {useServiceName} from 'pages/Explore/TraceExploration';
+import { getHistogramVizPanel, yBucketToDuration } from '../panels/histogram';
+import { TraceSceneState } from './TracesByServiceScene';
+import { SelectionColor } from '../layouts/allComparison';
+import { buildHistogramQuery } from '../queries/histogram';
+import { isEqual } from 'lodash';
+import { DurationComparisonControl } from './DurationComparisonControl';
+import { exemplarsTransformations, removeExemplarsTransformation } from '../../../utils/exemplars';
+import { InsightsTimelineWidget } from 'addedComponents/InsightsTimelineWidget/InsightsTimelineWidget';
+import { useServiceName } from 'pages/Explore/TraceExploration';
 
 export interface RateMetricsPanelState extends SceneObjectState {
   panel?: SceneFlexLayout;


### PR DESCRIPTION
Annotation frames require a dataTopic to differentiate them from time series frames. While this isn't currently a problem, it will be when annotations are mixed in with series frames in the transformation pipeline.

I will make sure we add backward compatibility in [multi annotation-lanes](https://github.com/grafana/grafana/pull/111559/files#diff-f159dadb766058b13727eae083dc2e80376436a72ac5ca9903ee15d0b3218e31R18) to avoid breaking changes in older versions of Traces Drilldown.