### PR TITLE
chore: fix local development

### DIFF
--- a/devenv/docker-compose.yaml
+++ b/devenv/docker-compose.yaml
@@ -6,25 +6,26 @@ services:
     build:
       context: ../.config
       args:
-        grafana_image: ${GRAFANA_IMAGE:-grafana-dev}
+        grafana_image: ${GRAFANA_IMAGE:-grafana}
         grafana_version: ${GRAFANA_VERSION:-12.3.0}
     environment:
       - GF_FEATURE_TOGGLES_ENABLE=${GF_FEATURE_TOGGLES_ENABLE:-}
     ports:
       - 3000:3000/tcp
     volumes:
-      - ../dist:/var/lib/grafana/plugins/grafana-explore-traces
+      - ../dist:/var/lib/grafana/plugins/grafana-exploretraces-app
       - ../provisioning:/etc/grafana/provisioning
+      - ./grafana.ini:/etc/grafana/grafana.ini
     extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - 'host.docker.internal:host-gateway'
 
   tempo:
-    image: grafana/tempo:latest@sha256:112d818cc82ad33052e42868fc7b2557f5962eaa5ba35d19878402675479e09d
-    command: [ "-config.file=/etc/tempo.yaml" ]
+    image: grafana/tempo:2.10.4@sha256:a6616c9d224770c883a67b50e4941e99c5df81b076ef05f516bb7cce5a96cec0
+    command: ['-config.file=/etc/tempo.yaml']
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
-      - "3200:3200"   # tempo
+      - '3200:3200' # tempo
 
   # generates uninteresting traces, but is useful for testing
   k6-tracing:
@@ -46,8 +47,8 @@ services:
     image: rabbitmq:management@sha256:23fe4f224d3d4d4e3c3904e82fb8a47824f0ee03412c33b7b21e6bf00b9852fa
     restart: always
     ports:
-      - "5672:5672"
-      - "15672:15672"
+      - '5672:5672'
+      - '15672:15672'
     healthcheck:
       test: rabbitmq-diagnostics check_running
       interval: 5s
@@ -59,9 +60,9 @@ services:
     image: postgres:14.5@sha256:135c62a8134dcef829a1e4f5568bfae44bcfa2c75659ff948f43c71964366aa4
     restart: always
     environment:
-      POSTGRES_PASSWORD: "mythical"
+      POSTGRES_PASSWORD: 'mythical'
     ports:
-      - "5432:5432"
+      - '5432:5432'
 
   # A microservice that makes requests to the API server microservice. Requests are also pushed onto the mythical-queue.
   mythical-requester-A:
@@ -93,7 +94,7 @@ services:
       - OTEL_EXPORTER_OTLP_TRACES_INSECURE=true
       - OTEL_RESOURCE_ATTRIBUTES=ip=1.2.3.5,region=eu-east
 
-   # A microservice that makes requests to the API server microservice. Requests are also pushed onto the mythical-queue.
+    # A microservice that makes requests to the API server microservice. Requests are also pushed onto the mythical-queue.
   mythical-requester-B:
     image: grafana/intro-to-mltp:mythical-beasts-requester-0.3.1@sha256:2643fb2e2cd1100e9edecb44d67c82cfa436ea97ff23aeeb646ea063776e539b
     restart: always

--- a/devenv/grafana.ini
+++ b/devenv/grafana.ini
@@ -1,0 +1,6 @@
+[feature_toggles]
+# Disable auto-updating of preinstalled plugins so the stable `grafana` image
+# doesn't wipe our bind-mounted ../dist trying to "update" grafana-exploretraces-app
+# from the catalog. Other preinstalled plugins (loki, pyroscope, metricsdrilldown)
+# still install on first boot.
+preinstallAutoUpdate = false

--- a/devenv/tempo.yaml
+++ b/devenv/tempo.yaml
@@ -32,11 +32,8 @@ storage:
     backend: local # backend configuration to use
     block:
       bloom_filter_false_positive: .05 # bloom filter false positive rate.  lower values create larger filters but fewer false positives
-      v2_index_downsample_bytes: 1000 # number of bytes per index record
-      v2_encoding: zstd # block encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
     wal:
       path: /tmp/tempo/wal # where to store the wal locally
-      v2_encoding: snappy # wal encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
     local:
       path: /tmp/tempo/blocks
 


### PR DESCRIPTION
### ✨ Description

Fixes the `devenv/` docker-compose stack for local plugin dev.

### 📖 Summary of the changes

- `devenv/docker-compose.yaml`:
  - Plugin bind mount `grafana-explore-traces` → `grafana-exploretraces-app` (must match `plugin.json#id`).
  - Default `grafana_image` `grafana-dev` → `grafana` (still overridable via `GRAFANA_IMAGE`).
  - Mount new `./grafana.ini`.
  - Pin tempo `latest@sha` → `2.10.4@sha`.
- `devenv/grafana.ini` (new): `preinstallAutoUpdate = false` so the stable grafana image doesn't wipe the bind-mounted `../dist` on boot.
- `devenv/tempo.yaml`: drop `v2_*` encoding keys — removed in Tempo 2.10.x.

Local-dev only. CI uses `docker-compose.e2e.yaml` and isn't affected.

### 🧪 How to test?

```sh
pnpm build
pnpm server
```

Open http://localhost:3000 and confirm the plugin loads from `dist/`.