### PR TITLE
feat: Send filters to EntityAssertionsWidget

### DIFF
--- a/src/addedComponents/EntityAssertionsWidget/EntityAssertionsWidget.tsx
+++ b/src/addedComponents/EntityAssertionsWidget/EntityAssertionsWidget.tsx
@@ -51,10 +51,6 @@ export function EntityAssertionsWidget({ serviceName, model }: Props) {
     };
   }, [model]);
 
-  if (isLoading || !EntityAssertionsWidgetExternal || !timeRange) {
-    return null;
-  }
-
   // Convert AdHocVariableFilter to EntityFilterPropertyMatcher format for additionalMatchers
   const additionalMatchers: EntityFilterPropertyMatcher[] = useMemo(() => {
     return filters
@@ -67,6 +63,10 @@ export function EntityAssertionsWidget({ serviceName, model }: Props) {
         type: 'String' as EntityPropertyTypes,
       }));
   }, [filters]);
+
+  if (isLoading || !EntityAssertionsWidgetExternal || !timeRange) {
+    return null;
+  }
 
   return (
     <EntityAssertionsWidgetExternal


### PR DESCRIPTION
Adds the Traces Drilldown filters to the query for the EntityAssertionsWidget.

Uses the Traces config in Asserts to map the labels.

Equivalent Asserts [PR](https://github.com/grafana/asserts-app-plugin/pull/2504).
Fixes: https://github.com/grafana/traces-drilldown/issues/601

<img width="947" height="661" alt="Screenshot 2026-01-15 at 16 20 00" src="https://github.com/user-attachments/assets/0ccef269-bb97-4248-bee3-b406cdcd1a5c" />

<img width="667" height="754" alt="Screenshot 2026-01-15 at 16 20 12" src="https://github.com/user-attachments/assets/403d95a9-09a0-4c60-adcd-34a237531fd7" />
