### PR TITLE
chore: Reduce renders for InsightsTimelineWidget

### DIFF
--- a/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
+++ b/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
@@ -1,12 +1,10 @@
-import React, { ReactElement } from 'react';
+import React, { memo, ReactElement } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { usePluginComponent } from '@grafana/runtime';
-import { sceneGraph, SceneObject } from '@grafana/scenes';
 import { InsightsTimelineWidgetProps } from "@grafana/plugin-types/grafana-asserts-app/"
 import { css } from '@emotion/css';
 import { useStyles2 } from '@grafana/ui';
-import { getMetricVariable } from 'utils/utils';
 import { MetricFunction } from 'utils/shared';
 
 export type AssertionSeverity = 'warning' | 'critical' | 'info';
@@ -15,17 +13,16 @@ export type InsightsTimelineWidgetExternal = (props: InsightsTimelineWidgetProps
 
 interface Props {
   serviceName: string;
-  model: SceneObject;
+  metric: MetricFunction;
+  startTime: string;
+  endTime: string;
 }
 
-export function InsightsTimelineWidget({ serviceName, model }: Props) {
-  const { isLoading, component: InsightsTimelineWidgetExternal } = usePluginComponent<InsightsTimelineWidgetProps>(
+export const InsightsTimelineWidget = memo(function InsightsTimelineWidget({ serviceName, metric, startTime, endTime }: Props) {  const { isLoading, component: InsightsTimelineWidgetExternal } = usePluginComponent<InsightsTimelineWidgetProps>(
     'grafana-asserts-app/insights-timeline-widget/v1'
   );
   const styles = useStyles2(getStyles);
-  const sceneTimeRange = sceneGraph.getTimeRange(model).useState();
-
-  const metric = getMetricVariable(model).state.value as MetricFunction;
+  
   let filterBySeverity: AssertionSeverity[] = [];
   if (metric === 'errors') {
     filterBySeverity = ['critical', 'warning'];
@@ -38,21 +35,21 @@ export function InsightsTimelineWidget({ serviceName, model }: Props) {
     filterBySummaryKeywords = ['latency'];
   }
 
-  if (isLoading || !InsightsTimelineWidgetExternal || !sceneTimeRange || !serviceName) {
+  if (isLoading || !InsightsTimelineWidgetExternal || !serviceName) {
     return null;
   }
 
   return (
     <InsightsTimelineWidgetExternal
-      serviceName={serviceName}
-      start={sceneTimeRange.from.valueOf()}
-      end={sceneTimeRange.to.valueOf()}
+      serviceName={serviceName}      
+      start={startTime}
+      end={endTime}
       filterBySeverity={filterBySeverity}
       filterBySummaryKeywords={filterBySummaryKeywords}
       label={<div className={styles.label}>Insights</div>}
     />
   );
-}
+});
 
 function getStyles(theme: GrafanaTheme2) {
   return {

--- a/src/components/Explore/TracesByService/REDPanel.tsx
+++ b/src/components/Explore/TracesByService/REDPanel.tsx
@@ -263,6 +263,7 @@ export class REDPanel extends SceneObjectBase<RateMetricsPanelState> {
     const { value: metric } = getMetricVariable(model).useState();
     const styles = useStyles2(getStyles);
     const serviceName = useServiceName(model);
+    const timeRange = sceneGraph.getTimeRange(model).useState();
 
     if (!panel) {
       return;
@@ -312,10 +313,14 @@ export class REDPanel extends SceneObjectBase<RateMetricsPanelState> {
           </div>
         </div>
         <panel.Component model={panel} />
-        <InsightsTimelineWidget
-          serviceName={serviceName || ''}
-          model={model}
-        />
+        {timeRange && (
+          <InsightsTimelineWidget
+            serviceName={serviceName || ''}           
+            metric={metric as MetricFunction}
+            startTime={timeRange.from.valueOf()}
+            endTime={timeRange.to.valueOf()}
+          />
+        )}
       </div>
     );
   };


### PR DESCRIPTION
Reduces renders by passing in time range and metric rather than the whole model