### PR TITLE
chore: Add refresh control to embedded header

### DIFF
--- a/src/pages/Explore/TraceExploration.tsx
+++ b/src/pages/Explore/TraceExploration.tsx
@@ -260,6 +260,7 @@ const EmbeddedHeader = ({ model }: SceneComponentProps<TraceExplorationScene>) =
   const filtersVariable = getFiltersVariable(traceExploration);
   const primarySignalVariable = getPrimarySignalVariable(traceExploration);
   const timeRangeControl = traceExploration.state.controls.find((control) => control instanceof SceneTimePicker);
+  const refreshControl = traceExploration.state.controls.find((control) => control instanceof SceneRefreshPicker);
 
   const timeRangeState = traceExploration.state.$timeRange?.useState();
   const filtersVariableState = filtersVariable.useState();
@@ -295,6 +296,7 @@ const EmbeddedHeader = ({ model }: SceneComponentProps<TraceExplorationScene>) =
             Traces Drilldown
           </LinkButton>
           {timeRangeControl && <timeRangeControl.Component model={timeRangeControl} />}
+          {refreshControl && <refreshControl.Component model={refreshControl} />}
         </Stack>
       </Stack>
     </div>


### PR DESCRIPTION
Adds the refresh control to the embedded header, primarily from a request from the Knowledge Graph team.

Fixes https://github.com/grafana/asserts-app-plugin/issues/3092