### PR TITLE
chore: fix description casing in exposeComponent

### DIFF
--- a/src/module.tsx
+++ b/src/module.tsx
@@ -19,7 +19,7 @@ export const plugin = new AppPlugin<{}>()
   .exposeComponent({
     id: 'grafana-exploretraces-app/open-in-explore-traces-button/v1',
     title: 'Open in Traces Drilldown button',
-    description: 'A button that opens a traces view in the Traces drilldown app.',
+    description: 'A button that opens a traces view in the Traces Drilldown app.',
     component: SuspendedOpenInExploreTracesButton as React.ComponentType<OpenInExploreTracesButtonProps>,
   })
   .exposeComponent({


### PR DESCRIPTION
Descriptions don't match (lowercase vs capitalize Drilldown) causing a warning in the browser console.

More details in https://raintank-corp.slack.com/archives/C075BDBTX96/p1763444641091179