### PR TITLE
chore: Fix release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
   CD:
     name: Deploy plugin
     needs: bump-version
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v6.0.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main # zizmor: ignore[unpinned-uses] - required for prod-targets-all until next release
     permissions:
       contents: write
       id-token: write
@@ -41,6 +41,7 @@ jobs:
       pull-requests: read
     with:
       environment: prod
+      prod-targets-all: false
       attestation: true
       grafana-cloud-deployment-type: provisioned
       auto-merge-environments: dev,ops


### PR DESCRIPTION
Add `prod-targets-all: false` to our release action so that kicking off a new release will not trigger two release workflows: 1 for the commit that bumps the version and one for the actual release. This is so the workflow that bumps the version does not cancel the actual release.

cc @tolzhabayev @aangelisc @xnyo