### PR TITLE
feat: display service.namespace alongside service.name

### DIFF
--- a/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionUtils.ts
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionUtils.ts
@@ -4,7 +4,7 @@ import { SceneObject } from "@grafana/scenes";
 import { calculateBucketSize } from "utils/dates";
 import { getDatasourceVariable } from "utils/utils";
 
-export function aggregateExceptions(messageField: Field<string>, typeField?: Field<string>, timeField?: Field<number>, serviceField?: Field<string>) {
+export function aggregateExceptions(messageField: Field<string>, typeField?: Field<string>, timeField?: Field<number>, serviceField?: Field<string>, serviceNamespaceField?: Field<string>) {
   const occurrences = new Map<string, number>();
   const types = new Map<string, string>();
   const lastSeenTimes = new Map<string, number>();
@@ -19,17 +19,19 @@ export function aggregateExceptions(messageField: Field<string>, typeField?: Fie
     const type = typeField?.values[i];
     const timestamp = timeField?.values[i];
     const service = serviceField?.values[i];
-    
+    const serviceNamespace = serviceNamespaceField?.values[i];
+    const displayService = serviceNamespace ? `${serviceNamespace}/${service}` : service;
+
     if (message) {
       const normalizedMessage = normalizeExceptionMessage(message);
       occurrences.set(normalizedMessage, (occurrences.get(normalizedMessage) || 0) + 1);
-      
+
       if (!types.has(normalizedMessage) && type) {
         types.set(normalizedMessage, type);
       }
 
-      if (!services.has(normalizedMessage) && service) {
-        services.set(normalizedMessage, service);
+      if (!services.has(normalizedMessage) && displayService) {
+        services.set(normalizedMessage, displayService);
       }
 
       if (timestamp) {

--- a/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionsScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionsScene.tsx
@@ -128,13 +128,14 @@ export class ExceptionsScene extends SceneObjectBase<ExceptionsSceneState> {
     const messageField = df.fields.find((f) => f.name === 'exception.message');
     const typeField = df.fields.find((f) => f.name === 'exception.type');
     const serviceField = df.fields.find((f) => f.name === 'service.name');
+    const serviceNamespaceField = df.fields.find((f) => f.name === 'service.namespace');
     const timeField = df.fields.find((f) => f.name === 'time');
 
     if (!messageField || !messageField.values.length) {
       return [];
     }
 
-    const aggregated = aggregateExceptions(messageField, typeField, timeField, serviceField);
+    const aggregated = aggregateExceptions(messageField, typeField, timeField, serviceField, serviceNamespaceField);
 
     return aggregated.messages.map((message, index) => ({
       type: aggregated.types[index] || 'Unknown',

--- a/src/components/Explore/TracesByService/Tabs/Structure/StructureScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Structure/StructureScene.tsx
@@ -107,7 +107,7 @@ export class StructureTabScene extends SceneObjectBase<ServicesTabSceneState> {
     const openTrace = getOpenTrace(this);
 
     return PanelBuilders.traces()
-      .setTitle(`Structure for ${tree.serviceName} [${countSpans(tree)} spans used]`)
+      .setTitle(`Structure for ${tree.serviceNamespace ? `${tree.serviceNamespace}/${tree.serviceName}` : tree.serviceName} [${countSpans(tree)} spans used]`)
       .setOption('createFocusSpanLink' as any, (traceId: string, spanId: string): LinkModel<Field> => {
         return {
           title: 'Open trace',
@@ -219,7 +219,7 @@ export class StructureTabScene extends SceneObjectBase<ServicesTabSceneState> {
         traceID: node.traceID,
         spanID: node.spans[0].spanID,
         parentSpanId: spanID,
-        serviceName: node.serviceName,
+        serviceName: node.serviceNamespace ? `${node.serviceNamespace}/${node.serviceName}` : node.serviceName,
         operationName: node.operationName,
         statusCode: erroredSpans > 0 ? 2 /*error*/ : 0 /*unset*/,
         duration: node.spans.reduce((acc, c) => acc + parseInt(c.durationNanos, 10), 0) / node.spans.length / 1000000,
@@ -368,7 +368,7 @@ function buildQuery(metric: MetricFunction) {
 
   // ({${rootSelectors}} &>> { ${metricQuery} }) # finds trees of spans in error or with high duration
   //    || ({${rootSelectors}})                  # finds single spans in error or with high duration
-  const query = `({${rootSelectors}} &>> { ${metricQuery} }) || ({${rootSelectors}}) | select(status, resource.service.name, name, nestedSetParent, nestedSetLeft, nestedSetRight)`;
+  const query = `({${rootSelectors}} &>> { ${metricQuery} }) || ({${rootSelectors}}) | select(status, resource.service.name, resource.service.namespace, name, nestedSetParent, nestedSetLeft, nestedSetRight)`;
 
   return {
     refId: 'A',

--- a/src/components/Explore/queries/exceptions.ts
+++ b/src/components/Explore/queries/exceptions.ts
@@ -3,7 +3,7 @@ import { VAR_FILTERS_EXPR } from 'utils/shared';
 export function buildExceptionsQuery() {
   return {
     refId: 'A',
-    query: `{${VAR_FILTERS_EXPR} && status = error} | select(resource.service.name, event.exception.message,event.exception.stacktrace,event.exception.type) with(most_recent=true)`,
+    query: `{${VAR_FILTERS_EXPR} && status = error} | select(resource.service.name, resource.service.namespace, event.exception.message,event.exception.stacktrace,event.exception.type) with(most_recent=true)`,
     queryType: 'traceql',
     tableType: 'spans',
     limit: 400,

--- a/src/components/Explore/queries/queries.test.ts
+++ b/src/components/Explore/queries/queries.test.ts
@@ -111,7 +111,7 @@ describe('buildExceptionsQuery', () => {
     expect(query).toEqual({
       refId: 'A',
       query:
-        '{${primarySignal} && ${filters} && status = error} | select(resource.service.name, event.exception.message,event.exception.stacktrace,event.exception.type) with(most_recent=true)',
+        '{${primarySignal} && ${filters} && status = error} | select(resource.service.name, resource.service.namespace, event.exception.message,event.exception.stacktrace,event.exception.type) with(most_recent=true)',
       queryType: 'traceql',
       tableType: 'spans',
       limit: 400,

--- a/src/utils/trace-merge/merge.test.ts
+++ b/src/utils/trace-merge/merge.test.ts
@@ -1,7 +1,9 @@
 import { dumpTree, mergeTraces } from './merge';
+import { createNode } from './tree-node';
 import { SearchResponse } from '../../types';
 
 import serviceStructResponse from './test-responses/service-struct.json';
+import serviceStructWithNamespaceResponse from './test-responses/service-struct-with-namespace.json';
 
 describe('mergeTraces', () => {
   beforeEach(() => {
@@ -30,5 +32,74 @@ describe('mergeTraces', () => {
       '  Service-E:Span-name-XYZ 3\n' +
       '  Service-F:HTTP Outgoing Request 1\n'
     );
+  });
+});
+
+describe('service.namespace support', () => {
+  it('same service.name with different namespace produces separate tree nodes', () => {
+    const mockResponse = serviceStructWithNamespaceResponse as unknown as SearchResponse;
+    const tree = mergeTraces(mockResponse.traces);
+    const treeDump = dumpTree(tree, 0);
+
+    expect(treeDump).toContain('namespace-1/Service-A:HTTP POST');
+    expect(treeDump).toContain('namespace-2/Service-A:HTTP POST');
+    expect(treeDump).toContain('Service-C:HTTP GET');
+  });
+
+  it('span without namespace produces plain serviceName with no slash prefix', () => {
+    const span = {
+      spanID: 'test0001',
+      name: 'HTTP GET',
+      startTimeUnixNano: '0',
+      durationNanos: '1000',
+      attributes: [
+        { key: 'service.name', value: { stringValue: 'Service-C' } },
+        { key: 'nestedSetLeft', value: { intValue: '1' } },
+        { key: 'nestedSetRight', value: { intValue: '2' } },
+        { key: 'nestedSetParent', value: { intValue: '-1' } },
+      ],
+    };
+    const node = createNode(span as any);
+    expect(node.serviceName).toBe('Service-C');
+    expect(node.serviceNamespace).toBe('');
+    expect(node.name).toBe('Service-C:HTTP GET');
+  });
+
+  it('createNode with service.namespace attr sets serviceNamespace correctly', () => {
+    const span = {
+      spanID: 'test0002',
+      name: 'HTTP POST',
+      startTimeUnixNano: '0',
+      durationNanos: '1000',
+      attributes: [
+        { key: 'service.name', value: { stringValue: 'Service-A' } },
+        { key: 'service.namespace', value: { stringValue: 'namespace-1' } },
+        { key: 'nestedSetLeft', value: { intValue: '1' } },
+        { key: 'nestedSetRight', value: { intValue: '2' } },
+        { key: 'nestedSetParent', value: { intValue: '-1' } },
+      ],
+    };
+    const node = createNode(span as any);
+    expect(node.serviceNamespace).toBe('namespace-1');
+    expect(node.name).toBe('namespace-1/Service-A:HTTP POST');
+  });
+
+  it('createNode with service.namespace.name attr (Prometheus fallback) sets serviceNamespace correctly', () => {
+    const span = {
+      spanID: 'test0003',
+      name: 'HTTP POST',
+      startTimeUnixNano: '0',
+      durationNanos: '1000',
+      attributes: [
+        { key: 'service.name', value: { stringValue: 'Service-A' } },
+        { key: 'service.namespace.name', value: { stringValue: 'namespace-prom' } },
+        { key: 'nestedSetLeft', value: { intValue: '1' } },
+        { key: 'nestedSetRight', value: { intValue: '2' } },
+        { key: 'nestedSetParent', value: { intValue: '-1' } },
+      ],
+    };
+    const node = createNode(span as any);
+    expect(node.serviceNamespace).toBe('namespace-prom');
+    expect(node.name).toBe('namespace-prom/Service-A:HTTP POST');
   });
 });

--- a/src/utils/trace-merge/merge.ts
+++ b/src/utils/trace-merge/merge.ts
@@ -6,6 +6,7 @@ export function mergeTraces(traces: TraceSearchMetadata[]): TreeNode {
   const tree = new TreeNode({
     name: 'root',
     serviceName: '',
+    serviceNamespace: '',
     operationName: '',
     left: Number.MIN_SAFE_INTEGER,
     right: Number.MAX_SAFE_INTEGER,

--- a/src/utils/trace-merge/test-responses/service-struct-with-namespace.json
+++ b/src/utils/trace-merge/test-responses/service-struct-with-namespace.json
@@ -1,0 +1,59 @@
+{
+  "traces": [
+    {
+      "traceID": "aabbccddeeff00112233445566778899",
+      "rootServiceName": "Service-A",
+      "rootTraceName": "HTTP POST",
+      "startTimeUnixNano": "1712759380000000000",
+      "durationMs": 50,
+      "spanSets": [
+        {
+          "spans": [
+            {
+              "spanID": "aaaa000000000001",
+              "name": "HTTP POST",
+              "startTimeUnixNano": "1712759380100000000",
+              "durationNanos": "5000000",
+              "attributes": [
+                { "key": "nestedSetLeft", "value": { "intValue": "1" } },
+                { "key": "nestedSetParent", "value": { "intValue": "-1" } },
+                { "key": "nestedSetRight", "value": { "intValue": "6" } },
+                { "key": "service.name", "value": { "stringValue": "Service-A" } },
+                { "key": "service.namespace", "value": { "stringValue": "namespace-1" } },
+                { "key": "status", "value": { "stringValue": "ok" } }
+              ]
+            },
+            {
+              "spanID": "aaaa000000000002",
+              "name": "HTTP POST",
+              "startTimeUnixNano": "1712759380200000000",
+              "durationNanos": "3000000",
+              "attributes": [
+                { "key": "nestedSetLeft", "value": { "intValue": "2" } },
+                { "key": "nestedSetParent", "value": { "intValue": "1" } },
+                { "key": "nestedSetRight", "value": { "intValue": "3" } },
+                { "key": "service.name", "value": { "stringValue": "Service-A" } },
+                { "key": "service.namespace", "value": { "stringValue": "namespace-2" } },
+                { "key": "status", "value": { "stringValue": "ok" } }
+              ]
+            },
+            {
+              "spanID": "aaaa000000000003",
+              "name": "HTTP GET",
+              "startTimeUnixNano": "1712759380300000000",
+              "durationNanos": "2000000",
+              "attributes": [
+                { "key": "nestedSetLeft", "value": { "intValue": "4" } },
+                { "key": "nestedSetParent", "value": { "intValue": "1" } },
+                { "key": "nestedSetRight", "value": { "intValue": "5" } },
+                { "key": "service.name", "value": { "stringValue": "Service-C" } },
+                { "key": "status", "value": { "stringValue": "ok" } }
+              ]
+            }
+          ],
+          "matched": 3
+        }
+      ]
+    }
+  ]
+}

--- a/src/utils/trace-merge/tree-node.ts
+++ b/src/utils/trace-merge/tree-node.ts
@@ -4,6 +4,7 @@ import { nestedSetLeft, nestedSetRight } from './utils';
 export class TreeNode {
   name: string;
   serviceName: string;
+  serviceNamespace: string;
   operationName: string;
   spans: Span[];
   left: number;
@@ -15,6 +16,7 @@ export class TreeNode {
   constructor({
     name,
     serviceName,
+    serviceNamespace,
     operationName,
     spans,
     left,
@@ -23,6 +25,7 @@ export class TreeNode {
   }: {
     name: string;
     serviceName: string;
+    serviceNamespace: string;
     operationName: string;
     spans: Span[];
     left: number;
@@ -31,6 +34,7 @@ export class TreeNode {
   }) {
     this.name = name;
     this.serviceName = serviceName;
+    this.serviceNamespace = serviceNamespace;
     this.operationName = operationName;
     this.spans = spans;
     this.left = left;
@@ -71,11 +75,15 @@ export class TreeNode {
 
 export function createNode(s: Span): TreeNode {
   const serviceNameAttr = s.attributes?.find((a) => a.key === 'service.name');
+  const serviceNamespaceAttr =
+    s.attributes?.find((a) => a.key === 'service.namespace') ??
+    s.attributes?.find((a) => a.key === 'service.namespace.name');
   return new TreeNode({
     left: nestedSetLeft(s),
     right: nestedSetRight(s),
     name: nodeName(s),
     serviceName: serviceNameAttr?.value.stringValue ?? serviceNameAttr?.value?.Value?.string_value ?? '',
+    serviceNamespace: serviceNamespaceAttr?.value.stringValue ?? serviceNamespaceAttr?.value?.Value?.string_value ?? '',
     operationName: s.name ?? '',
     spans: [s],
     traceID: s.traceId ?? '',
@@ -84,11 +92,14 @@ export function createNode(s: Span): TreeNode {
 
 function nodeName(s: Span): string {
   let svcName = '';
+  let namespace = '';
   for (const a of s.attributes || []) {
-    if (a.key === 'service.name' && a.value.stringValue) {
-      svcName = a.value.stringValue;
+    if (a.key === 'service.name') {
+      svcName = a.value.stringValue ?? a.value?.Value?.string_value ?? '';
+    }
+    if (a.key === 'service.namespace' || a.key === 'service.namespace.name') {
+      namespace = a.value.stringValue ?? a.value?.Value?.string_value ?? '';
     }
   }
-
-  return `${svcName}:${s.name}`;
+  return `${namespace ? namespace + '/' : ''}${svcName}:${s.name}`;
 }


### PR DESCRIPTION
### ✨ Description

**Related issue(s):** https://github.com/grafana/traces-drilldown/issues/657
Resolves https://github.com/grafana/traces-drilldown/issues/657

In multi-namespace Kubernetes environments, services sharing the same `service.name` but different `service.namespace` were incorrectly merged into a single node in the Structure and Exceptions tabs.

### 📖 Summary of the changes

- `TreeNode` now tracks `serviceNamespace`, extracted from `service.namespace` (or `service.namespace.name` as a Prometheus fallback)
- The merge key includes namespace, so `namespace/service:op` produces separate nodes per namespace
- Structure and Exceptions queries now select `resource.service.namespace`
- Display values render as `namespace/service-name` when a namespace is present; behavior is unchanged when it is absent

### 🧪 How to test?

- Open the **Structure** or **Exceptions** tab against traces from a multi-namespace cluster — services with the same name in different namespaces should appear separately, labelled `namespace/service-name`
- On a single-namespace or no-namespace setup, verify output is unchanged
