### PR TITLE
fix: update levignore to pass grafana runtime compatibility check

### DIFF
--- a/.levignore.js
+++ b/.levignore.js
@@ -3,5 +3,9 @@ module.exports = {
     /getPluginLinkExtensions/, // removed in 12.0.0 (https://github.com/grafana/grafana/pull/102102)
     /DataLinksContext/, // added in 12.3.0 (https://github.com/grafana/grafana/pull/110590)
     /useDataLinksContext/, // added in 12.3.0 (https://github.com/grafana/grafana/pull/110590)
+    /DashboardInfo/, // dashboardId removed in 12.4.x, not used by this plugin
+  ],
+  changes: [
+    /^config$/, // type expansion in 12.4.x, plugin only reads stable properties
   ],
 };


### PR DESCRIPTION
## Summary
- Add `DashboardInfo` to `removals` in `.levignore.js` — `dashboardId` was removed in `@grafana/runtime` 12.4.x and is not used by this plugin
- Add `config` to `changes` in `.levignore.js` — type was expanded with new fields in 12.4.x, plugin only reads stable properties (`appSubUrl`, `buildInfo.version`, `feedbackLinksEnabled`, `featureToggles`)

## Test plan
- [x] Ran `npx @grafana/levitate@latest is-compatible --path src/module.tsx --target @grafana/data,@grafana/ui,@grafana/runtime` locally — passes with no incompatibilities