### PR TITLE
chore: Use OpenFeature for all feature flags

### DIFF
--- a/src/components/Explore/SavedSearches/LoadSearchScene.test.tsx
+++ b/src/components/Explore/SavedSearches/LoadSearchScene.test.tsx
@@ -6,7 +6,7 @@ import { usePluginComponent } from '@grafana/runtime';
 import { DataSourceVariable, sceneGraph, SceneObject, SceneTimeRange } from '@grafana/scenes';
 
 import { LoadSearchScene } from './LoadSearchScene';
-import { useHasSavedSearches, useSavedSearches, isQueryLibrarySupported } from './saveSearch';
+import { useHasSavedSearches, useSavedSearches, useQueryLibrarySupported } from './saveSearch';
 import { getDatasourceVariable, getFiltersVariable, getTraceExplorationScene } from '../../../utils/utils';
 import { DataQuery } from '@grafana/schema';
 
@@ -79,7 +79,7 @@ describe('LoadSearchScene', () => {
       state: { value: { from: 'now-1h', to: 'now', raw: { from: 'now-1h', to: 'now' } } },
     } as unknown as SceneTimeRange);
     jest.mocked(usePluginComponent).mockReturnValue({ component: undefined, isLoading: false });
-    jest.mocked(isQueryLibrarySupported).mockReturnValue(false);
+    jest.mocked(useQueryLibrarySupported).mockReturnValue(false);
   });
 
   test('Disables button when there are no saved searches', () => {
@@ -132,7 +132,7 @@ describe('LoadSearchScene', () => {
 
   test('Uses the exposed component if available', () => {
     const component = () => <div>Exposed component</div>;
-    jest.mocked(isQueryLibrarySupported).mockReturnValue(true);
+    jest.mocked(useQueryLibrarySupported).mockReturnValue(true);
     jest.mocked(usePluginComponent).mockReturnValue({ component, isLoading: false });
 
     const scene = new LoadSearchScene({ dsUid: 'test-datasource-uid', dsName: 'test-datasource-uid' });
@@ -143,7 +143,7 @@ describe('LoadSearchScene', () => {
 
   describe('Loading a search', () => {
     beforeEach(() => {
-      jest.mocked(isQueryLibrarySupported).mockReturnValue(true);
+      jest.mocked(useQueryLibrarySupported).mockReturnValue(true);
       // @ts-expect-error
       jest.mocked(usePluginComponent).mockReturnValue({ component: FakeExposedComponent, isLoading: false });
       mockUseHasSavedSearches.mockReturnValue(true);

--- a/src/components/Explore/SavedSearches/LoadSearchScene.tsx
+++ b/src/components/Explore/SavedSearches/LoadSearchScene.tsx
@@ -10,7 +10,7 @@ import { ToolbarButton, useStyles2 } from '@grafana/ui';
 import { LoadSearchModal } from './LoadSearchModal';
 import { getDatasourceVariable, getTraceExplorationScene } from '../../../utils/utils';
 import { DataQuery } from '@grafana/schema';
-import { OpenQueryLibraryComponentProps, useHasSavedSearches, isQueryLibrarySupported, applySavedSearchToScene } from './saveSearch';
+import { OpenQueryLibraryComponentProps, useHasSavedSearches, useQueryLibrarySupported, applySavedSearchToScene } from './saveSearch';
 
 export interface LoadSearchSceneState extends SceneObjectState {
   dsName: string;
@@ -61,6 +61,7 @@ export class LoadSearchScene extends SceneObjectBase<LoadSearchSceneState> {
     const { dsName, dsUid, isOpen } = model.useState();
     const styles = useStyles2(getStyles);
     const hasSavedSearches = useHasSavedSearches(dsUid);
+    const queryLibrarySupported = useQueryLibrarySupported();
 
     const { component: OpenQueryLibraryComponent, isLoading: isLoadingExposedComponent } =
       usePluginComponent<OpenQueryLibraryComponentProps>('grafana/query-library-context/v1');
@@ -111,7 +112,7 @@ export class LoadSearchScene extends SceneObjectBase<LoadSearchSceneState> {
       return null;
     }
 
-    if (!isQueryLibrarySupported()) {
+    if (!queryLibrarySupported) {
       return fallbackComponent;
     } else if (isLoadingExposedComponent || !OpenQueryLibraryComponent) {
       return null;

--- a/src/components/Explore/SavedSearches/SaveSearchButton.test.tsx
+++ b/src/components/Explore/SavedSearches/SaveSearchButton.test.tsx
@@ -6,7 +6,7 @@ import { usePluginComponent } from '@grafana/runtime';
 import { DataSourceVariable, SceneObject, sceneGraph } from '@grafana/scenes';
 
 import { SaveSearchButton } from './SaveSearchButton';
-import { isQueryLibrarySupported, useSavedSearches } from './saveSearch';
+import { useQueryLibrarySupported, useSavedSearches } from './saveSearch';
 import { renderTraceQLLabelFilters } from '../../../utils/filters-renderer';
 import { getDatasourceVariable, getFiltersVariable, getTraceExplorationScene } from '../../../utils/utils';
 
@@ -53,7 +53,7 @@ describe('SaveSearchButton', () => {
       deleteSearch: jest.fn(),
     });
     jest.mocked(usePluginComponent).mockReturnValue({ component: undefined, isLoading: false });
-    jest.mocked(isQueryLibrarySupported).mockReturnValue(false);
+    jest.mocked(useQueryLibrarySupported).mockReturnValue(false);
   });
 
   test('Opens the modal when the button is clicked', () => {
@@ -91,7 +91,7 @@ describe('SaveSearchButton', () => {
 
   test('Uses the exposed component if available', () => {
     const component = () => <div>Exposed component</div>;
-    jest.mocked(isQueryLibrarySupported).mockReturnValue(true);
+    jest.mocked(useQueryLibrarySupported).mockReturnValue(true);
     jest.mocked(usePluginComponent).mockReturnValue({ component, isLoading: false });
 
     render(<SaveSearchButton sceneRef={mockSceneRef} />);

--- a/src/components/Explore/SavedSearches/SaveSearchButton.tsx
+++ b/src/components/Explore/SavedSearches/SaveSearchButton.tsx
@@ -8,7 +8,7 @@ import { ToolbarButton } from '@grafana/ui';
 import { getDatasourceVariable, getFiltersVariable, getTraceExplorationScene } from '../../../utils/utils';
 import { SaveSearchModal } from './SaveSearchModal';
 import { renderTraceQLLabelFilters } from '../../../utils/filters-renderer';
-import { isQueryLibrarySupported, OpenQueryLibraryComponentProps } from './saveSearch';
+import { OpenQueryLibraryComponentProps, useQueryLibrarySupported } from './saveSearch';
 
 interface Props {
   sceneRef: SceneObject;
@@ -16,6 +16,7 @@ interface Props {
 
 export function SaveSearchButton({ sceneRef }: Props) {
   const [saving, setSaving] = useState(false);
+  const queryLibrarySupported = useQueryLibrarySupported();
   const { component: OpenQueryLibraryComponent, isLoading: isLoadingExposedComponent } =
     usePluginComponent<OpenQueryLibraryComponentProps>('grafana/query-library-context/v1');
 
@@ -70,7 +71,7 @@ export function SaveSearchButton({ sceneRef }: Props) {
     return null;
   }
 
-  if (!isQueryLibrarySupported()) {
+  if (!queryLibrarySupported) {
     return fallbackComponent;
   } else if (isLoadingExposedComponent || !OpenQueryLibraryComponent) {
     return null;

--- a/src/components/Explore/SavedSearches/saveSearch.test.ts
+++ b/src/components/Explore/SavedSearches/saveSearch.test.ts
@@ -2,25 +2,27 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 
 import { config } from '@grafana/runtime';
 
+import { useFlagQueryLibrary } from '../../../featureFlags/featureFlags';
 import {
   applySavedSearchToScene,
-  isQueryLibrarySupported,
   narrowSavedSearches,
   SAVED_SEARCHES_KEY,
   SavedSearch,
   useCheckForExistingSearch,
   useHasSavedSearches,
+  useQueryLibrarySupported,
   useSavedSearches,
 } from './saveSearch';
+
+jest.mock('../../../featureFlags/featureFlags', () => ({
+  useFlagQueryLibrary: jest.fn(() => true),
+}));
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   config: {
     buildInfo: {
       version: '12.4.0',
-    },
-    featureToggles: {
-      queryLibrary: true,
     },
   },
 }));
@@ -144,20 +146,28 @@ describe('useHasSavedSearches', () => {
   });
 });
 
-describe('isQueryLibrarySupported', () => {
+const mockedUseFlagQueryLibrary = jest.mocked(useFlagQueryLibrary);
+
+describe('useQueryLibrarySupported', () => {
   test('Returns true when supported', () => {
-    expect(isQueryLibrarySupported()).toBe(true);
+    mockedUseFlagQueryLibrary.mockReturnValue(true);
+    config.buildInfo.version = '12.4.0';
+    const { result } = renderHook(() => useQueryLibrarySupported());
+    expect(result.current).toBe(true);
   });
 
   test('Returns false if the feature is not enabled', () => {
-    config.featureToggles.queryLibrary = false;
-    expect(isQueryLibrarySupported()).toBe(false);
+    mockedUseFlagQueryLibrary.mockReturnValue(false);
+    config.buildInfo.version = '12.4.0';
+    const { result } = renderHook(() => useQueryLibrarySupported());
+    expect(result.current).toBe(false);
   });
 
   test('Returns false if the Grafana version is not supported', () => {
-    config.featureToggles.queryLibrary = true;
+    mockedUseFlagQueryLibrary.mockReturnValue(true);
     config.buildInfo.version = '12.3.0';
-    expect(isQueryLibrarySupported()).toBe(false);
+    const { result } = renderHook(() => useQueryLibrarySupported());
+    expect(result.current).toBe(false);
   });
 });
 

--- a/src/components/Explore/SavedSearches/saveSearch.ts
+++ b/src/components/Explore/SavedSearches/saveSearch.ts
@@ -7,6 +7,7 @@ import { config } from '@grafana/runtime';
 import { SceneObject } from '@grafana/scenes';
 import { DataQuery } from '@grafana/schema';
 
+import { useFlagQueryLibrary } from '../../../featureFlags/featureFlags';
 import pluginJson from '../../../plugin.json';
 import { TraceqlFilter, traceqlFiltersToAdHoc } from '../../../utils/links';
 import { parseTraceQLQuery } from '../../../utils/lezer-traceql-parser';
@@ -21,8 +22,9 @@ function notifySavedSearchesChanged() {
   window.dispatchEvent(new CustomEvent(SAVED_SEARCHES_CHANGED_EVENT));
 }
 
-export function isQueryLibrarySupported() {
-  return !semver.ltr(config.buildInfo.version, MIN_VERSION) && config.featureToggles.queryLibrary;
+export function useQueryLibrarySupported(): boolean {
+  const queryLibrary = useFlagQueryLibrary();
+  return !semver.ltr(config.buildInfo.version, MIN_VERSION) && queryLibrary;
 }
 
 export function useCheckForExistingSearch(dsUid: string, query: string) {

--- a/src/components/Explore/TracesByService/REDPanel.tsx
+++ b/src/components/Explore/TracesByService/REDPanel.tsx
@@ -42,7 +42,7 @@ import { exemplarsTransformations, removeExemplarsTransformation } from '../../.
 import { useServiceName } from 'pages/Explore/TraceExploration';
 import { locationService } from '@grafana/runtime';
 import { InsightsTimelineWidget } from 'addedComponents/InsightsTimelineWidget/InsightsTimelineWidget';
-import { TIME_SEEKER_FEATURE_FLAG_KEY, useTimeSeekerFeatureEnabled } from 'featureFlags/openFeature';
+import { TIME_SEEKER_FEATURE_FLAG_KEY, useFlagTracesDrilldownTimeSeeker } from 'featureFlags/featureFlags';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'utils/analytics';
 
 export interface RateMetricsPanelState extends SceneObjectState {
@@ -275,7 +275,7 @@ export class REDPanel extends SceneObjectBase<RateMetricsPanelState> {
     const serviceName = useServiceName(model);
     const timeRange = sceneGraph.getTimeRange(model).useState();
     const { timeSeekerScene } = traceExploration.useState();
-    const timeSeekerEnabled = useTimeSeekerFeatureEnabled();
+    const timeSeekerEnabled = useFlagTracesDrilldownTimeSeeker();
     const embedded = traceExploration.state.embedded === true;
     // Mini embedded layout never shows the seeker (only full RED / full embed).
     const showTimeSeeker = !embeddedMini && Boolean(timeSeekerScene) && timeSeekerEnabled;

--- a/src/featureFlags/featureFlags.tsx
+++ b/src/featureFlags/featureFlags.tsx
@@ -11,7 +11,6 @@ const queryLibraryKey = 'queryLibrary' satisfies keyof FeatureToggles;
 const TRACES_DRILLDOWN_TIME_SEEKER = 'tracesDrilldownTimeSeeker' as const;
 const tracesDrilldownTimeSeekerKey = TRACES_DRILLDOWN_TIME_SEEKER as keyof FeatureToggles;
 
-/** Stable string for analytics and other non-hook call sites. */
 export const TIME_SEEKER_FEATURE_FLAG_KEY = TRACES_DRILLDOWN_TIME_SEEKER;
 
 export function useFlagTracesDrilldownTimeSeeker(): boolean {

--- a/src/featureFlags/featureFlags.tsx
+++ b/src/featureFlags/featureFlags.tsx
@@ -1,0 +1,23 @@
+import type { FeatureToggles } from '@grafana/data';
+import { useBooleanFlagDetails } from '@openfeature/react-sdk';
+
+/**
+ * Grafana registry-backed flags via OpenFeature. Call sites must sit under
+ * `OpenFeaturePluginScope` from `./openFeature`.
+ */
+const queryLibraryKey = 'queryLibrary' satisfies keyof FeatureToggles;
+
+/** `pkg/services/featuremgmt/registry.go` — widen until available in `@grafana/data` types (FeatureToggles). */
+const TRACES_DRILLDOWN_TIME_SEEKER = 'tracesDrilldownTimeSeeker' as const;
+const tracesDrilldownTimeSeekerKey = TRACES_DRILLDOWN_TIME_SEEKER as keyof FeatureToggles;
+
+/** Stable string for analytics and other non-hook call sites. */
+export const TIME_SEEKER_FEATURE_FLAG_KEY = TRACES_DRILLDOWN_TIME_SEEKER;
+
+export function useFlagTracesDrilldownTimeSeeker(): boolean {
+  return useBooleanFlagDetails(tracesDrilldownTimeSeekerKey, false).value;
+}
+
+export function useFlagQueryLibrary(): boolean {
+  return useBooleanFlagDetails(queryLibraryKey, false).value;
+}

--- a/src/featureFlags/openFeature.test.tsx
+++ b/src/featureFlags/openFeature.test.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { render, renderHook, screen, waitFor } from '@testing-library/react';
 import { OpenFeature } from '@openfeature/web-sdk';
-import { config, logWarning } from '@grafana/runtime';
+import { logWarning } from '@grafana/runtime';
 
+import { TIME_SEEKER_FEATURE_FLAG_KEY, useFlagTracesDrilldownTimeSeeker } from './featureFlags';
 import {
   ensureOpenFeaturePluginInitialized,
   OpenFeaturePluginScope,
+  PLUGIN_OPEN_FEATURE_DOMAIN,
   resetOpenFeaturePluginStateForTesting,
-  TIME_SEEKER_FEATURE_FLAG_KEY,
-  useTimeSeekerFeatureEnabled,
 } from './openFeature';
 
 jest.mock('@grafana/runtime', () => {
@@ -20,7 +20,6 @@ jest.mock('@grafana/runtime', () => {
       namespace: 'test-ns',
       appSubUrl: '',
       openFeatureContext: {},
-      featureToggles: {} as Record<string, boolean | undefined>,
     },
     logWarning: jest.fn(),
   };
@@ -34,8 +33,6 @@ jest.mock('@openfeature/ofrep-web-provider', () => ({
   },
 }));
 
-const featureToggles = config.featureToggles as Record<string, boolean | undefined>;
-
 function OpenFeatureTestWrapper({ children }: { children: React.ReactNode }) {
   return <OpenFeaturePluginScope>{children}</OpenFeaturePluginScope>;
 }
@@ -47,9 +44,6 @@ describe('openFeature', () => {
     resetOpenFeaturePluginStateForTesting();
     jest.clearAllMocks();
     await OpenFeature.clearProviders();
-    for (const key of Object.keys(featureToggles)) {
-      delete featureToggles[key];
-    }
     setProviderAndWaitSpy = jest.spyOn(OpenFeature, 'setProviderAndWait').mockResolvedValue(undefined);
   });
 
@@ -65,6 +59,12 @@ describe('openFeature', () => {
     });
   });
 
+  describe('PLUGIN_OPEN_FEATURE_DOMAIN', () => {
+    it('is stable for OFREP / provider binding', () => {
+      expect(PLUGIN_OPEN_FEATURE_DOMAIN).toBe('traces-drilldown');
+    });
+  });
+
   describe('OpenFeaturePluginScope', () => {
     it('renders children', () => {
       render(
@@ -76,20 +76,12 @@ describe('openFeature', () => {
     });
   });
 
-  describe('useTimeSeekerFeatureEnabled', () => {
-    it('returns false when the toggle is unset and evaluation is false', () => {
-      const { result } = renderHook(() => useTimeSeekerFeatureEnabled(), {
+  describe('useFlagTracesDrilldownTimeSeeker', () => {
+    it('returns false when the toggle evaluates false', () => {
+      const { result } = renderHook(() => useFlagTracesDrilldownTimeSeeker(), {
         wrapper: OpenFeatureTestWrapper,
       });
       expect(result.current).toBe(false);
-    });
-
-    it('returns true when config.featureToggles enables the key', () => {
-      featureToggles[TIME_SEEKER_FEATURE_FLAG_KEY] = true;
-      const { result } = renderHook(() => useTimeSeekerFeatureEnabled(), {
-        wrapper: OpenFeatureTestWrapper,
-      });
-      expect(result.current).toBe(true);
     });
   });
 
@@ -99,19 +91,17 @@ describe('openFeature', () => {
       expect(logWarning).not.toHaveBeenCalled();
     });
 
-    it('logs and installs the boot fallback provider when OFREP registration fails', async () => {
+    it('logs when OFREP registration fails and leaves defaults', async () => {
       setProviderAndWaitSpy.mockRejectedValue(new Error('ofrep-down'));
-      const setProviderSpy = jest.spyOn(OpenFeature, 'setProvider');
 
       await ensureOpenFeaturePluginInitialized();
 
       await waitFor(() => {
         expect(logWarning).toHaveBeenCalledWith(
-          'OpenFeature OFREP provider failed; using config.featureToggles fallback',
+          'OpenFeature OFREP provider failed; feature flags remain at default values',
           expect.objectContaining({ error: 'ofrep-down' })
         );
       });
-      expect(setProviderSpy).toHaveBeenCalled();
     });
 
     it('returns the same promise when called repeatedly', async () => {

--- a/src/featureFlags/openFeature.test.tsx
+++ b/src/featureFlags/openFeature.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, renderHook, screen, waitFor } from '@testing-library/react';
+import { OpenFeatureTestProvider } from '@openfeature/react-sdk';
 import { OpenFeature } from '@openfeature/web-sdk';
 import { logWarning } from '@grafana/runtime';
 
@@ -32,10 +33,6 @@ jest.mock('@openfeature/ofrep-web-provider', () => ({
     runsOn = 'client';
   },
 }));
-
-function OpenFeatureTestWrapper({ children }: { children: React.ReactNode }) {
-  return <OpenFeaturePluginScope>{children}</OpenFeaturePluginScope>;
-}
 
 describe('openFeature', () => {
   let setProviderAndWaitSpy: jest.SpiedFunction<(typeof OpenFeature)['setProviderAndWait']>;
@@ -77,11 +74,27 @@ describe('openFeature', () => {
   });
 
   describe('useFlagTracesDrilldownTimeSeeker', () => {
-    it('returns false when the toggle evaluates false', () => {
+    it('returns the hook default when the flag is unset in the test provider', () => {
       const { result } = renderHook(() => useFlagTracesDrilldownTimeSeeker(), {
-        wrapper: OpenFeatureTestWrapper,
+        wrapper: ({ children }) => (
+          <OpenFeatureTestProvider domain={PLUGIN_OPEN_FEATURE_DOMAIN}>{children}</OpenFeatureTestProvider>
+        ),
       });
       expect(result.current).toBe(false);
+    });
+
+    it('returns true when the test provider maps the Grafana registry flag on', () => {
+      const { result } = renderHook(() => useFlagTracesDrilldownTimeSeeker(), {
+        wrapper: ({ children }) => (
+          <OpenFeatureTestProvider
+            domain={PLUGIN_OPEN_FEATURE_DOMAIN}
+            flagValueMap={{ [TIME_SEEKER_FEATURE_FLAG_KEY]: true }}
+          >
+            {children}
+          </OpenFeatureTestProvider>
+        ),
+      });
+      expect(result.current).toBe(true);
     });
   });
 

--- a/src/featureFlags/openFeature.tsx
+++ b/src/featureFlags/openFeature.tsx
@@ -1,54 +1,38 @@
 import React, { useEffect } from 'react';
-import { OpenFeatureProvider, useBooleanFlagValue } from '@openfeature/react-sdk';
+import { OpenFeatureProvider } from '@openfeature/react-sdk';
 import { OFREPWebProvider } from '@openfeature/ofrep-web-provider';
 import { StandardResolutionReasons } from '@openfeature/core';
 import { OpenFeature, type Provider, type ResolutionDetails } from '@openfeature/web-sdk';
 
 import { config, logWarning } from '@grafana/runtime';
 
-const DOMAIN = 'traces-drilldown';
+/** OpenFeature domain for this plugin’s evaluations (OFREP to Grafana’s feature API). */
+export const PLUGIN_OPEN_FEATURE_DOMAIN = 'traces-drilldown';
 
-/**
- * Grafana core feature toggle (`pkg/services/featuremgmt/registry.go`). Shipped in Grafana 13+;
- * see https://github.com/grafana/grafana/pull/121650
- *
- * Enable for an instance:
- * - Env: `GF_FEATURE_TOGGLES_ENABLE=tracesDrilldownTimeSeeker`
- * - Or `custom.ini`: `[feature_toggles]` → `tracesDrilldownTimeSeeker = true`
- *
- * After bumping `@grafana/data` to a release that regenerates types from that registry, you can
- * narrow this constant with `satisfies keyof FeatureToggles` (import from `@grafana/data`).
- */
-export const TIME_SEEKER_FEATURE_FLAG_KEY = 'tracesDrilldownTimeSeeker' as const;
-
-/**
- * Reads a boolean from Grafana’s boot `config.featureToggles` without asserting the whole object’s shape.
- * Only actual booleans count; anything else falls back to `defaultValue` (avoids treating `"true"` etc. as on).
- */
-function readBootBooleanFeatureToggle(flagKey: string, defaultValue: boolean): boolean {
-  const togglesUnknown: unknown = config.featureToggles;
-  if (togglesUnknown == null || typeof togglesUnknown !== 'object') {
-    return defaultValue;
+/** OFREP base URL for Grafana’s feature API (same host as the app, respects `appSubUrl`). Browser-only. */
+function getFeaturesOfrepBaseUrl(): string | undefined {
+  if (typeof window === 'undefined') {
+    return undefined;
   }
-  const raw = (togglesUnknown as Record<string, unknown>)[flagKey];
-  return typeof raw === 'boolean' ? raw : defaultValue;
+  const sub = (config.appSubUrl ?? '').replace(/\/$/, '');
+  const path = `${sub}/apis/features.grafana.app/v0alpha1/namespaces/${encodeURIComponent(config.namespace)}`;
+  const pathname = path.startsWith('/') ? path : `/${path}`;
+  return new URL(pathname, window.location.origin).toString();
 }
 
 function defaultDetails<T>(value: T): ResolutionDetails<T> {
   return { value, reason: StandardResolutionReasons.DEFAULT };
 }
 
-/** Used when the Grafana feature API (OFREP) is unavailable — e.g. older OSS, network error. */
-const grafanaBootFallbackProvider: Provider = {
-  metadata: { name: 'grafana-boot-feature-toggles-fallback' },
+/**
+ * Resolves every flag to the evaluator’s default until a live provider (OFREP) is ready.
+ * Does not read boot config; avoids stale values vs the feature API.
+ */
+const defaultOnlyProvider: Provider = {
+  metadata: { name: 'traces-drilldown-default-flags' },
   runsOn: 'client',
-  resolveBooleanEvaluation(flagKey, defaultValue, _ctx, _log): ResolutionDetails<boolean> {
-    const value = readBootBooleanFeatureToggle(flagKey, defaultValue);
-    return {
-      value,
-      reason: StandardResolutionReasons.STATIC,
-      variant: value ? 'true' : 'false',
-    };
+  resolveBooleanEvaluation(_flagKey, defaultValue): ResolutionDetails<boolean> {
+    return { value: defaultValue, reason: StandardResolutionReasons.DEFAULT };
   },
   resolveStringEvaluation: (_k, defaultValue) => defaultDetails(defaultValue),
   resolveNumberEvaluation: (_k, defaultValue) => defaultDetails(defaultValue),
@@ -56,30 +40,30 @@ const grafanaBootFallbackProvider: Provider = {
 };
 
 let initOnce: Promise<void> | null = null;
-let syncFallbackRegistered = false;
+let defaultProviderRegistered = false;
 
 /** Clears init/latch state between tests. Do not use in production code. */
 export function resetOpenFeaturePluginStateForTesting(): void {
   initOnce = null;
-  syncFallbackRegistered = false;
+  defaultProviderRegistered = false;
 }
 
 /**
- * Registers the sync boot provider on the OpenFeature client for `DOMAIN`.
- * Called at module load (below) so a resolver exists before any `useBooleanFlagValue` runs.
- * `OpenFeaturePluginScope` calls this again idempotently so tests can re-install after
+ * Ensures a synchronous provider exists before any OpenFeature hooks run.
+ * Re-asserted from `OpenFeaturePluginScope` so tests can re-install after
  * `resetOpenFeaturePluginStateForTesting()` + `OpenFeature.clearProviders()`.
  */
-function ensureSyncFallbackProviderRegistered(): void {
-  if (syncFallbackRegistered) {
+function ensureDefaultOnlyProviderRegistered(): void {
+  if (defaultProviderRegistered) {
     return;
   }
-  OpenFeature.setProvider(DOMAIN, grafanaBootFallbackProvider);
-  syncFallbackRegistered = true;
+  OpenFeature.setProvider(PLUGIN_OPEN_FEATURE_DOMAIN, defaultOnlyProvider);
+  defaultProviderRegistered = true;
 }
 
 /**
- * Registers OFREP against Grafana’s feature API, or `config.featureToggles` on failure.
+ * Registers OFREP against Grafana’s feature API. On failure, the default-only provider
+ * stays in place so hooks keep returning their declared defaults.
  */
 export function ensureOpenFeaturePluginInitialized(): Promise<void> {
   initOnce ??= (async () => {
@@ -88,10 +72,14 @@ export function ensureOpenFeaturePluginInitialized(): Promise<void> {
       namespace: config.namespace,
       ...config.openFeatureContext,
     };
-    const baseUrl = `${config.appSubUrl ?? ''}/apis/features.grafana.app/v0alpha1/namespaces/${config.namespace}`;
+    const baseUrl = getFeaturesOfrepBaseUrl();
+    if (!baseUrl) {
+      logWarning('OpenFeature OFREP skipped; not in a browser context', {});
+      return;
+    }
     try {
       await OpenFeature.setProviderAndWait(
-        DOMAIN,
+        PLUGIN_OPEN_FEATURE_DOMAIN,
         new OFREPWebProvider({
           baseUrl,
           pollInterval: -1,
@@ -100,33 +88,29 @@ export function ensureOpenFeaturePluginInitialized(): Promise<void> {
         evaluationContext
       );
     } catch (error: unknown) {
-      logWarning('OpenFeature OFREP provider failed; using config.featureToggles fallback', {
+      logWarning('OpenFeature OFREP provider failed; feature flags remain at default values', {
         error: error instanceof Error ? error.message : String(error),
       });
-      OpenFeature.setProvider(DOMAIN, grafanaBootFallbackProvider);
     }
   })();
   return initOnce;
 }
 
-export function useTimeSeekerFeatureEnabled(): boolean {
-  const fromOpenFeature = useBooleanFlagValue(TIME_SEEKER_FEATURE_FLAG_KEY, false);
-  const fromBootConfig = readBootBooleanFeatureToggle(TIME_SEEKER_FEATURE_FLAG_KEY, false);
-  return fromOpenFeature || fromBootConfig;
-}
-
 /**
- * Wraps the app with OpenFeature. Supplies React context for hooks; re-asserts the boot
- * provider after test resets. OFREP is registered asynchronously and may refine flag values when ready.
+ * Wraps the app with OpenFeature for {@link PLUGIN_OPEN_FEATURE_DOMAIN}.
+ *
+ * Any component that calls `useBooleanFlag*` / `useFlag*` from `featureFlags.tsx` must render
+ * under this scope (or tests must wrap with the same provider), otherwise React OpenFeature
+ * hooks will not resolve a client.
  */
 export function OpenFeaturePluginScope({ children }: { children: React.ReactNode }) {
-  ensureSyncFallbackProviderRegistered();
+  ensureDefaultOnlyProviderRegistered();
 
   useEffect(() => {
     void ensureOpenFeaturePluginInitialized();
   }, []);
 
-  return <OpenFeatureProvider domain={DOMAIN}>{children}</OpenFeatureProvider>;
+  return <OpenFeatureProvider domain={PLUGIN_OPEN_FEATURE_DOMAIN}>{children}</OpenFeatureProvider>;
 }
 
-ensureSyncFallbackProviderRegistered();
+ensureDefaultOnlyProviderRegistered();


### PR DESCRIPTION
Migrates all remaining feature toggles to fully support OpenFeature and removes the fallback to config.featureToggles.

See https://github.com/grafana/grafana/blob/main/contribute/feature-toggles.md for more details.