### PR TITLE
chore: Fix attributes sidebar test warnings

### DIFF
--- a/src/components/Explore/AttributesSidebar.test.tsx
+++ b/src/components/Explore/AttributesSidebar.test.tsx
@@ -5,6 +5,12 @@ import { AttributesSidebar } from './AttributesSidebar';
 import { SelectableValue } from '@grafana/data';
 import { AdHocFiltersVariable, SceneObject } from '@grafana/scenes';
 
+// Mock react-inlinesvg to prevent async state updates during tests
+jest.mock('react-inlinesvg', () => ({
+  __esModule: true,
+  default: ({ src, innerRef, ...props }: any) => React.createElement('span', { 'data-testid': 'mocked-svg', ...props }),
+}));
+
 // Mock the hooks and utilities
 jest.mock('hooks', () => ({
   useFavoriteAttributes: jest.fn(() => ({


### PR DESCRIPTION
When running tests locally I noticed a bunch of tests printing warnings in the attributes sidebar because of `react-inlinesvg` causing async updates.

<img width="1030" height="774" alt="Screenshot 2025-11-25 at 09 41 50" src="https://github.com/user-attachments/assets/d30cab60-f54e-4cf6-930f-4d42bd82b111" />
