### PR TITLE
docs: Fix missing periods in docs

### DIFF
--- a/docs/sources/determine-use-case/index.md
+++ b/docs/sources/determine-use-case/index.md
@@ -44,34 +44,34 @@ You might have noticed:
 
 ### How to start
 
-1. Select **Errors** as your metric type
-2. Start with **Root spans** to see service-level error patterns
-3. Use the **Comparison** tab to identify which attributes correlate with errors
-4. Use the **Breakdown** tab to see which services or operations have the most errors
-5. Use the **Exceptions** tab to find common error messages
-6. Use **Root cause errors** to see the error chain structure
+1. Select **Errors** as your metric type.
+2. Start with **Root spans** to see service-level error patterns.
+3. Use the **Comparison** tab to identify which attributes correlate with errors.
+4. Use the **Breakdown** tab to see which services or operations have the most errors.
+5. Use the **Exceptions** tab to find common error messages.
+6. Use **Root cause errors** to see the error chain structure.
 
 **When to switch to All spans**: If you need to find errors deeper in the call chain, like database errors or downstream service failures that don't appear at the root level, switch to **All spans**.
 
 ### Example scenarios
 
 **You know a service is failing but not why**: 
-1. Select **Errors** metric and **Root spans**
-2. Filter by the service name
-3. Use **Comparison** to see which attributes differ between successful and failed requests
-4. Use **Root cause errors** to see the error chain structure
+1. Select **Errors** metric and **Root spans**.
+2. Filter by the service name.
+3. Use **Comparison** to see which attributes differ between successful and failed requests.
+4. Use **Root cause errors** to see the error chain structure.
 
 **You see error alerts but don't know the source**: 
-1. Select **Errors** metric and **Root spans**
-2. Use **Breakdown** to see which services have the most errors
-3. Drill into the problematic service using filters
-4. Use **Comparison** to identify what's different about the failing requests
+1. Select **Errors** metric and **Root spans**.
+2. Use **Breakdown** to see which services have the most errors.
+3. Drill into the problematic service using filters.
+4. Use **Comparison** to identify what's different about the failing requests.
 
 **You need to find internal errors**: 
-1. Start with **Errors** metric and **Root spans** to see service-level patterns
-2. If errors don't appear at the root level, switch to **All spans**
-3. This reveals database errors, downstream service failures, or internal operation errors
-4. Use **Exceptions** to find common error messages
+1. Start with **Errors** metric and **Root spans** to see service-level patterns.
+2. If errors don't appear at the root level, switch to **All spans**.
+3. This reveals database errors, downstream service failures, or internal operation errors.
+4. Use **Exceptions** to find common error messages.
 
 ## Use case 2: Analyze performance
 
@@ -85,35 +85,35 @@ You might be investigating:
 
 ### How to start
 
-1. Select **Duration** as your metric type
-2. Start with **Root spans** for end-to-end request latency
-3. Use the duration heatmap to identify latency patterns
-4. Select percentiles (p90, p95, p99) based on your SLA requirements
-5. Use **Root cause latency** to see which operations are slowest
-6. Use **Slow traces** to examine individual slow requests
-7. Use **Breakdown** to see duration by different attributes like service, environment, or region
+1. Select **Duration** as your metric type.
+2. Start with **Root spans** for end-to-end request latency.
+3. Use the duration heatmap to identify latency patterns.
+4. Select percentiles (p90, p95, p99) based on your SLA requirements.
+5. Use **Root cause latency** to see which operations are slowest.
+6. Use **Slow traces** to examine individual slow requests.
+7. Use **Breakdown** to see duration by different attributes like service, environment, or region.
 
 **When to switch to All spans**: If you need to find slow internal operations like database queries or background jobs that don't appear at the root level, switch to **All spans**.
 
 ### Example scenarios
 
 **Users report slow responses**: 
-1. Select **Duration** metric and **Root spans**
-2. Look at the heatmap for latency spikes
-3. Use **Root cause latency** to see which service operations are causing delays
-4. Use **Slow traces** to examine individual slow requests
+1. Select **Duration** metric and **Root spans**.
+2. Look at the heatmap for latency spikes.
+3. Use **Root cause latency** to see which service operations are causing delays.
+4. Use **Slow traces** to examine individual slow requests.
 
 **You want to optimize a specific endpoint**: 
-1. Select **Duration** metric and **Root spans**
-2. Add filters for the endpoint
-3. Use **Breakdown** to see duration by different attributes like service, environment, or region
-4. Select appropriate percentiles (p90, p95, p99) based on your optimization goals
+1. Select **Duration** metric and **Root spans**.
+2. Add filters for the endpoint.
+3. Use **Breakdown** to see duration by different attributes like service, environment, or region.
+4. Select appropriate percentiles (p90, p95, p99) based on your optimization goals.
 
 **You need to find slow database queries**: 
-1. Select **Duration** metric and **All spans** (database queries appear as child spans)
-2. Filter by database-related attributes
-3. Use **Breakdown** to see which queries are slowest
-4. Examine the slowest spans in **Slow traces** to identify problematic queries
+1. Select **Duration** metric and **All spans** (database queries appear as child spans).
+2. Filter by database-related attributes.
+3. Use **Breakdown** to see which queries are slowest.
+4. Examine the slowest spans in **Slow traces** to identify problematic queries.
 
 ## Use case 3: Monitor activity
 
@@ -127,53 +127,53 @@ You might want to:
 
 ### How to start
 
-1. Select **Rate** as your metric type
-2. Start with **Root spans** for service-level request rates
-3. Use **Service structure** to visualize service-to-service communication
-4. Use **Breakdown** to see request rates by different attributes
-5. Use **Comparison** to identify unusual patterns compared to baseline
-6. Use **Traces** tab to examine individual requests
+1. Select **Rate** as your metric type.
+2. Start with **Root spans** for service-level request rates.
+3. Use **Service structure** to visualize service-to-service communication.
+4. Use **Breakdown** to see request rates by different attributes.
+5. Use **Comparison** to identify unusual patterns compared to baseline.
+6. Use **Traces** tab to examine individual requests.
 
 **When to switch to All spans**: If you need to see internal operations or child spans within traces, switch to **All spans**. Most activity monitoring use cases work well with **Root spans**.
 
 ### Example scenarios
 
 **You want to understand service dependencies**: 
-1. Select **Rate** metric and **Root spans**
-2. Use **Service structure** to see how services call each other
-3. Identify the communication patterns and dependencies
-4. Use **Traces** to examine individual request flows
+1. Select **Rate** metric and **Root spans**.
+2. Use **Service structure** to see how services call each other.
+3. Identify the communication patterns and dependencies.
+4. Use **Traces** to examine individual request flows.
 
 **You notice unusual activity spikes**: 
-1. Select **Rate** metric and **Root spans**
-2. Use **Breakdown** to see which services or operations have increased rates
-3. Use **Comparison** to compare against normal baseline behavior
-4. Switch to **Errors** or **Duration** if the spike indicates problems
+1. Select **Rate** metric and **Root spans**.
+2. Use **Breakdown** to see which services or operations have increased rates.
+3. Use **Comparison** to compare against normal baseline behavior.
+4. Switch to **Errors** or **Duration** if the spike indicates problems.
 
 **You're doing capacity planning**: 
-1. Select **Rate** metric and **Root spans**
-2. Use **Breakdown** by service, environment, or region
-3. Understand request distribution patterns
-4. Use **Service structure** to see communication volumes between services
+1. Select **Rate** metric and **Root spans**.
+2. Use **Breakdown** by service, environment, or region.
+3. Understand request distribution patterns.
+4. Use **Service structure** to see communication volumes between services.
 
 ## Choose your starting point
 
 Your starting point depends on what you already know:
 
 **You know what's wrong**: 
-- Errors present → Start with **Errors** metric and **Root spans**
-- Performance issues → Start with **Duration** metric and **Root spans**
-- Specific service affected → Add a filter for that service first, then select the appropriate metric
+- Errors present → Start with **Errors** metric and **Root spans**.
+- Performance issues → Start with **Duration** metric and **Root spans**.
+- Specific service affected → Add a filter for that service first, then select the appropriate metric.
 
 **You need to explore**: 
-- Start with **Rate** metric and **Root spans** to get an overview
-- Look for unusual patterns in the graphs
-- Switch to **Errors** or **Duration** based on what you find
+- Start with **Rate** metric and **Root spans** to get an overview.
+- Look for unusual patterns in the graphs.
+- Switch to **Errors** or **Duration** based on what you find.
 
 **You're doing proactive analysis**: 
-- Start with **Rate** metric and **Root spans** to understand normal patterns
-- Use **Comparison** to identify deviations from baseline
-- Switch to **Errors** or **Duration** when you find areas of concern
+- Start with **Rate** metric and **Root spans** to understand normal patterns.
+- Use **Comparison** to identify deviations from baseline.
+- Switch to **Errors** or **Duration** when you find areas of concern.
 
 ## Related concepts
 
@@ -184,7 +184,7 @@ Your starting point depends on what you already know:
 
 After you've determined your use case:
 
-- [Choose a RED metric](../investigate/choose-red-metric/) to match your investigation goal
-- [Choose root or full span data](../investigate/choose-span-data/) based on the depth you need
-- [Analyze tracing data](../investigate/analyze-tracing-data/) using the appropriate tabs for your metric type
-- [Add filters](../investigate/add-filters/) to refine your investigation as you discover patterns
+- [Choose a RED metric](../investigate/choose-red-metric/) to match your investigation goal.
+- [Choose root or full span data](../investigate/choose-span-data/) based on the depth you need.
+- [Analyze tracing data](../investigate/analyze-tracing-data/) using the appropriate tabs for your metric type.
+- [Add filters](../investigate/add-filters/) to refine your investigation as you discover patterns.

--- a/docs/sources/get-started/example-investigation.md
+++ b/docs/sources/get-started/example-investigation.md
@@ -66,7 +66,7 @@ Refer to [Choose root or full span data](../../investigate/choose-span-data/) fo
 1. The **span timeline** shows the sequence of operations:
    - Parent spans (for example, `frontend GET /api/quotes`)
    - Child spans (for example, `HTTP GET`)
-   - Error spans are highlighted in red/orange
+   - Error spans are highlighted in red/orange.
 1. Use the **Filters** to focus on:
    - **Critical path**: The slowest path through the trace
    - **Errors**: Only spans with errors
@@ -86,10 +86,10 @@ Refer to [Choose root or full span data](../../investigate/choose-span-data/) fo
 
 By following this walkthrough, you learned how to:
 
-- Navigate Traces Drilldown and select the **Errors** metric
-- View errored traces in a table format
-- Examine individual trace details
-- Use **Breakdown** to identify error patterns
+- Navigate Traces Drilldown and select the **Errors** metric.
+- View errored traces in a table format.
+- Examine individual trace details.
+- Use **Breakdown** to identify error patterns.
 
 For more advanced investigation techniques like using the **Comparison** tab and **Inspect** feature, refer to the [Example: Investigate source of errors](../../get-started/#example-investigate-source-of-errors) section.
 
@@ -97,8 +97,8 @@ For more advanced investigation techniques like using the **Comparison** tab and
 
 Now that you've completed the basic walkthrough:
 
-- [Determine your use case](../../determine-use-case/) to choose the right investigation approach
-- [Choose a RED metric](../../investigate/choose-red-metric/) to guide what you analyze next
-- [Add filters](../../investigate/add-filters/) to refine the scope of your investigation
-- [Analyze tracing data](../../investigate/analyze-tracing-data/) with Breakdown, Comparison, and Root cause views
-- [Choose root or full span data](../../investigate/choose-span-data/) depending on your use case
+- [Determine your use case](../../determine-use-case/) to choose the right investigation approach.
+- [Choose a RED metric](../../investigate/choose-red-metric/) to guide what you analyze next.
+- [Add filters](../../investigate/add-filters/) to refine the scope of your investigation.
+- [Analyze tracing data](../../investigate/analyze-tracing-data/) with Breakdown, Comparison, and Root cause views.
+- [Choose root or full span data](../../investigate/choose-span-data/) depending on your use case.


### PR DESCRIPTION
Fixes missing periods in two docs: investigation example and workflow. 