### PR TITLE
fix: Escape filters with newlines etc

### DIFF
--- a/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionUtils.ts
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionUtils.ts
@@ -114,10 +114,6 @@ export function normalizeExceptionMessage(message: string): string {
   return message.replace(/\s+/g, ' ').trim();
 }
 
-export function escapeTraceQlString(value: string) {
-  return value.replace(/["\\]/g, (s) => `\\${s}`);
-}
-
 export function getDatasourceUidOrThrow(scene: SceneObject) {
   const datasourceUid = getDatasourceVariable(scene).state.value?.toString();
   if (!datasourceUid) {

--- a/src/components/Explore/TracesByService/Tabs/Exceptions/accordion/ExceptionAccordion.test.ts
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/accordion/ExceptionAccordion.test.ts
@@ -5,9 +5,13 @@ jest.mock('utils/utils', () => ({
   getFiltersVariable: () => ({ state: { filters: [{ key: 'foo', operator: '=', value: 'bar' }] } }),
 }));
 
-jest.mock('utils/filters-renderer', () => ({
-  renderTraceQLLabelFilters: () => 'foo="bar"',
-}));
+jest.mock('utils/filters-renderer', () => {
+  const actual = jest.requireActual<typeof import('utils/filters-renderer')>('utils/filters-renderer');
+  return {
+    ...actual,
+    renderTraceQLLabelFilters: () => 'foo="bar"',
+  };
+});
 
 describe('ExceptionAccordion helpers', () => {
   describe('getMessageHighlight', () => {

--- a/src/components/Explore/TracesByService/Tabs/Exceptions/accordion/ExceptionAccordion.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/accordion/ExceptionAccordion.tsx
@@ -6,12 +6,11 @@ import { css } from '@emotion/css';
 import { SceneObject } from '@grafana/scenes';
 
 import { AttributesSidebar } from 'components/Explore/AttributesSidebar';
-import { renderTraceQLLabelFilters } from 'utils/filters-renderer';
+import { escapeTraceQlStringLiteral, renderTraceQLLabelFilters } from 'utils/filters-renderer';
 import { getFiltersVariable, getPrimarySignalVariable, getSpanListColumnsVariable, getTraceByServiceScene } from 'utils/utils';
 import { ExceptionRow } from '../ExceptionsTable';
 import { ExceptionComparison } from './ExceptionComparison';
 import { ExceptionTraceResults } from './ExceptionTraceResults';
-import { escapeTraceQlString } from '../ExceptionUtils';
 
 interface ExceptionAccordionProps {
   row: ExceptionRow;
@@ -129,8 +128,8 @@ export const buildExceptionFilterExpr = ({
   const primarySignalExpr = (getPrimarySignalVariable(scene).state.value as string) || 'true';
   const filtersExpr = renderTraceQLLabelFilters(getFiltersVariable(scene).state.filters);
 
-  const escapedMessage = escapeTraceQlString(exceptionMessage);
-  const typeFilter = exceptionType && exceptionType !== 'Unknown' ? ` && event.exception.type = "${escapeTraceQlString(exceptionType)}"` : '';
+  const escapedMessage = escapeTraceQlStringLiteral(exceptionMessage);
+  const typeFilter = exceptionType && exceptionType !== 'Unknown' ? ` && event.exception.type = "${escapeTraceQlStringLiteral(exceptionType)}"` : '';
 
   return `{${primarySignalExpr} && ${filtersExpr} && status = error && event.exception.message = "${escapedMessage}"${typeFilter}}`;
 };

--- a/src/utils/filters-renderer.test.ts
+++ b/src/utils/filters-renderer.test.ts
@@ -125,6 +125,19 @@ describe('filters-renderer', () => {
         const filters: AdHocVariableFilter[] = [{ key: 'name', operator: '=', value: 'some "query" \\ ' }];
         expect(renderTraceQLLabelFilters(filters)).toBe('name="some \\"query\\" \\\\ "');
       });
+
+      it('should escape newlines tabs and carriage returns so TraceQL string literals stay closed', () => {
+        const filters: AdHocVariableFilter[] = [
+          {
+            key: 'event.exception.message',
+            operator: '=',
+            value: 'No result found for query [\n        SELECT a FROM stores a \n        WHERE x = 1\n        ]',
+          },
+        ];
+        expect(renderTraceQLLabelFilters(filters)).toBe(
+          'event.exception.message="No result found for query [\\n        SELECT a FROM stores a \\n        WHERE x = 1\\n        ]"'
+        );
+      });
     });
   });
 });

--- a/src/utils/filters-renderer.ts
+++ b/src/utils/filters-renderer.ts
@@ -1,5 +1,18 @@
 import { AdHocVariableFilter } from '@grafana/data';
 
+/**
+ * Escapes a value for use inside TraceQL double-quoted string literals.
+ * Raw newlines (and tabs/CR) break parsing with "literal not terminated"; they must be written as \\n etc.
+ */
+export function escapeTraceQlStringLiteral(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+}
+
 export function renderTraceQLLabelFilters(filters: AdHocVariableFilter[]) {
   const expr = filters
     .filter((f) => f.key && f.operator && f.value)
@@ -29,9 +42,7 @@ function renderFilter(filter: AdHocVariableFilter) {
       !isQuotedNumericString(val)
   ) {
     if (typeof val === 'string') {
-      // Escape " and \ to \" and \\ respectively
-      val = val.replace(/["\\]/g, (s) => `\\${s}`);
-      val = `"${val}"`;
+      val = `"${escapeTraceQlStringLiteral(val)}"`;
     }
   }
 


### PR DESCRIPTION
Escape `\n`, `\t`, `\r`, `\"` & `\\` in filters.

Fixes https://github.com/grafana/traces-drilldown/issues/629