### PR TITLE
fix: Fix issue with logsDrilldownExtension.fn

### DIFF
--- a/src/pages/Explore/DataLinksCustomContext.test.tsx
+++ b/src/pages/Explore/DataLinksCustomContext.test.tsx
@@ -126,6 +126,19 @@ describe('DataLinksCustomContext', () => {
       expect(capturedContext).toBeNull();
     });
 
+    it('when extension entry exists but fn is missing', () => {
+      mockedUsePluginFunctions.mockReturnValue({ functions: [{} as any] });
+
+      render(
+        <DataLinksCustomContext timeRange={createMockTimeRange() as any}>
+          <TestConsumer />
+        </DataLinksCustomContext>
+      );
+
+      expect(screen.getByTestId('child')).toBeInTheDocument();
+      expect(capturedContext).toBeNull();
+    });
+
     it('when timeRange is not provided', () => {
       render(
         <DataLinksCustomContext>

--- a/src/pages/Explore/DataLinksCustomContext.tsx
+++ b/src/pages/Explore/DataLinksCustomContext.tsx
@@ -39,19 +39,23 @@ export function DataLinksCustomContext(props: Props) {
   });
 
   const logsDrilldownExtension = extensions?.functions?.[0] ?? undefined;
+  const logsDrilldownFn =
+    logsDrilldownExtension && typeof logsDrilldownExtension.fn === 'function'
+      ? logsDrilldownExtension.fn
+      : undefined;
 
   // Use refs to keep stable callback identity regardless of whether upstream hooks return new references
   const dataLinksContextRef = useRef(dataLinksContext);
   dataLinksContextRef.current = dataLinksContext;
 
-  const logsDrilldownExtensionRef = useRef(logsDrilldownExtension);
-  logsDrilldownExtensionRef.current = logsDrilldownExtension;
+  const logsDrilldownFnRef = useRef(logsDrilldownFn);
+  logsDrilldownFnRef.current = logsDrilldownFn;
 
   const dataLinkPostProcessor: DataLinkPostProcessor = useCallback((options) => {
     const ctx = dataLinksContextRef.current;
-    const ext = logsDrilldownExtensionRef.current;
+    const extensionInvoke = logsDrilldownFnRef.current;
 
-    if (!ctx || !ext) {
+    if (!ctx || !extensionInvoke) {
       return options.linkModel;
     }
 
@@ -63,7 +67,7 @@ export function DataLinksCustomContext(props: Props) {
     const dataSourceType = getDataSourceSrv().getInstanceSettings(linkDataSourceUid)?.type;
 
     if (query && linkModel && dataSourceType === 'loki' && timeRange) {
-      const extensionLink = logsDrilldownExtension.fn({
+      const extensionLink = extensionInvoke({
         targets: [
           {
             ...query,
@@ -86,7 +90,7 @@ export function DataLinksCustomContext(props: Props) {
 
   const contextValue = useMemo(() => ({ dataLinkPostProcessor }), [dataLinkPostProcessor]);
 
-  if (embedded || !postProcessingSupported || !logsDrilldownExtension || !timeRange) {
+  if (embedded || !postProcessingSupported || !logsDrilldownFn || !timeRange) {
     return <>{children}</>;
   }
 


### PR DESCRIPTION
Guards against an issue where `logsDrilldownExtension` is not defined!

<img width="874" height="585" alt="Screenshot 2026-04-02 at 15 31 32" src="https://github.com/user-attachments/assets/852b580c-0971-4d98-bed6-c2de708df20c" />
