### PR TITLE
docs: Update for Include/Exclude, Adaptive Traces tab, and time seeker

### DIFF
--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -95,7 +95,7 @@ The visualization highlights that:
 - There were 500 traces containing HTTP 500 status codes during the error period
 - This represents a 100% deviation from normal behavior
 
-Click **Add to filters** to narrow the investigation to these values, or choose **Inspect** to explore the full distribution.
+Select **Include** to narrow the investigation to these values, or choose **Inspect** to explore the full distribution.
 
 ![Errors are immediately visible by the large red bars](/media/docs/explore-traces/traces-drilldown-errors-comparison-http-status-code-v1.2.png 'Errors are immediately visible by the large red bars')
 
@@ -112,7 +112,7 @@ In this example, selecting **Inspect** on `span.http.status_code` shows the dist
 - Error state: Significant portion return `500` errors
 - Root cause: something caused the internal server errors during the selected time frame
 
-Use **Add to filters** on the `500` card to keep only error spans and continue the investigation.
+Select **Include** on the `500` card to keep only error spans and continue the investigation.
 
 ![Inspect the HTTP 500 errors](/media/docs/explore-traces/traces-drilldown-errors-comparison-http-status-attr-selected-v1.2.png 'Inspect the HTTP 500 errors')
 

--- a/docs/sources/investigate/add-filters.md
+++ b/docs/sources/investigate/add-filters.md
@@ -30,7 +30,7 @@ The list of filters expands as you investigate and explore your tracing data usi
 1. Refine your investigation by adding filters.
 1. Optional: Use the tabs underneath the metrics selection to provide insights into breakdowns, comparisons, latency, and other explorations.
 1. Choose filters to focus on problem areas. Each selected filter is added to the **Filters** bar at the top of the page. You can select filters on the **Comparison** and **Breakdown** tabs in the following ways:
-   - Select **Add to filters**.
+   - Select **Include** to add a matching filter (`=`) or **Exclude** to add a negating filter (`!=`).
    - Use the **Filters** bar near the top.
    - Attributes shown with a filter icon in the **Attributes** sidebar are already applied in your current **Filters**. The **Attributes** sidebar helps you pick and favorite attributes used for grouping, comparison, and **Trace list** columns. Refer to the [UI reference](../../ui-reference/).
 

--- a/docs/sources/investigate/analyze-tracing-data.md
+++ b/docs/sources/investigate/analyze-tracing-data.md
@@ -49,7 +49,7 @@ The selector appears only when **Duration** is selected.
 
 ## Use the Comparison tab
 
-The **Comparison** tab helps you surface and rank which span attributes are most correlated with the selected metric so you can immediately spot what's driving your trace-level issues.
+The **Comparison** tab helps you surface and rank which span attributes are most correlated with the selected metric so you can spot what's driving your trace-level issues.
 
 ![Comparison view](/media/docs/explore-traces/traces-drilldown-root-spans-duration-comparison-tab-v1.2.png)
 
@@ -133,6 +133,17 @@ If you notice a rise in the Errors metric, you can use the **Exceptions** tab to
 4. Click the message to jump to the Trace list pre-filtered by that exception.
 5. Sort by Duration to find the most impacted requests, then open a trace to inspect retries and upstream dependencies.
 
+
+## Use the Adaptive Traces tab 
+
+The **Adaptive Traces** tab appears when both of the following conditions are met:
+
+- [Adaptive Traces](https://grafana.com/docs/grafana-cloud/adaptive-telemetry/adaptive-traces/) is enabled and configured on your Grafana Cloud stack.
+- You've applied an `instrumentation.tailsampling.policy` filter in the **Filters** bar.
+
+When these conditions are met, the tab displays span latency data for the selected tail-sampling policy, helping you understand how the policy affects trace collection and latency distribution within the current time range.
+
+If Adaptive Traces isn't enabled or no tail-sampling policy filter is applied, the tab doesn't appear.
 ## Use the Trace list tab
 
 Each RED metric has a trace list:
@@ -145,6 +156,26 @@ From this view, you can add additional attributes to new columns using **Add ext
 
 Use the **Attributes** sidebar to add columns. Select multiple attributes to include them as table columns. Use **Search attributes** and **Favorites** to find attributes.
 Attributes already in your **Filters** are listed at the top of the **Attributes** sidebar.
+
+<!-- TODO: Uncomment when Grafana 13 ships and tracesDrilldownTimeSeeker toggle reaches GA.
+## Use the time range seeker
+
+The time range seeker helps you find spikes and anomalies across a wider time window than the main RED metric panel. It appears below the RED panel and displays a compact, sampled overview of your selected metric over a longer period (up to several days).
+
+To use the time range seeker:
+
+1. Look for spikes or patterns in the overview chart.
+1. Drag across the chart to select a time window. The main RED panel and all tabs update to reflect the selected range.
+1. Use the floating controls to refine the window:
+   - Pan left or right to shift the visible window.
+   - Zoom in or out to narrow or widen the context.
+   - Select **Focus selection** (crosshair icon) to reset the view to your current selection.
+   - Select **Set range** (calendar icon) to open the time range picker and enter an exact range.
+
+The seeker loads data in sampled batches (24 hours by default) for faster responses. You can configure the batch range in the plugin's configuration page to match your Tempo instance's maximum query range. A warning icon appears when the seeker needs to load a large amount of data.
+
+The time range seeker requires the `tracesDrilldownTimeSeeker` feature toggle. Refer to [Grafana feature toggles](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/) for more information.
+-->
 
 ## Change the selected time range
 

--- a/docs/sources/ui-reference/_index.md
+++ b/docs/sources/ui-reference/_index.md
@@ -36,14 +36,29 @@ For details on workflows, refer to [Analyze tracing data](../investigate/analyze
    - The **Errors** graph (top right) displays the error rate over time, with red bars indicating errors.
    - The **Duration** heatmap (bottom right) visualizes the distribution of span durations and can help identify latency patterns.
 
+<!-- TODO: Uncomment when Grafana 13 ships and tracesDrilldownTimeSeeker toggle reaches GA.
+1. **Time range seeker**:
+   Below the RED metric panel, the time range seeker displays a compact overview chart spanning a wider time window (up to several days) so you can spot spikes and trends beyond the currently selected range.
+
+   Drag across the chart to select a time window, then use the floating controls to refine it:
+   - **Pan left / Pan right**: Shift the visible window in either direction.
+   - **Zoom in / Zoom out**: Narrow or widen the context around your selection.
+   - **Focus selection**: Reset the visible window to your current selection.
+   - **Set range**: Open the time range picker to enter an exact range.
+
+   The seeker loads data in batches and uses sampling for faster responses over long time ranges. A warning icon appears if the time range requires loading a large amount of data.
+
+   The time range seeker requires the `tracesDrilldownTimeSeeker` feature toggle to be enabled. Refer to [Grafana feature toggles](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/) for more information.
+-->
+
 1. **Investigation-focused tabs**:
    Each metric type has its own set of tabs that help you explore your tracing data. These tabs differ depending on the metric type you've selected.
    For example, when you use **Rate**, the investigation tabs show **Breakdown**, **Service structure**, **Comparison**, and **Traces**.
    - **Exceptions** (**Errors** only): Group exception messages with counts, trend sparkline, emitting service, and last-seen.
     - Percentiles (Duration only): Choose `p50`, `p75`, `p90`, `p95`, `p99` for Duration views. Default: `p90`. If you clear all, `p90` applies automatically.
 
-1. **Add to filters**:
-   Each attribute group includes an **Add to filters** option, so you can add your selections into the current investigation.
+1. **Include and Exclude**:
+   Each attribute group includes **Include** and **Exclude** buttons. Select **Include** to add a matching filter (`=`) or **Exclude** to add a negating filter (`!=`) to your current investigation.
 
 1. **Time range selector**:
    At the top right, you can adjust the time range for displayed data using the time picker. In this example, the time range is set to the last 24 hours. Refer to [Set dashboard time range](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/use-dashboards/#set-dashboard-time-range) for more information.


### PR DESCRIPTION
Updates documentation to match recent feature PRs:

- **PR #624**: Renames "Add to filters" to **Include** and **Exclude** with filter operator descriptions (`=` / `!=`) across get-started, add-filters, analyze-tracing-data, and UI reference pages.
- **PR #614**: Adds Adaptive Traces tab section documenting visibility conditions (`instrumentation.tailsampling.policy` filter + plugin availability) and what the tab surfaces (span latency data). Code-verified against `AdaptiveTracesScene.tsx` and `TabsBarScene.tsx`.
- **PR #611**: Adds commented-out time range seeker documentation (both analyze-tracing-data and UI reference), ready to uncomment when `tracesDrilldownTimeSeeker` reaches GA. All claims validated against implementation.

Made with [Cursor](https://cursor.com)