### PR TITLE
chore(i18n): add ESLint rules and translate all user-facing strings

### DIFF
--- a/e2e/components.spec.ts
+++ b/e2e/components.spec.ts
@@ -61,7 +61,12 @@ test.describe('components', () => {
     await expect(page.getByLabel('Grid')).toBeVisible();
     await expect(page.getByLabel('Rows')).toBeVisible();
 
-    await page.getByPlaceholder('Search', { exact: true }).fill('mythical');
-    await expect(page.getByTitle('mythical-requester')).toBeVisible();
+    // Breakdown grid filter (ByFrameRepeater); debounced ~250ms before panels re-render.
+    const breakdownPanelSearch = page.locator('#searchFieldInput');
+    await expect(breakdownPanelSearch).toBeVisible({ timeout: 20000 });
+    await breakdownPanelSearch.fill('mythical');
+    await expect(page.locator('#trace-exploration').getByText('mythical-requester', { exact: true })).toBeVisible({
+      timeout: 20000,
+    });
   });
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,11 +14,12 @@ export default [
     },
   },
   {
+    name: 'grafana/i18n-rules',
     files: ['src/**/*.{ts,tsx}'],
     ignores: ['src/**/*.test.{ts,tsx}', 'src/**/__tests__/**'],
     plugins: { '@grafana/i18n': grafanaI18nPlugin },
     rules: {
-      '@grafana/i18n/no-untranslated-strings': ['warn', { calleesToIgnore: ['^css$', 'use[A-Z].*'] }],
+      '@grafana/i18n/no-untranslated-strings': ['error', { calleesToIgnore: ['^css$', 'use[A-Z].*'] }],
       '@grafana/i18n/no-translation-top-level': 'error',
     },
   },

--- a/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
+++ b/src/addedComponents/InsightsTimelineWidget/InsightsTimelineWidget.tsx
@@ -1,5 +1,6 @@
 import React, { memo, ReactElement } from 'react';
 
+import { t } from '@grafana/i18n';
 import { usePluginComponent } from '@grafana/runtime';
 import { InsightsTimelineWidgetProps } from '@grafana/plugin-types/grafana-asserts-app/';
 import { MetricFunction } from 'utils/shared';
@@ -56,7 +57,7 @@ export const InsightsTimelineWidget = memo(function InsightsTimelineWidget({
         end={endTime}
         filterBySeverity={filterBySeverity}
         filterBySummaryKeywords={filterBySummaryKeywords}
-        label={'Insights'}
+        label={t('insights-timeline-widget.label', 'Insights')}
       />
     </div>
   );

--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Button, Field, useStyles2, FieldSet, Combobox } from '@grafana/ui';
+import { t, Trans } from '@grafana/i18n';
 import { PluginConfigPageProps, AppPluginMeta, PluginMeta, GrafanaTheme2 } from '@grafana/data';
 import { FetchResponse, getBackendSrv, locationService } from '@grafana/runtime';
 import { css } from '@emotion/css';
@@ -41,10 +42,10 @@ const AppConfig = ({ plugin }: Props) => {
   return (
     <div data-testid={testIds.appConfig.container}>
       {/* ENABLE / DISABLE PLUGIN */}
-      <FieldSet label="Enable / Disable">
+      <FieldSet label={t('app-config.fieldset.enable-disable', 'Enable / Disable')}>
         {!enabled && (
           <>
-            <div className={s.colorWeak}>The plugin is currently not enabled.</div>
+            <div className={s.colorWeak}><Trans i18nKey="app-config.plugin-not-enabled">The plugin is currently not enabled.</Trans></div>
             <Button
               className={s.marginTop}
               variant="primary"
@@ -56,7 +57,7 @@ const AppConfig = ({ plugin }: Props) => {
                 })
               }
             >
-              Enable plugin
+              <Trans i18nKey="app-config.enable-plugin">Enable plugin</Trans>
             </Button>
           </>
         )}
@@ -64,7 +65,7 @@ const AppConfig = ({ plugin }: Props) => {
         {/* Disable the plugin */}
         {enabled && (
           <>
-            <div className={s.colorWeak}>The plugin is currently enabled.</div>
+            <div className={s.colorWeak}><Trans i18nKey="app-config.plugin-enabled">The plugin is currently enabled.</Trans></div>
             <Button
               className={s.marginTop}
               variant="destructive"
@@ -76,17 +77,17 @@ const AppConfig = ({ plugin }: Props) => {
                 })
               }
             >
-              Disable plugin
+              <Trans i18nKey="app-config.disable-plugin">Disable plugin</Trans>
             </Button>
           </>
         )}
       </FieldSet>
 
       {/* CUSTOM SETTINGS */}
-      <FieldSet label="Time Seeker Settings" className={s.marginTopXl}>
+      <FieldSet label={t('app-config.fieldset.time-seeker-settings', 'Time Seeker Settings')} className={s.marginTopXl}>
         <Field
-          label="Query Range"
-          description="The time range for each cached batch in the Time Seeker. Larger values mean fewer queries but more data per query."
+          label={t('app-config.field.query-range', 'Query Range')}
+          description={t('app-config.field.query-range-description', 'The time range for each cached batch in the Time Seeker. Larger values mean fewer queries but more data per query.')}
         >
           <Combobox<number>
             width={30}
@@ -112,7 +113,7 @@ const AppConfig = ({ plugin }: Props) => {
               })
             }
           >
-            Save settings
+            <Trans i18nKey="app-config.save-settings">Save settings</Trans>
           </Button>
         </div>
       </FieldSet>

--- a/src/components/Explore/AttributesSidebar.tsx
+++ b/src/components/Explore/AttributesSidebar.tsx
@@ -3,6 +3,7 @@ import React, { useMemo, useState, useEffect, useCallback } from 'react';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { TabsBar, Tab, Input, Icon, IconButton, useStyles2, Badge, Checkbox, Button, useTheme2 } from '@grafana/ui';
+import { t, Trans } from '@grafana/i18n';
 import { RESOURCE_ATTR, SPAN_ATTR, ignoredAttributes } from 'utils/shared';
 import { getFiltersVariable } from 'utils/utils';
 import { SceneObject } from '@grafana/scenes';
@@ -300,13 +301,13 @@ export function AttributesSidebar({
   };
 
   const scopeButtons = [
-    { label: 'All', value: 'All' as ScopeType },
-    { label: 'Resource', value: 'Resource' as ScopeType },
-    { label: 'Span', value: 'Span' as ScopeType },
+    { label: t('attributes-sidebar.scope.all', 'All'), value: 'All' as ScopeType },
+    { label: t('attributes-sidebar.scope.resource', 'Resource'), value: 'Resource' as ScopeType },
+    { label: t('attributes-sidebar.scope.span', 'Span'), value: 'Span' as ScopeType },
   ];
 
   if (showFavorites) {
-    scopeButtons.unshift({ label: 'Favorites', value: 'Favorites' as ScopeType });
+    scopeButtons.unshift({ label: t('attributes-sidebar.scope.favorites', 'Favorites'), value: 'Favorites' as ScopeType });
   }
 
   return (
@@ -319,18 +320,18 @@ export function AttributesSidebar({
           <div className={styles.selectedAttributeLabel}>
             {isMulti ? (
               <>
-                <strong>Selected ({getSelectedAttributes().length}):</strong>{' '}
-                {getSelectedAttributes().length > 0 ? getSelectedAttributes().join(', ') : 'None'}
+                <strong>{t('attributes-sidebar.selected-count', 'Selected ({{count}}):', { count: getSelectedAttributes().length })}</strong>{' '}
+                {getSelectedAttributes().length > 0 ? getSelectedAttributes().join(', ') : t('attributes-sidebar.none', 'None')}
               </>
             ) : (
               <>
-                <strong>Selected:</strong> {selected}
+                <strong><Trans i18nKey="attributes-sidebar.selected">Selected:</Trans></strong> {selected}
               </>
             )}
           </div>
           {allowAllOption && selected !== 'All' && (
             <Button variant="secondary" size="sm" onClick={() => handleAttributeSelect('All')}>
-              All
+              <Trans i18nKey="attributes-sidebar.all-button">All</Trans>
             </Button>
           )}
         </div>
@@ -340,7 +341,7 @@ export function AttributesSidebar({
           <Input
             className={styles.searchInput}
             prefix={<Icon name="search" />}
-            placeholder="Search attributes..."
+            placeholder={t('attributes-sidebar.search-placeholder', 'Search attributes...')}
             value={searchValue}
             onChange={(e) => setSearchValue(e.currentTarget.value)}
             onKeyDown={handleSearchKeyDown}
@@ -349,7 +350,7 @@ export function AttributesSidebar({
                 <IconButton
                   name="times"
                   variant="secondary"
-                  tooltip="Clear search"
+                  tooltip={t('attributes-sidebar.clear-search', 'Clear search')}
                   onClick={() => setSearchValue('')}
                 />
               )
@@ -377,7 +378,7 @@ export function AttributesSidebar({
       <ul className={styles.attributesList} onDragOver={handleListDragOver} onDragLeave={handleListDragLeave}>
         {filteredAttributes.length === 0 ? (
           <div className={styles.emptyState}>
-            {searchValue || selectedScope !== 'All' ? 'No attributes match your criteria' : 'No attributes available'}
+            {searchValue || selectedScope !== 'All' ? t('attributes-sidebar.no-match', 'No attributes match your criteria') : t('attributes-sidebar.no-available', 'No attributes available')}
           </div>
         ) : (
           filteredAttributes.map((attribute, index) => {
@@ -394,7 +395,7 @@ export function AttributesSidebar({
                 {/* Ghost element above */}
                 {showGhostAbove && (
                   <li className={styles.ghostElement} onDrop={() => handleDrop(index)}>
-                    <div className={styles.ghostContent}>Drop here</div>
+                    <div className={styles.ghostContent}><Trans i18nKey="attributes-sidebar.drop-here">Drop here</Trans></div>
                   </li>
                 )}
 
@@ -436,7 +437,7 @@ export function AttributesSidebar({
                       variant="secondary"
                       size="sm"
                       className={`${styles.starButton} ${isFavorites ? styles.starButtonActive : ''}`}
-                      tooltip={isFavorites ? 'Remove from favorites' : 'Add to favorites'}
+                      tooltip={isFavorites ? t('attributes-sidebar.remove-from-favorites', 'Remove from favorites') : t('attributes-sidebar.add-to-favorites', 'Add to favorites')}
                       onClick={(event) => toggleStar(attribute.value, event)}
                     />
                   )}
@@ -445,7 +446,7 @@ export function AttributesSidebar({
                 {/* Ghost element below */}
                 {showGhostBelow && (
                   <li className={styles.ghostElement} onDrop={() => handleDrop(index)}>
-                    <div className={styles.ghostContent}>Drop here</div>
+                    <div className={styles.ghostContent}><Trans i18nKey="attributes-sidebar.drop-here-below">Drop here</Trans></div>
                   </li>
                 )}
               </React.Fragment>

--- a/src/components/Explore/ByFrameRepeater.tsx
+++ b/src/components/Explore/ByFrameRepeater.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { DataFrame, FieldType, GrafanaTheme2, LoadingState, PanelData, sortDataFrame } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import {
   SceneComponentProps,
   SceneCSSGridLayout,
@@ -127,7 +128,7 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
         children: [
           new SceneFlexItem({
             body: new EmptyStateScene({
-              message: 'No data for search term',
+              message: t('by-frame-repeater.no-data-for-search', 'No data for search term'),
               padding: '32px',
             }),
           }),

--- a/src/components/Explore/LayoutSwitcher.tsx
+++ b/src/components/Explore/LayoutSwitcher.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
 import { SceneComponentProps, SceneObject, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { Label, RadioButtonGroup, Stack, useStyles2 } from '@grafana/ui';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../utils/analytics';
@@ -21,7 +22,7 @@ export class LayoutSwitcher extends SceneObjectBase<LayoutSwitcherState> {
 
     return (
       <Stack>
-        <Label className={styles.label}>View</Label>
+        <Label className={styles.label}><Trans i18nKey="layout-switcher.view-label">View</Trans></Label>
         <RadioButtonGroup options={options} value={active} onChange={model.onLayoutChange} />
       </Stack>
     );

--- a/src/components/Explore/SavedSearches/LoadSearchModal.tsx
+++ b/src/components/Explore/SavedSearches/LoadSearchModal.tsx
@@ -5,6 +5,7 @@ import { css } from '@emotion/css';
 import { dateTime, GrafanaTheme2 } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 import { SceneObject } from '@grafana/scenes';
+import { t, Trans } from '@grafana/i18n';
 import { Modal, Box, useStyles2, Stack, Text, Divider, ScrollContainer, IconButton, Button } from '@grafana/ui';
 
 import { SavedSearch, useSavedSearches, applySavedSearchToScene } from './saveSearch';
@@ -64,10 +65,10 @@ export function LoadSearchModal({ onClose, sceneRef }: Props) {
   }, [onClose, sceneRef, selectedSearch]);
 
   return (
-    <Modal title="Load a previously saved search" isOpen={true} onDismiss={onClose}>
+    <Modal title={t('load-search-modal.title', 'Load a previously saved search')} isOpen={true} onDismiss={onClose}>
       {!isLoading && searches.length === 0 && (
         <Box backgroundColor="secondary" padding={1.5} marginBottom={2}>
-          <Text variant="body">No saved searches to display.</Text>
+          <Text variant="body"><Trans i18nKey="load-search-modal.no-saved-searches">No saved searches to display.</Trans></Text>
         </Box>
       )}
       {searches.length > 0 && (
@@ -113,10 +114,10 @@ export function LoadSearchModal({ onClose, sceneRef }: Props) {
                         size="xl"
                         name="trash-alt"
                         onClick={onDelete}
-                        tooltip="Remove"
+                        tooltip={t('load-search-modal.remove-tooltip', 'Remove')}
                       />
                       <Button onClick={onSelectClick} variant="primary">
-                        Select
+                        <Trans i18nKey="load-search-modal.select-button">Select</Trans>
                       </Button>
                     </Stack>
                   </Box>

--- a/src/components/Explore/SavedSearches/LoadSearchScene.tsx
+++ b/src/components/Explore/SavedSearches/LoadSearchScene.tsx
@@ -5,6 +5,7 @@ import { css } from '@emotion/css';
 import { AppEvents, GrafanaTheme2 } from '@grafana/data';
 import { getAppEvents, reportInteraction, usePluginComponent } from '@grafana/runtime';
 import { SceneComponentProps, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+import { t } from '@grafana/i18n';
 import { ToolbarButton, useStyles2 } from '@grafana/ui';
 
 import { LoadSearchModal } from './LoadSearchModal';
@@ -78,7 +79,7 @@ export class LoadSearchScene extends SceneObjectBase<LoadSearchSceneState> {
             onClick={model.toggleOpen}
             className={styles.button}
             tooltip={
-              hasSavedSearches ? 'Load saved search' : 'No saved searches to load'
+              hasSavedSearches ? t('load-search-scene.load-saved-search', 'Load saved search') : t('load-search-scene.no-saved-searches', 'No saved searches to load')
             }
           />
           {isOpen && <LoadSearchModal sceneRef={model} onClose={model.toggleClosed} />}
@@ -125,7 +126,7 @@ export class LoadSearchScene extends SceneObjectBase<LoadSearchSceneState> {
         datasourceFilters={[dsName]}
         icon="folder-open"
         onSelectQuery={onSelectQuery}
-        tooltip="Load saved query"
+        tooltip={t('load-search-scene.load-saved-query', 'Load saved query')}
       />
     );
   };

--- a/src/components/Explore/SavedSearches/SaveSearchButton.tsx
+++ b/src/components/Explore/SavedSearches/SaveSearchButton.tsx
@@ -3,6 +3,7 @@ import React, { useMemo, useState } from 'react';
 import { usePluginComponent } from '@grafana/runtime';
 import { SceneObject } from '@grafana/scenes';
 import { DataQuery } from '@grafana/schema';
+import { t } from '@grafana/i18n';
 import { ToolbarButton } from '@grafana/ui';
 
 import { getDatasourceVariable, getFiltersVariable, getTraceExplorationScene } from '../../../utils/utils';
@@ -42,7 +43,7 @@ export function SaveSearchButton({ sceneRef }: Props) {
           variant="canvas"
           icon="save"
           onClick={() => setSaving(true)}
-          tooltip="Save search"
+          tooltip={t('save-search-button.save-search', 'Save search')}
         />
         {saving && <SaveSearchModal dsUid={dsUid} sceneRef={sceneRef} onClose={() => setSaving(false)} />}
       </>
@@ -81,7 +82,7 @@ export function SaveSearchButton({ sceneRef }: Props) {
     <OpenQueryLibraryComponent
       datasourceFilters={[dsName]}
       query={query}
-      tooltip="Save in Saved Queries"
+      tooltip={t('save-search-button.save-in-saved-queries', 'Save in Saved Queries')}
     />
   );
 }

--- a/src/components/Explore/SavedSearches/SaveSearchModal.tsx
+++ b/src/components/Explore/SavedSearches/SaveSearchModal.tsx
@@ -6,6 +6,7 @@ import { AppEvents, GrafanaTheme2 } from '@grafana/data';
 import { getAppEvents, reportInteraction } from '@grafana/runtime';
 import { SceneObject } from '@grafana/scenes';
 import { Modal, Button, Box, Field, Input, Stack, useStyles2, Alert } from '@grafana/ui';
+import { t, Trans } from '@grafana/i18n';
 
 import { getFiltersVariable, getTraceExplorationScene } from '../../../utils/utils';
 import { renderTraceQLLabelFilters } from '../../../utils/filters-renderer';
@@ -69,9 +70,9 @@ export function SaveSearchModal({ dsUid, onClose, sceneRef }: Props) {
   );
 
   return (
-    <Modal title="Save current search" isOpen={true} onDismiss={onClose}>
+    <Modal title={t('save-search-modal.title', 'Save current search')} isOpen={true} onDismiss={onClose}>
       <Alert title="" severity="info">
-        Saved searches are stored locally in your browser and will only be available on this device.
+        <Trans i18nKey="save-search-modal.info-alert">Saved searches are stored locally in your browser and will only be available on this device.</Trans>
       </Alert>
       <Box marginBottom={2}>
         <code className={styles.query}>{query}</code>
@@ -82,10 +83,10 @@ export function SaveSearchModal({ dsUid, onClose, sceneRef }: Props) {
             <Box flex={1} marginBottom={2}>
               {existingSearch && (
                 <Alert title="" severity="warning">
-                  There is a previously saved search with the same query: {existingSearch.title}
+                  <Trans i18nKey="save-search-modal.existing-search-warning">There is a previously saved search with the same query: {{ title: existingSearch.title }}</Trans>
                 </Alert>
               )}
-              <Field label="Title" noMargin htmlFor="save-search-title">
+              <Field label={t('save-search-modal.field.title', 'Title')} noMargin htmlFor="save-search-title">
                 <Input
                   id="save-search-title"
                   required
@@ -96,7 +97,7 @@ export function SaveSearchModal({ dsUid, onClose, sceneRef }: Props) {
               </Field>
             </Box>
             <Box flex={1} marginBottom={2}>
-              <Field label="Description" noMargin htmlFor="save-search-description">
+              <Field label={t('save-search-modal.field.description', 'Description')} noMargin htmlFor="save-search-description">
                 <Input
                   id="save-search-description"
                   value={description}
@@ -108,21 +109,21 @@ export function SaveSearchModal({ dsUid, onClose, sceneRef }: Props) {
           </Stack>
           <Modal.ButtonRow>
             <Button variant="secondary" fill="outline" onClick={onClose} disabled={state === 'saving'}>
-              Cancel
+              <Trans i18nKey="save-search-modal.cancel">Cancel</Trans>
             </Button>
             <Button type="submit" disabled={!title || state === 'saving'}>
-              Save
+              <Trans i18nKey="save-search-modal.save">Save</Trans>
             </Button>
           </Modal.ButtonRow>
         </form>
       ) : (
         <>
-          <Alert title="Success" severity="success">
-            Search successfully saved.
+          <Alert title={t('save-search-modal.success-title', 'Success')} severity="success">
+            <Trans i18nKey="save-search-modal.success-message">Search successfully saved.</Trans>
           </Alert>
           <Modal.ButtonRow>
             <Button variant="secondary" fill="outline" onClick={onClose}>
-              Close
+              <Trans i18nKey="save-search-modal.close">Close</Trans>
             </Button>
           </Modal.ButtonRow>
         </>

--- a/src/components/Explore/Search.tsx
+++ b/src/components/Explore/Search.tsx
@@ -1,6 +1,7 @@
 import { Field, Input, Icon, useStyles2 } from "@grafana/ui"
 import React from "react"
 import { GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { css } from "@emotion/css";
 
 type Props = {
@@ -15,7 +16,7 @@ export const Search = (props: Props) => {
   return (
     <Field className={styles.searchField}>
       <Input
-        placeholder='Search'
+        placeholder={t('search.placeholder', 'Search')}
         prefix={<Icon name={'search'} />}
         value={searchQuery}
         onChange={onSearchQueryChange}

--- a/src/components/Explore/StreamingIndicator.tsx
+++ b/src/components/Explore/StreamingIndicator.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { Icon, Tooltip, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
@@ -19,7 +20,7 @@ export const StreamingIndicator = ({
   }
 
   return (
-    <Tooltip content={'Streaming'}>
+    <Tooltip content={t('streaming-indicator.tooltip', 'Streaming')}>
       <Icon name={'circle-mono'} size="md" className={styles.streamingIndicator} />
     </Tooltip>
   );

--- a/src/components/Explore/TraceQLIssueDetector.tsx
+++ b/src/components/Explore/TraceQLIssueDetector.tsx
@@ -7,6 +7,7 @@ import {
 } from '@grafana/scenes';
 import { getDatasourceVariable } from '../../utils/utils';
 import { Alert, LinkButton } from '@grafana/ui';
+import { t, Trans } from '@grafana/i18n';
 import React from 'react';
 
 interface TraceQLIssueDetectorState extends SceneObjectState {
@@ -85,9 +86,6 @@ export class TraceQLIssueDetector extends SceneObjectBase<TraceQLIssueDetectorSt
   }
 } 
 
-const TraceQLWarningTitle = 'TraceQL metrics not configured';
-const TraceQLWarningMessage = 'We found an error running a TraceQL metrics query: "localblocks processor not found". This typically means the "local-blocks" processor is not configured in Tempo, which is required for Grafana Traces Drilldown to work.';
-
 export const TraceQLConfigWarning: React.FC<{ detector: TraceQLIssueDetector }> = ({ detector }) => {
   const { hasIssue } = detector.useState();
 
@@ -98,10 +96,10 @@ export const TraceQLConfigWarning: React.FC<{ detector: TraceQLIssueDetector }> 
   return (
     <Alert
       severity="warning"
-      title={TraceQLWarningTitle}
+      title={t('traceql-issue-detector.warning-title', 'TraceQL metrics not configured')}
     >
       <p>
-        {TraceQLWarningMessage}
+        {t('traceql-issue-detector.warning-message', 'We found an error running a TraceQL metrics query: "localblocks processor not found". This typically means the "local-blocks" processor is not configured in Tempo, which is required for Grafana Traces Drilldown to work.')}
         <LinkButton
           icon="external-link-alt"
           fill="text"
@@ -109,7 +107,7 @@ export const TraceQLConfigWarning: React.FC<{ detector: TraceQLIssueDetector }> 
           target="_blank"
           href="https://grafana.com/docs/tempo/latest/operations/traceql-metrics"
         >
-          Read documentation
+          <Trans i18nKey="traceql-issue-detector.read-documentation">Read documentation</Trans>
         </LinkButton>
       </p>
     </Alert>

--- a/src/components/Explore/TracesByService/DurationComparisonControl.tsx
+++ b/src/components/Explore/TracesByService/DurationComparisonControl.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { SceneObjectBase, SceneComponentProps, SceneObjectState } from '@grafana/scenes';
 import { GrafanaTheme2 } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
 import { Button, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { getMetricValue, getTraceByServiceScene, shouldShowSelection } from 'utils/utils';
@@ -50,7 +51,7 @@ export class DurationComparisonControl extends SceneObjectBase<ComparisonControl
           onClick={model.startInvestigation}
           tooltip={tooltip}
         >
-          {isDisabled ? 'Slowest traces selected' : 'Select slowest traces'}
+          {isDisabled ? <Trans i18nKey="duration-comparison-control.slowest-traces-selected">Slowest traces selected</Trans> : <Trans i18nKey="duration-comparison-control.select-slowest-traces">Select slowest traces</Trans>}
         </Button>
       </div>
     );

--- a/src/components/Explore/TracesByService/REDPanel.tsx
+++ b/src/components/Explore/TracesByService/REDPanel.tsx
@@ -11,6 +11,7 @@ import {
   SceneObjectState,
 } from '@grafana/scenes';
 import { arrayToDataFrame, DataFrame, GrafanaTheme2, LoadingState, DataTopic } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { ComparisonSelection, EMPTY_STATE_ERROR_MESSAGE, explorationDS, MetricFunction } from 'utils/shared';
 import { EmptyStateScene } from 'components/states/EmptyState/EmptyStateScene';
 import { LoadingStateScene } from 'components/states/LoadingState/LoadingStateScene';
@@ -255,7 +256,7 @@ export class REDPanel extends SceneObjectBase<RateMetricsPanelState> {
         lineWidth: 1,
         lineStyle: 'solid',
         color: SelectionColor,
-        text: 'Comparison selection',
+        text: t('red-panel.comparison-selection', 'Comparison selection'),
       },
     ]);
     frame.name = 'xymark';

--- a/src/components/Explore/TracesByService/Tabs/AdaptiveTraces/AdaptiveTracesScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/AdaptiveTraces/AdaptiveTracesScene.tsx
@@ -7,6 +7,7 @@ import {
   SceneObjectState,
   sceneGraph,
 } from '@grafana/scenes';
+import { t } from '@grafana/i18n';
 import { useStyles2, LoadingPlaceholder } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { TimeRange } from '@grafana/data';
@@ -65,7 +66,7 @@ export class AdaptiveTracesScene extends SceneObjectBase<AdaptiveTracesSceneStat
     if (isLoading) {
       return (
         <div className={styles.container}>
-          <LoadingPlaceholder text="Loading Adaptive Traces..." />
+          <LoadingPlaceholder text={t('adaptive-traces-scene.loading', 'Loading Adaptive Traces...')} />
         </div>
       );
     }

--- a/src/components/Explore/TracesByService/Tabs/Breakdown/AttributesBreakdownScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Breakdown/AttributesBreakdownScene.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 
 import { DataFrame, GrafanaTheme2 } from '@grafana/data';
 import { CustomVariable, SceneComponentProps, SceneObject, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+import { t } from '@grafana/i18n';
 import { Stack, useStyles2 } from '@grafana/ui';
 
 import { MetricFunction } from '../../../../../utils/shared';
@@ -124,8 +125,8 @@ export class AttributesBreakdownScene extends SceneObjectBase<AttributesBreakdow
               metric === 'duration'
                 ? []
                 : [
-                    { label: 'Rate', color: 'green' },
-                    { label: 'Error', color: 'red' },
+                    { label: t('attributes-breakdown-scene.rate-label', 'Rate'), color: 'green' },
+                    { label: t('attributes-breakdown-scene.error-label', 'Error'), color: 'red' },
                   ]
             }
           />

--- a/src/components/Explore/TracesByService/Tabs/Breakdown/PercentilesSelect.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Breakdown/PercentilesSelect.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { CustomVariable } from '@grafana/scenes';
 import { Label, MultiCombobox, Stack, useStyles2 } from '@grafana/ui';
+import { t, Trans } from '@grafana/i18n';
 import React, { useEffect } from 'react';
 
 export const PercentilesSelect = ({ percentilesVariable }: { percentilesVariable: CustomVariable }) => {
@@ -9,11 +10,11 @@ export const PercentilesSelect = ({ percentilesVariable }: { percentilesVariable
   const styles = useStyles2(getStyles);
 
   const options = [
-    { label: 'p50', value: '0.5' },
-    { label: 'p75', value: '0.75' },
-    { label: 'p90', value: '0.9', description: 'Default' },
-    { label: 'p95', value: '0.95' },
-    { label: 'p99', value: '0.99' },
+    { label: t('percentiles-select.p50', 'p50'), value: '0.5' },
+    { label: t('percentiles-select.p75', 'p75'), value: '0.75' },
+    { label: t('percentiles-select.p90', 'p90'), value: '0.9', description: t('percentiles-select.default', 'Default') },
+    { label: t('percentiles-select.p95', 'p95'), value: '0.95' },
+    { label: t('percentiles-select.p99', 'p99'), value: '0.99' },
   ];
 
   useEffect(() => {
@@ -24,7 +25,7 @@ export const PercentilesSelect = ({ percentilesVariable }: { percentilesVariable
 
   return (
     <Stack>
-      <Label className={styles.label}>Percentiles</Label>
+      <Label className={styles.label}><Trans i18nKey="percentiles-select.label">Percentiles</Trans></Label>
       <MultiCombobox<string>
         width={'auto'}
         minWidth={20}

--- a/src/components/Explore/TracesByService/Tabs/Comparison/AttributesComparisonScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Comparison/AttributesComparisonScene.tsx
@@ -14,6 +14,7 @@ import {
   VariableDependencyConfig,
   VariableValue,
 } from '@grafana/scenes';
+import { t } from '@grafana/i18n';
 import { Checkbox, getTheme, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 
 import {
@@ -226,17 +227,17 @@ export class AttributesComparisonScene extends SceneObjectBase<AttributesCompari
       <div className={styles.container}>
         <div className={styles.controls}>
           <AttributesDescription
-            description="Attributes are ordered by the difference between the baseline and selection values for each value."
+            description={t('attributes-comparison-scene.description', 'Attributes are ordered by the difference between the baseline and selection values for each value.')}
             tags={[
               {
-                label: 'Baseline',
+                label: t('attributes-comparison-scene.baseline-label', 'Baseline'),
                 color:
                   traceExploration.getMetricFunction() === 'duration'
                     ? BaselineColor
                     : getTheme().visualization.getColorByName('semi-dark-green'),
               },
               {
-                label: 'Selection',
+                label: t('attributes-comparison-scene.selection-label', 'Selection'),
                 color:
                   traceExploration.getMetricFunction() === 'duration'
                     ? SelectionColor
@@ -245,13 +246,13 @@ export class AttributesComparisonScene extends SceneObjectBase<AttributesCompari
             ]}
           />
           <div className={styles.controlsRight}>
-            <Tooltip content="Hide panels that only have baseline percentage and no selection">
+            <Tooltip content={t('attributes-comparison-scene.hide-baseline-only-tooltip', 'Hide panels that only have baseline percentage and no selection')}>
               <div>
                 <Checkbox
                   data-testid="comparison-hide-baseline-only"
                   value={hideBaselineOnlyPanels ?? false}
                   onChange={(ev) => model.setState({ hideBaselineOnlyPanels: ev.currentTarget.checked ?? false })}
-                  label="Hide baseline-only"
+                  label={t('attributes-comparison-scene.hide-baseline-only-label', 'Hide baseline-only')}
                 />
               </div>
             </Tooltip>

--- a/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionsScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionsScene.tsx
@@ -10,6 +10,7 @@ import {
   SceneQueryRunner,
 } from '@grafana/scenes';
 import { GrafanaTheme2, LoadingState, PanelData } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
 import { LoadingStateScene } from 'components/states/LoadingState/LoadingStateScene';
 import { EmptyStateScene } from 'components/states/EmptyState/EmptyStateScene';
 import { EmptyState } from 'components/states/EmptyState/EmptyState';
@@ -168,7 +169,7 @@ export class ExceptionsScene extends SceneObjectBase<ExceptionsSceneState> {
       <div className={styles.container}>
         <div className={styles.header}>
           <div className={styles.description}>
-            View exception details from errored traces for the current set of filters.
+            <Trans i18nKey="exceptions-scene.description">View exception details from errored traces for the current set of filters.</Trans>
           </div>
         </div>
         <div className={styles.content}>

--- a/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionsTable.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionsTable.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Icon, useStyles2, Tooltip } from '@grafana/ui';
+import { t, Trans } from '@grafana/i18n';
 import { css } from '@emotion/css';
 import { SparklineCell } from './SparklineCell';
 import { ExceptionAccordionContent } from './accordion/ExceptionAccordion';
@@ -98,20 +99,20 @@ export const ExceptionsTable = ({ rows, theme, onFilterClick, scene }: Exception
         <thead>
           <tr className={styles.headerRow}>
             <th className={styles.headerCell}>
-              <span>Exception Details</span>
-              <Tooltip content="Exception type, message, service, and last seen timestamp. Use the include/exclude buttons to include or exclude exception messages, or click on type or message to filter.">
+              <span><Trans i18nKey="exceptions-table.header.exception-details">Exception Details</Trans></span>
+              <Tooltip content={t('exceptions-table.header.exception-details-tooltip', 'Exception type, message, service, and last seen timestamp. Use the include/exclude buttons to include or exclude exception messages, or click on type or message to filter.')}>
                 <Icon name="info-circle" size="sm" className={styles.headerIcon} />
               </Tooltip>
             </th>
             <th className={styles.headerCellOccurrences}>
-              <span>Occurrences</span>
-              <Tooltip content="Total number of times this exception has occurred">
+              <span><Trans i18nKey="exceptions-table.header.occurrences">Occurrences</Trans></span>
+              <Tooltip content={t('exceptions-table.header.occurrences-tooltip', 'Total number of times this exception has occurred')}>
                 <Icon name="info-circle" size="sm" className={styles.headerIcon} />
               </Tooltip>
             </th>
             <th className={styles.headerCellFrequency}>
-              <span>Frequency</span>
-              <Tooltip content="Visual representation of exception frequency over time">
+              <span><Trans i18nKey="exceptions-table.header.frequency">Frequency</Trans></span>
+              <Tooltip content={t('exceptions-table.header.frequency-tooltip', 'Visual representation of exception frequency over time')}>
                 <Icon name="info-circle" size="sm" className={styles.headerIcon} />
               </Tooltip>
             </th>
@@ -176,16 +177,16 @@ export const ExceptionsTable = ({ rows, theme, onFilterClick, scene }: Exception
                           <button
                             className={styles.filterButton}
                             onClick={(e) => handleIncludeClick(row.message, e)}
-                            aria-label="Include exception message"
+                            aria-label={t('exceptions-table.include-aria-label', 'Include exception message')}
                           >
-                            Include
+                            <Trans i18nKey="exceptions-table.include">Include</Trans>
                           </button>
                           <button
                             className={styles.filterButton}
                             onClick={(e) => handleExcludeClick(row.message, e)}
-                            aria-label="Exclude exception message"
+                            aria-label={t('exceptions-table.exclude-aria-label', 'Exclude exception message')}
                           >
-                            Exclude
+                            <Trans i18nKey="exceptions-table.exclude">Exclude</Trans>
                           </button>
                         </div>
                       </div>

--- a/src/components/Explore/TracesByService/Tabs/Exceptions/SparklineCell.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/SparklineCell.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FieldType, GrafanaTheme2 } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
 import { Sparkline, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { GraphDrawStyle, VisibilityMode } from '@grafana/schema';
@@ -12,7 +13,7 @@ interface SparklineCellProps {
 export const SparklineCell = ({ seriesData, theme }: SparklineCellProps) => {
   const styles = useStyles2(getStyles);
   if (!seriesData || !seriesData.length) {
-    return <div className={styles.message}>No data</div>;
+    return <div className={styles.message}><Trans i18nKey="sparkline-cell.no-data">No data</Trans></div>;
   }
 
   const countValues = seriesData.map((point) => point.count);
@@ -22,7 +23,7 @@ export const SparklineCell = ({ seriesData, theme }: SparklineCellProps) => {
   const validTimeValues = timeValues.filter((v) => isFinite(v) && !isNaN(v));
 
   if (validCountValues.length < 2 || validTimeValues.length < 2) {
-    return <div className={styles.message}>Not enough data</div>;
+    return <div className={styles.message}><Trans i18nKey="sparkline-cell.not-enough-data">Not enough data</Trans></div>;
   }
 
   const minCount = Math.min(...validCountValues);

--- a/src/components/Explore/TracesByService/Tabs/Exceptions/accordion/ExceptionAccordion.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/accordion/ExceptionAccordion.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { GrafanaTheme2, toOption } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
 import { Stack, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { SceneObject } from '@grafana/scenes';
@@ -33,7 +34,7 @@ export const ExceptionAccordionContent = ({ row, scene }: ExceptionAccordionProp
         <div className={styles.message}>
           {row.message && (
             <div>
-              <span className={styles.errorLabel}>Error:</span>{' '}
+              <span className={styles.errorLabel}><Trans i18nKey="exception-accordion.error-label">Error:</Trans></span>{' '}
               {(() => {
                 const highlight = getMessageHighlight(row.message);
                 if (!highlight) {

--- a/src/components/Explore/TracesByService/Tabs/Exceptions/accordion/ExceptionComparison.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/accordion/ExceptionComparison.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 
 import { css } from '@emotion/css';
 import { DataFrame, GrafanaTheme2, LoadingState } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph, SceneObject, SceneObjectBase, SceneObjectState, SceneQueryRunner } from '@grafana/scenes';
 import { useStyles2 } from '@grafana/ui';
 
@@ -114,7 +115,7 @@ class ExceptionDistributionPanel extends SceneObjectBase<ExceptionDistributionPa
                   <div className={styles.barWrap} aria-hidden={true}>
                     <div className={styles.barFill} style={{ width: barWidth }} />
                   </div>
-                  <div className={styles.meta} title={`${percent}%`}>
+                  <div className={styles.meta} title={t('exception-comparison.percent-title', '{{percent}}%', { percent })}>
                     <span className={styles.pct}>{percent}%</span>
                   </div>
                 </div>

--- a/src/components/Explore/TracesByService/Tabs/Spans/SpanListScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Spans/SpanListScene.tsx
@@ -16,6 +16,7 @@ import { LoadingStateScene } from 'components/states/LoadingState/LoadingStateSc
 import { EmptyStateScene } from 'components/states/EmptyState/EmptyStateScene';
 import { css } from '@emotion/css';
 import Skeleton from 'react-loading-skeleton';
+import { t, Trans } from '@grafana/i18n';
 import { Icon, Link, Stack, TableCellDisplayMode, TableCustomCellOptions, useStyles2, useTheme2 } from '@grafana/ui';
 import { map, Observable } from 'rxjs';
 import {
@@ -95,7 +96,7 @@ export class SpanListScene extends SceneObjectBase<SpanListSceneState> {
                       >
                         {name}
                       </div>
-                      <Link href={this.getLinkToExplore(traceId, spanId)} target={'_blank'} title={'Open in new tab'}>
+                      <Link href={this.getLinkToExplore(traceId, spanId)} target={'_blank'} title={t('span-list-scene.open-in-new-tab', 'Open in new tab')}>
                         <Icon name={'external-link-alt'} size={'sm'} />
                       </Link>
                     </div>
@@ -238,7 +239,7 @@ export class SpanListScene extends SceneObjectBase<SpanListSceneState> {
     return (
       <div className={styles.container}>
         <div className={styles.header}>
-          <div className={styles.description}>View a list of spans for the current set of filters.</div>
+          <div className={styles.description}><Trans i18nKey="span-list-scene.description">View a list of spans for the current set of filters.</Trans></div>
         </div>
         <div className={styles.content}>
           <Stack direction="row" gap={2} width="100%">

--- a/src/components/Explore/TracesByService/Tabs/Structure/StructureScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Structure/StructureScene.tsx
@@ -26,6 +26,7 @@ import { mergeTraces } from '../../../../../utils/trace-merge/merge';
 import { createDataFrame, Field, FieldType, GrafanaTheme2, LinkModel, LoadingState } from '@grafana/data';
 import { TreeNode } from '../../../../../utils/trace-merge/tree-node';
 import { Icon, LinkButton, Stack, Text, useTheme2 } from '@grafana/ui';
+import { t, Trans } from '@grafana/i18n';
 import Skeleton from 'react-loading-skeleton';
 import { EmptyState } from '../../../../states/EmptyState/EmptyState';
 import { css } from '@emotion/css';
@@ -110,7 +111,7 @@ export class StructureTabScene extends SceneObjectBase<ServicesTabSceneState> {
       .setTitle(`Structure for ${tree.serviceName} [${countSpans(tree)} spans used]`)
       .setOption('createFocusSpanLink' as any, (traceId: string, spanId: string): LinkModel<Field> => {
         return {
-          title: 'Open trace',
+          title: t('structure-scene.open-trace', 'Open trace'),
           href: '#',
           onClick: () => openTrace(traceId, spanId),
           origin: {} as Field,
@@ -254,8 +255,8 @@ export class StructureTabScene extends SceneObjectBase<ServicesTabSceneState> {
       case 'rate':
         description = (
           <>
-            <div>Analyse the service structure of the traces that match the current filters.</div>
-            <div>Each panel represents an aggregate view compiled using spans from multiple traces.</div>
+            <div><Trans i18nKey="structure-scene.rate-description">Analyse the service structure of the traces that match the current filters.</Trans></div>
+            <div><Trans i18nKey="structure-scene.rate-panel-info">Each panel represents an aggregate view compiled using spans from multiple traces.</Trans></div>
           </>
         );
         emptyMsg = 'server';
@@ -263,8 +264,8 @@ export class StructureTabScene extends SceneObjectBase<ServicesTabSceneState> {
       case 'errors':
         description = (
           <>
-            <div>Analyse the errors structure of the traces that match the current filters.</div>
-            <div>Each panel represents an aggregate view compiled using spans from multiple traces.</div>
+            <div><Trans i18nKey="structure-scene.errors-description">Analyse the errors structure of the traces that match the current filters.</Trans></div>
+            <div><Trans i18nKey="structure-scene.errors-panel-info">Each panel represents an aggregate view compiled using spans from multiple traces.</Trans></div>
           </>
         );
         emptyMsg = 'error';
@@ -272,8 +273,8 @@ export class StructureTabScene extends SceneObjectBase<ServicesTabSceneState> {
       case 'duration':
         description = (
           <>
-            <div>Analyse the structure of slow spans from the traces that match the current filters.</div>
-            <div>Each panel represents an aggregate view compiled using spans from multiple traces.</div>
+            <div><Trans i18nKey="structure-scene.duration-description">Analyse the structure of slow spans from the traces that match the current filters.</Trans></div>
+            <div><Trans i18nKey="structure-scene.duration-panel-info">Each panel represents an aggregate view compiled using spans from multiple traces.</Trans></div>
           </>
         );
         emptyMsg = 'slow';
@@ -289,19 +290,18 @@ export class StructureTabScene extends SceneObjectBase<ServicesTabSceneState> {
         </Text>
         <Text textAlignment={'center'} variant="body">
           <div className={styles.longText}>
-            The structure tab shows {emptyMsg} spans beneath what you are currently investigating. Currently, there are
-            no descendant {emptyMsg} spans beneath the spans you are investigating.
+            <Trans i18nKey="structure-scene.no-data-message">The structure tab shows {{ emptyMsg }} spans beneath what you are currently investigating. Currently, there are no descendant {{ emptyMsg }} spans beneath the spans you are investigating.</Trans>
           </div>
         </Text>
         <Stack gap={0.5} alignItems={'center'}>
           <Icon name="info-circle" />
           <Text textAlignment={'center'} variant="body">
-            The structure tab works best with full traces.
+            <Trans i18nKey="structure-scene.works-best">The structure tab works best with full traces.</Trans>
           </Text>
         </Stack>
 
         <div className={styles.actionContainer}>
-          Read more about
+          <Trans i18nKey="structure-scene.read-more">Read more about</Trans>
           <div className={styles.action}>
             <LinkButton
               icon="external-link-alt"

--- a/src/components/Explore/TracesByService/TraceDrawerScene.tsx
+++ b/src/components/Explore/TracesByService/TraceDrawerScene.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { t } from '@grafana/i18n';
 import { SceneObjectState, SceneObjectBase, SceneComponentProps, SceneObject } from '@grafana/scenes';
 import { EmptyStateScene } from 'components/states/EmptyState/EmptyStateScene';
 import { TraceViewPanelScene } from '../panels/TraceViewPanelScene';
@@ -48,7 +49,7 @@ export class TraceDrawerScene extends SceneObjectBase<DetailsSceneState> {
     } else {
       this.setState({
         body: new EmptyStateScene({
-          message: 'No trace selected',
+          message: t('trace-drawer-scene.no-trace-selected', 'No trace selected'),
         }),
       });
     }

--- a/src/components/Explore/TracesByService/TracesByServiceScene.tsx
+++ b/src/components/Explore/TracesByService/TracesByServiceScene.tsx
@@ -48,6 +48,7 @@ import {
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from '../../../utils/analytics';
 import { MiniREDPanel } from './MiniREDPanel';
 import { Icon, LinkButton, Stack, Tooltip, useStyles2 } from '@grafana/ui';
+import { Trans } from '@grafana/i18n';
 import { css } from '@emotion/css';
 import { getDefaultSelectionForMetric } from '../../../utils/comparison';
 import { map, Observable } from 'rxjs';
@@ -298,7 +299,7 @@ export class TracesByServiceScene extends SceneObjectBase<TraceSceneState> {
         <div className={styles.title}>
           <Tooltip content={<MetricTypeTooltip />} placement={'right-start'} interactive>
             <span className={styles.hand}>
-              Select metric type <Icon name={'info-circle'} />
+              <Trans i18nKey="traces-by-service.select-metric-type">Select metric type</Trans> <Icon name={'info-circle'} />
             </span>
           </Tooltip>
         </div>
@@ -313,22 +314,19 @@ const MetricTypeTooltip = () => {
 
   return (
     <Stack direction={'column'} gap={1}>
-      <div className={styles.tooltip.title}>RED metrics for traces</div>
+      <div className={styles.tooltip.title}><Trans i18nKey="traces-by-service.tooltip.title">RED metrics for traces</Trans></div>
       <span className={styles.tooltip.subtitle}>
-        Explore rate, errors, and duration (RED) metrics generated from traces by Tempo.
+        <Trans i18nKey="traces-by-service.tooltip.subtitle">Explore rate, errors, and duration (RED) metrics generated from traces by Tempo.</Trans>
       </span>
       <div className={styles.tooltip.text}>
         <div>
-          <span className={styles.tooltip.emphasize}>Rate</span> - Spans per second that match your filter, useful to
-          find unusual spikes in activity
+          <span className={styles.tooltip.emphasize}><Trans i18nKey="traces-by-service.tooltip.rate-label">Rate</Trans></span> <Trans i18nKey="traces-by-service.tooltip.rate-description">- Spans per second that match your filter, useful to find unusual spikes in activity</Trans>
         </div>
         <div>
-          <span className={styles.tooltip.emphasize}>Errors</span> -Spans that are failing, overall issues in tracing
-          ecosystem
+          <span className={styles.tooltip.emphasize}><Trans i18nKey="traces-by-service.tooltip.errors-label">Errors</Trans></span> <Trans i18nKey="traces-by-service.tooltip.errors-description">-Spans that are failing, overall issues in tracing ecosystem</Trans>
         </div>
         <div>
-          <span className={styles.tooltip.emphasize}>Duration</span> - Amount of time those spans take, represented as a
-          heat map (responds time, latency)
+          <span className={styles.tooltip.emphasize}><Trans i18nKey="traces-by-service.tooltip.duration-label">Duration</Trans></span> <Trans i18nKey="traces-by-service.tooltip.duration-description">- Amount of time those spans take, represented as a heat map (responds time, latency)</Trans>
         </div>
       </div>
 
@@ -345,7 +343,7 @@ const MetricTypeTooltip = () => {
             reportAppInteraction(USER_EVENTS_PAGES.common, USER_EVENTS_ACTIONS.common.metric_docs_link_clicked)
           }
         >
-          Read documentation
+          <Trans i18nKey="traces-by-service.tooltip.read-documentation">Read documentation</Trans>
         </LinkButton>
       </div>
     </Stack>
@@ -367,7 +365,7 @@ function getStyles(theme: GrafanaTheme2) {
       cursor: 'pointer',
     }),
     tooltip: {
-      label: 'tooltip',
+      label: 'tooltip' as const,
       title: css({
         fontSize: '14px',
         fontWeight: 500,

--- a/src/components/Explore/actions/AddToFiltersAction.tsx
+++ b/src/components/Explore/actions/AddToFiltersAction.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { DataFrame, GrafanaTheme2 } from '@grafana/data';
 import { SceneObjectState, SceneObjectBase, SceneComponentProps, AdHocFiltersVariable } from '@grafana/scenes';
+import { t, Trans } from '@grafana/i18n';
 import { useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { getFiltersVariable, getLabelValue } from '../../../utils/utils';
@@ -48,12 +49,12 @@ export class AddToFiltersAction extends SceneObjectBase<AddToFiltersActionState>
     const styles = useStyles2(getStyles);
 
     return (
-      <div className={styles.group} role="group" aria-label="Add to filters">
+      <div className={styles.group} role="group" aria-label={t('add-to-filters-action.aria-label', 'Add to filters')}>
         <button type="button" className={styles.segment} onClick={model.onIncludeClick}>
-          Include
+          <Trans i18nKey="add-to-filters-action.include">Include</Trans>
         </button>
         <button type="button" className={styles.segment} onClick={model.onExcludeClick}>
-          Exclude
+          <Trans i18nKey="add-to-filters-action.exclude">Exclude</Trans>
         </button>
       </div>
     );

--- a/src/components/Explore/actions/InspectAttributeAction.tsx
+++ b/src/components/Explore/actions/InspectAttributeAction.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { Trans } from '@grafana/i18n';
 import {
   SceneObjectState,
   SceneObjectBase,
@@ -20,7 +21,7 @@ export class InspectAttributeAction extends SceneObjectBase<InspectAttributeActi
 
     return (
       <Button variant="secondary" size="sm" fill="solid" onClick={() => model.state.onClick()}>
-        Inspect
+        <Trans i18nKey="inspect-attribute-action.inspect">Inspect</Trans>
       </Button>
     );
   };

--- a/src/components/Explore/layouts/HighestDifferencePanel.tsx
+++ b/src/components/Explore/layouts/HighestDifferencePanel.tsx
@@ -1,5 +1,6 @@
 import { SceneComponentProps, SceneObjectBase, SceneObjectState, VizPanel } from '@grafana/scenes';
 import { DataFrame, GrafanaTheme2 } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
 import { Button, Stack, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import React from 'react';
@@ -92,16 +93,16 @@ export class HighestDifferencePanel extends SceneObjectBase<HighestDifferencePan
           {maxDifference !== undefined && maxDifferenceIndex !== undefined && (
             <>
               <Stack gap={1} justifyContent={'space-between'} alignItems={'center'}>
-                <div className={styles.title}>Highest difference</div>
+                <div className={styles.title}><Trans i18nKey="highest-difference-panel.title">Highest difference</Trans></div>
                 <Stack gap={0.5}>
                   {!includeFilterExists && (
                     <Button size="sm" variant="primary" fill="text" onClick={() => model.onIncludeClick()}>
-                      Include
+                      <Trans i18nKey="highest-difference-panel.include">Include</Trans>
                     </Button>
                   )}
                   {!excludeFilterExists && (
                     <Button size="sm" variant="primary" fill="text" onClick={() => model.onExcludeClick()}>
-                      Exclude
+                      <Trans i18nKey="highest-difference-panel.exclude">Exclude</Trans>
                     </Button>
                   )}
                 </Stack>

--- a/src/components/Explore/layouts/attributeBreakdown.ts
+++ b/src/components/Explore/layouts/attributeBreakdown.ts
@@ -10,6 +10,7 @@ import {
   SceneObject,
   VizPanelState,
 } from '@grafana/scenes';
+import { t } from '@grafana/i18n';
 import { LayoutSwitcher } from '../LayoutSwitcher';
 import { explorationDS, GRID_TEMPLATE_COLUMNS, MetricFunction } from '../../../utils/shared';
 import { ByFrameRepeater } from '../ByFrameRepeater';
@@ -57,9 +58,9 @@ export function buildNormalLayout(
       ],
     }),
     options: [
-      { value: 'single', label: 'Single' },
-      { value: 'grid', label: 'Grid' },
-      { value: 'rows', label: 'Rows' },
+      { value: 'single', label: t('attribute-breakdown.layout-single', 'Single') },
+      { value: 'grid', label: t('attribute-breakdown.layout-grid', 'Grid') },
+      { value: 'rows', label: t('attribute-breakdown.layout-rows', 'Rows') },
     ],
     active: 'grid',
     layouts: [

--- a/src/components/Explore/panels/PanelMenu.tsx
+++ b/src/components/Explore/panels/PanelMenu.tsx
@@ -1,4 +1,5 @@
 import { PanelMenuItem, toURLRange, urlUtil } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import {
   SceneObjectBase,
   VizPanelMenu,
@@ -24,11 +25,11 @@ export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPan
     this.addActivationHandler(() => {
       const items: PanelMenuItem[] = [
         {
-          text: 'Navigation',
+          text: t('panel-menu.navigation', 'Navigation'),
           type: 'group',
         },
         {
-          text: 'Explore',
+          text: t('panel-menu.explore', 'Explore'),
           iconClassName: 'compass',
           href: getExploreHref(this),
           onClick: () => onExploreClick(),

--- a/src/components/Explore/seeker/TimeSeekerControls.tsx
+++ b/src/components/Explore/seeker/TimeSeekerControls.tsx
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react';
 import { AbsoluteTimeRange, GrafanaTheme2, TimeRange, dateTime } from '@grafana/data';
 import { Icon, IconButton, TimeRangeInput, Tooltip, useStyles2, useTheme2 } from '@grafana/ui';
+import { t } from '@grafana/i18n';
 import { useTimeSeeker } from './TimeSeekerContext';
 import { css } from '@emotion/css';
 
@@ -91,48 +92,48 @@ export const TimeSeekerControls: React.FC = () => {
       <div className={styles.floatingControlsContent}>
         {hasLargeBatchWarning && (
           <Tooltip
-            content="The time seeker needs to load a large amount of data. Performance may be impacted."
+            content={t('time-seeker-controls.large-batch-warning', 'The time seeker needs to load a large amount of data. Performance may be impacted.')}
             placement="bottom"
           >
             <Icon name="exclamation-triangle" size="sm" style={{ color: theme.colors.warning.main }} />
           </Tooltip>
         )}
         <IconButton
-          tooltip="Pan left"
+          tooltip={t('time-seeker-controls.pan-left', 'Pan left')}
           name="arrow-left"
           onClick={() => panContextWindow('left')}
           size="sm"
           variant="secondary"
         />
         <IconButton
-          tooltip="Zoom out context"
+          tooltip={t('time-seeker-controls.zoom-out', 'Zoom out context')}
           name="search-minus"
           onClick={() => zoomContextWindow(2)}
           size="sm"
           variant="secondary"
         />
         <IconButton
-          tooltip="Zoom in context"
+          tooltip={t('time-seeker-controls.zoom-in', 'Zoom in context')}
           name="search-plus"
           onClick={() => zoomContextWindow(0.5)}
           size="sm"
           variant="secondary"
         />
         <IconButton
-          tooltip="Pan right"
+          tooltip={t('time-seeker-controls.pan-right', 'Pan right')}
           name="arrow-right"
           onClick={() => panContextWindow('right')}
           size="sm"
           variant="secondary"
         />
         <IconButton
-          tooltip="Focus selection"
+          tooltip={t('time-seeker-controls.focus-selection', 'Focus selection')}
           name="crosshair"
           onClick={resetContextWindow}
           size="sm"
           variant="secondary"
         />
-        <IconButton name="calendar-alt" tooltip="Set range" onClick={handleButtonClick} size="sm" variant="secondary" />
+        <IconButton name="calendar-alt" tooltip={t('time-seeker-controls.set-range', 'Set range')} onClick={handleButtonClick} size="sm" variant="secondary" />
         <div ref={timeRangeInputContainerRef} className={styles.timeRangeInputContainer}>
           <TimeRangeInput
             value={timeRangeValue}

--- a/src/components/Explore/seeker/TimeSeekerScene.tsx
+++ b/src/components/Explore/seeker/TimeSeekerScene.tsx
@@ -8,6 +8,7 @@ import {
   SceneTimeRange,
   sceneGraph,
 } from '@grafana/scenes';
+import { Trans } from '@grafana/i18n';
 import { Text, useStyles2, Spinner } from '@grafana/ui';
 import { css } from '@emotion/css';
 
@@ -415,7 +416,7 @@ export class TimeSeekerScene extends SceneObjectBase<TimeSeekerSceneState> {
 
     const wrapSeekerRow = (body: React.ReactNode) => (
       <div className={styles.seekerRow}>
-        <div className={styles.seekerLabel}>Seeker</div>
+        <div className={styles.seekerLabel}><Trans i18nKey="time-seeker-scene.seeker-label">Seeker</Trans></div>
         <div className={styles.container} ref={containerRef}>
           {body}
         </div>
@@ -428,7 +429,7 @@ export class TimeSeekerScene extends SceneObjectBase<TimeSeekerSceneState> {
         <div className={styles.placeholder}>
           <Spinner size={16} />
           <Text variant="bodySmall" color="secondary">
-            Loading time seeker…
+            <Trans i18nKey="time-seeker-scene.loading">Loading time seeker…</Trans>
           </Text>
         </div>
       );

--- a/src/components/Home/AttributePanelRows.tsx
+++ b/src/components/Home/AttributePanelRows.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
 import { DataFrame, GrafanaTheme2 } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
 import { Icon, useStyles2 } from '@grafana/ui';
 import React from 'react';
 import { HomepagePanelType } from './AttributePanel';
@@ -38,7 +39,7 @@ export const AttributePanelRows = (props: Props) => {
         return <SlowestServicesRows series={series} type={type} />;
     }
   }
-  return <div className={styles.container}>No series data</div>;
+  return <div className={styles.container}><Trans i18nKey="attribute-panel-rows.no-series-data">No series data</Trans></div>;
 };
 
 function getStyles(theme: GrafanaTheme2) {

--- a/src/components/Home/HeaderScene.tsx
+++ b/src/components/Home/HeaderScene.tsx
@@ -7,6 +7,7 @@ import {
   SceneObjectBase,
 } from '@grafana/scenes';
 import { Button, Icon, LinkButton, Stack, useStyles2, useTheme2 } from '@grafana/ui';
+import { Trans } from '@grafana/i18n';
 
 import {
   EXPLORATIONS_ROUTE,
@@ -34,16 +35,16 @@ export class HeaderScene extends SceneObjectBase {
         <div className={styles.header}>
           <div className={styles.headerTitleContainer}>
             {theme.isDark ? <DarkModeRocket /> : <LightModeRocket />}
-            <h2 className={styles.title}>Start your traces exploration!</h2>
+            <h2 className={styles.title}><Trans i18nKey="header-scene.title">Start your traces exploration!</Trans></h2>
           </div>
           <div>
-            <p>Drilldown and visualize your trace data without writing a query.</p>
+            <p><Trans i18nKey="header-scene.subtitle">Drilldown and visualize your trace data without writing a query.</Trans></p>
             <div className={styles.headerActions}>
               <Button variant='primary' onClick={() => {
                   reportAppInteraction(USER_EVENTS_PAGES.home, USER_EVENTS_ACTIONS.home.explore_traces_clicked);
                   navigate(EXPLORATIONS_ROUTE);
                 }}>
-                Let’s start
+                <Trans i18nKey="header-scene.lets-start">{"Let's start"}</Trans>
                 <Icon name='arrow-right' size='lg' />
               </Button>
               <LinkButton
@@ -57,7 +58,7 @@ export class HeaderScene extends SceneObjectBase {
                 className={styles.documentationLink}
                 onClick={() => reportAppInteraction(USER_EVENTS_PAGES.home, USER_EVENTS_ACTIONS.home.read_documentation_clicked)}
               >
-                Read documentation
+                <Trans i18nKey="header-scene.read-documentation">Read documentation</Trans>
               </LinkButton>
             </div>
           </div>
@@ -66,7 +67,7 @@ export class HeaderScene extends SceneObjectBase {
         <Bookmarks />
 
         <div className={styles.subHeader}>
-          <h4>Or quick-start into your tracing data</h4>
+          <h4><Trans i18nKey="header-scene.quick-start">Or quick-start into your tracing data</Trans></h4>
         </div>
 
         <Stack gap={2}>
@@ -74,13 +75,13 @@ export class HeaderScene extends SceneObjectBase {
             <div className={styles.variables}>
               {dsVariable && (
                 <Stack gap={1} alignItems={'center'}>
-                  <div className={styles.label}>Data source</div>
+                  <div className={styles.label}><Trans i18nKey="header-scene.data-source">Data source</Trans></div>
                   <dsVariable.Component model={dsVariable} />
                 </Stack>
               )}
               {filterVariable && (
                 <Stack gap={1} alignItems={'center'}>
-                  <div className={styles.label}>Filter</div>
+                  <div className={styles.label}><Trans i18nKey="header-scene.filter">Filter</Trans></div>
                   <filterVariable.Component model={filterVariable} />
                 </Stack>
               )}

--- a/src/components/states/ErrorState/ErrorStateScene.tsx
+++ b/src/components/states/ErrorState/ErrorStateScene.tsx
@@ -1,3 +1,4 @@
+import { t } from '@grafana/i18n';
 import { SceneObjectState, SceneObjectBase, SceneComponentProps } from '@grafana/scenes';
 import React from 'react';
 import { Alert } from '@grafana/ui';
@@ -11,7 +12,7 @@ export class ErrorStateScene extends SceneObjectBase<ErrorStateSceneState> {
   public static Component = ({ model }: SceneComponentProps<ErrorStateScene>) => {
     const { message } = model.useState();
     return (
-      <Alert title={'Query error'} severity={'error'} data-testid={testIds.errorState}>
+      <Alert title={t('error-state-scene.query-error', 'Query error')} severity={'error'} data-testid={testIds.errorState}>
         {message}
       </Alert>
     );

--- a/src/exposedComponents/OpenInExploreTracesButton/OpenInExploreTracesButton.tsx
+++ b/src/exposedComponents/OpenInExploreTracesButton/OpenInExploreTracesButton.tsx
@@ -1,3 +1,4 @@
+import { Trans } from '@grafana/i18n';
 import { useReturnToPrevious } from '@grafana/runtime';
 import { LinkButton } from '@grafana/ui';
 import React, { useMemo } from 'react';
@@ -52,7 +53,7 @@ export default function OpenInExploreTracesButton({
       href={href}
       onClick={() => setReturnToPrevious(returnToPreviousSource || 'previous')}
     >
-      Open in Traces Drilldown
+      <Trans i18nKey="open-in-explore-traces-button.label">Open in Traces Drilldown</Trans>
     </LinkButton>
   );
 }

--- a/src/exposedComponents/index.tsx
+++ b/src/exposedComponents/index.tsx
@@ -1,3 +1,4 @@
+import { Trans } from '@grafana/i18n';
 import { LinkButton } from '@grafana/ui';
 import { OpenFeaturePluginScope } from 'featureFlags/openFeature';
 import { OpenInExploreTracesButtonProps, EmbeddedTraceExplorationState } from 'exposedComponents/types';
@@ -14,7 +15,7 @@ export function SuspendedOpenInExploreTracesButton(props: OpenInExploreTracesBut
     <Suspense
       fallback={
         <LinkButton variant="secondary" disabled>
-          Open in Traces Drilldown
+          <Trans i18nKey="exposed-components.open-in-traces-drilldown">Open in Traces Drilldown</Trans>
         </LinkButton>
       }
     >
@@ -25,7 +26,7 @@ export function SuspendedOpenInExploreTracesButton(props: OpenInExploreTracesBut
 
 export function SuspendedEmbeddedTraceExploration(props: EmbeddedTraceExplorationState) {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<div><Trans i18nKey="exposed-components.loading">Loading...</Trans></div>}>
       <OpenFeaturePluginScope>
         <EmbeddedTraceExploration {...props} />
       </OpenFeaturePluginScope>

--- a/src/locales/en-US/grafana-exploretraces-app.json
+++ b/src/locales/en-US/grafana-exploretraces-app.json
@@ -1,10 +1,298 @@
 {
+  "adaptive-traces-scene": {
+    "loading": "Loading Adaptive Traces..."
+  },
+  "add-to-filters-action": {
+    "aria-label": "Add to filters",
+    "exclude": "Exclude",
+    "include": "Include"
+  },
   "app": {
     "page-title": "Traces Drilldown"
+  },
+  "app-config": {
+    "disable-plugin": "Disable plugin",
+    "enable-plugin": "Enable plugin",
+    "field": {
+      "query-range": "Query Range",
+      "query-range-description": "The time range for each cached batch in the Time Seeker. Larger values mean fewer queries but more data per query."
+    },
+    "fieldset": {
+      "enable-disable": "Enable / Disable",
+      "time-seeker-settings": "Time Seeker Settings"
+    },
+    "plugin-enabled": "The plugin is currently enabled.",
+    "plugin-not-enabled": "The plugin is currently not enabled.",
+    "save-settings": "Save settings"
+  },
+  "attribute-breakdown": {
+    "layout-grid": "Grid",
+    "layout-rows": "Rows",
+    "layout-single": "Single"
+  },
+  "attribute-panel-rows": {
+    "no-series-data": "No series data"
+  },
+  "attributes-breakdown-scene": {
+    "error-label": "Error",
+    "rate-label": "Rate"
+  },
+  "attributes-comparison-scene": {
+    "baseline-label": "Baseline",
+    "description": "Attributes are ordered by the difference between the baseline and selection values for each value.",
+    "hide-baseline-only-label": "Hide baseline-only",
+    "hide-baseline-only-tooltip": "Hide panels that only have baseline percentage and no selection",
+    "selection-label": "Selection"
+  },
+  "attributes-sidebar": {
+    "add-to-favorites": "Add to favorites",
+    "all-button": "All",
+    "clear-search": "Clear search",
+    "drop-here": "Drop here",
+    "drop-here-below": "Drop here",
+    "no-available": "No attributes available",
+    "no-match": "No attributes match your criteria",
+    "none": "None",
+    "remove-from-favorites": "Remove from favorites",
+    "scope": {
+      "all": "All",
+      "favorites": "Favorites",
+      "resource": "Resource",
+      "span": "Span"
+    },
+    "search-placeholder": "Search attributes...",
+    "selected": "Selected:",
+    "selected-count_one": "Selected ({{count}}):",
+    "selected-count_other": "Selected ({{count}}):"
+  },
+  "bookmark-icon": {
+    "bookmark": "Bookmark",
+    "remove-bookmark": "Remove bookmark"
+  },
+  "bookmark-item": {
+    "description": "<0>{{metric}}</0> of <2>{{signal}}</2> ({{actionView}})"
+  },
+  "bookmarks": {
+    "loading": "Loading bookmarks...",
+    "no-bookmarks": "Bookmark your favorite queries to view them here.",
+    "or-view-bookmarks": "Or view bookmarks",
+    "remove-bookmark": "Remove bookmark"
+  },
+  "by-frame-repeater": {
+    "no-data-for-search": "No data for search term"
+  },
+  "duration-comparison-control": {
+    "select-slowest-traces": "Select slowest traces",
+    "slowest-traces-selected": "Slowest traces selected"
+  },
+  "error-state-scene": {
+    "query-error": "Query error"
+  },
+  "exception-accordion": {
+    "error-label": "Error:"
+  },
+  "exception-comparison": {
+    "percent-title": "{{percent}}%"
+  },
+  "exceptions-scene": {
+    "description": "View exception details from errored traces for the current set of filters."
+  },
+  "exceptions-table": {
+    "exclude": "Exclude",
+    "exclude-aria-label": "Exclude exception message",
+    "header": {
+      "exception-details": "Exception Details",
+      "exception-details-tooltip": "Exception type, message, service, and last seen timestamp. Use the include/exclude buttons to include or exclude exception messages, or click on type or message to filter.",
+      "frequency": "Frequency",
+      "frequency-tooltip": "Visual representation of exception frequency over time",
+      "occurrences": "Occurrences",
+      "occurrences-tooltip": "Total number of times this exception has occurred"
+    },
+    "include": "Include",
+    "include-aria-label": "Include exception message"
+  },
+  "exemplars": {
+    "view-trace": "View trace"
+  },
+  "exposed-components": {
+    "loading": "Loading...",
+    "open-in-traces-drilldown": "Open in Traces Drilldown"
   },
   "grafana-ui": {
     "drawer": {
       "close": "Close"
+    }
+  },
+  "header-scene": {
+    "data-source": "Data source",
+    "filter": "Filter",
+    "lets-start": "Let's start",
+    "quick-start": "Or quick-start into your tracing data",
+    "read-documentation": "Read documentation",
+    "subtitle": "Drilldown and visualize your trace data without writing a query.",
+    "title": "Start your traces exploration!"
+  },
+  "highest-difference-panel": {
+    "exclude": "Exclude",
+    "include": "Include",
+    "title": "Highest difference"
+  },
+  "home": {
+    "data-source-label": "Data source",
+    "errored-services": "Errored services",
+    "slow-services": "Slow services",
+    "slow-traces": "Slow traces"
+  },
+  "insights-timeline-widget": {
+    "label": "Insights"
+  },
+  "inspect-attribute-action": {
+    "inspect": "Inspect"
+  },
+  "layout-switcher": {
+    "view-label": "View"
+  },
+  "load-search-modal": {
+    "no-saved-searches": "No saved searches to display.",
+    "remove-tooltip": "Remove",
+    "select-button": "Select",
+    "title": "Load a previously saved search"
+  },
+  "load-search-scene": {
+    "load-saved-query": "Load saved query",
+    "load-saved-search": "Load saved search",
+    "no-saved-searches": "No saved searches to load"
+  },
+  "open-in-explore-traces-button": {
+    "label": "Open in Traces Drilldown"
+  },
+  "panel-menu": {
+    "explore": "Explore",
+    "navigation": "Navigation"
+  },
+  "percentiles-select": {
+    "default": "Default",
+    "label": "Percentiles",
+    "p50": "p50",
+    "p75": "p75",
+    "p90": "p90",
+    "p95": "p95",
+    "p99": "p99"
+  },
+  "primary-signal-variable": {
+    "primary-signal": "Primary signal",
+    "primary-signal-label": "Primary signal"
+  },
+  "red-panel": {
+    "comparison-selection": "Comparison selection"
+  },
+  "save-search-button": {
+    "save-in-saved-queries": "Save in Saved Queries",
+    "save-search": "Save search"
+  },
+  "save-search-modal": {
+    "cancel": "Cancel",
+    "close": "Close",
+    "existing-search-warning": "There is a previously saved search with the same query: {{title}}",
+    "field": {
+      "description": "Description",
+      "title": "Title"
+    },
+    "info-alert": "Saved searches are stored locally in your browser and will only be available on this device.",
+    "save": "Save",
+    "success-message": "Search successfully saved.",
+    "success-title": "Success",
+    "title": "Save current search"
+  },
+  "search": {
+    "placeholder": "Search"
+  },
+  "smart-drawer": {
+    "back-to-all-traces": "Back to all traces"
+  },
+  "span-list-scene": {
+    "description": "View a list of spans for the current set of filters.",
+    "open-in-new-tab": "Open in new tab"
+  },
+  "sparkline-cell": {
+    "no-data": "No data",
+    "not-enough-data": "Not enough data"
+  },
+  "streaming-indicator": {
+    "tooltip": "Streaming"
+  },
+  "structure-scene": {
+    "duration-description": "Analyse the structure of slow spans from the traces that match the current filters.",
+    "duration-panel-info": "Each panel represents an aggregate view compiled using spans from multiple traces.",
+    "errors-description": "Analyse the errors structure of the traces that match the current filters.",
+    "errors-panel-info": "Each panel represents an aggregate view compiled using spans from multiple traces.",
+    "no-data-message": "The structure tab shows {{emptyMsg}} spans beneath what you are currently investigating. Currently, there are no descendant {{emptyMsg}} spans beneath the spans you are investigating.",
+    "open-trace": "Open trace",
+    "rate-description": "Analyse the service structure of the traces that match the current filters.",
+    "rate-panel-info": "Each panel represents an aggregate view compiled using spans from multiple traces.",
+    "read-more": "Read more about",
+    "works-best": "The structure tab works best with full traces."
+  },
+  "time-seeker-controls": {
+    "focus-selection": "Focus selection",
+    "large-batch-warning": "The time seeker needs to load a large amount of data. Performance may be impacted.",
+    "pan-left": "Pan left",
+    "pan-right": "Pan right",
+    "set-range": "Set range",
+    "zoom-in": "Zoom in context",
+    "zoom-out": "Zoom out context"
+  },
+  "time-seeker-scene": {
+    "loading": "Loading time seeker…",
+    "seeker-label": "Seeker"
+  },
+  "trace-drawer-scene": {
+    "no-trace-selected": "No trace selected"
+  },
+  "trace-exploration": {
+    "drawer": {
+      "view-trace": "View trace {{traceId}}"
+    },
+    "embedded-header": {
+      "traces-drilldown": "Traces Drilldown"
+    },
+    "header": {
+      "data-source": "Data source",
+      "filters": "Filters",
+      "need-help": "Need help",
+      "trace-id": "Trace ID",
+      "trace-id-placeholder": "Enter an ID and press Enter"
+    },
+    "menu": {
+      "documentation": "Documentation",
+      "give-feedback": "Give feedback"
+    },
+    "variable": {
+      "data-source": "Data source",
+      "duration-percentiles": "Duration Percentiles"
+    },
+    "version-header": {
+      "last-update": "Last update: {{compositeVersion}}",
+      "title": "Grafana Traces Drilldown v{{version}}"
+    }
+  },
+  "traceql-issue-detector": {
+    "read-documentation": "Read documentation",
+    "warning-message": "We found an error running a TraceQL metrics query: \"localblocks processor not found\". This typically means the \"local-blocks\" processor is not configured in Tempo, which is required for Grafana Traces Drilldown to work.",
+    "warning-title": "TraceQL metrics not configured"
+  },
+  "traces-by-service": {
+    "select-metric-type": "Select metric type",
+    "tooltip": {
+      "duration-description": "- Amount of time those spans take, represented as a heat map (responds time, latency)",
+      "duration-label": "Duration",
+      "errors-description": "-Spans that are failing, overall issues in tracing ecosystem",
+      "errors-label": "Errors",
+      "rate-description": "- Spans per second that match your filter, useful to find unusual spikes in activity",
+      "rate-label": "Rate",
+      "read-documentation": "Read documentation",
+      "subtitle": "Explore rate, errors, and duration (RED) metrics generated from traces by Tempo.",
+      "title": "RED metrics for traces"
     }
   }
 }

--- a/src/pages/Explore/PrimarySignalVariable.tsx
+++ b/src/pages/Explore/PrimarySignalVariable.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { CustomVariable, MultiValueVariable, MultiValueVariableState, SceneComponentProps } from '@grafana/scenes';
 import { primarySignalOptions } from './primary-signals';
+import { t, Trans } from '@grafana/i18n';
 import { Icon, RadioButtonGroup, Select, useStyles2, Text } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { components, DropdownIndicatorProps } from 'react-select';
@@ -24,7 +25,7 @@ const GroupHeading = () => {
   return (
     <div className={styles.heading}>
       <Text weight="bold" variant="bodySmall" color="secondary">
-        Primary signal
+        <Trans i18nKey="primary-signal-variable.primary-signal">Primary signal</Trans>
       </Text>
     </div>
   );
@@ -76,7 +77,7 @@ export class PrimarySignalVariable extends CustomVariable {
           className={styles.buttonGroup}
         />
         <Select
-          options={[{ label: 'Primary signal', options: selectOptions }]}
+          options={[{ label: t('primary-signal-variable.primary-signal-label', 'Primary signal'), options: selectOptions }]}
           value={''}
           placeholder=""
           isSearchable={false}

--- a/src/pages/Explore/SmartDrawer.tsx
+++ b/src/pages/Explore/SmartDrawer.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 import React from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
 import { Button, useStyles2 } from '@grafana/ui';
 import { Drawer } from './Drawer';
 
@@ -41,7 +42,7 @@ export const SmartDrawer = ({
     <div className={styles.container}>
       <div className={styles.drawerHeader}>
         <Button variant="primary" fill="text" size="md" icon={'arrow-left'} onClick={onClose}>
-          Back to all traces
+          <Trans i18nKey="smart-drawer.back-to-all-traces">Back to all traces</Trans>
         </Button>
       </div>
       {children}

--- a/src/pages/Explore/TraceExploration.tsx
+++ b/src/pages/Explore/TraceExploration.tsx
@@ -19,6 +19,7 @@ import {
 } from '@grafana/scenes';
 import { config, useReturnToPrevious } from '@grafana/runtime';
 import { Button, Dropdown, Icon, Menu, Stack, useStyles2, LinkButton, Input } from '@grafana/ui';
+import { t, Trans } from '@grafana/i18n';
 
 import {
   DATASOURCE_LS_KEY,
@@ -213,7 +214,7 @@ export class TraceExplorationScene extends SceneObjectBase {
           <SmartDrawer
             isOpen={!!drawerScene && !!traceId}
             onClose={onClose}
-            title={`View trace ${traceId}`}
+            title={t('trace-exploration.drawer.view-trace', 'View trace {{traceId}}', { traceId })}
             embedded={embedded}
             forceNoDrawer={embedded}
           >
@@ -293,7 +294,7 @@ const EmbeddedHeader = ({ model }: SceneComponentProps<TraceExplorationScene>) =
               reportAppInteraction(USER_EVENTS_PAGES.common, USER_EVENTS_ACTIONS.common.go_to_full_app_clicked);
             }}
           >
-            Traces Drilldown
+            <Trans i18nKey="trace-exploration.embedded-header.traces-drilldown">Traces Drilldown</Trans>
           </LinkButton>
           {timeRangeControl && <timeRangeControl.Component model={timeRangeControl} />}
           {refreshControl && <refreshControl.Component model={refreshControl} />}
@@ -331,8 +332,8 @@ const TraceExplorationHeader = ({ controls, model }: TraceExplorationHeaderProps
 
     return (
       <div className={styles.menuHeader}>
-        <h5>Grafana Traces Drilldown v{version}</h5>
-        <div className={styles.menuHeaderSubtitle}>Last update: {compositeVersion}</div>
+        <h5><Trans i18nKey="trace-exploration.version-header.title">Grafana Traces Drilldown v{{ version }}</Trans></h5>
+        <div className={styles.menuHeaderSubtitle}><Trans i18nKey="trace-exploration.version-header.last-update">Last update: {{ compositeVersion }}</Trans></div>
       </div>
     );
   }
@@ -342,8 +343,8 @@ const TraceExplorationHeader = ({ controls, model }: TraceExplorationHeaderProps
       <div className={styles.menu}>
         {config.feedbackLinksEnabled && (
           <Menu.Item
-            label="Give feedback"
-            ariaLabel="Give feedback"
+            label={t('trace-exploration.menu.give-feedback', 'Give feedback')}
+            ariaLabel={t('trace-exploration.menu.give-feedback', 'Give feedback')}
             icon={'comment-alt-message'}
             url="https://grafana.qualtrics.com/jfe/form/SV_9LUZ21zl3x4vUcS"
             target="_blank"
@@ -353,8 +354,8 @@ const TraceExplorationHeader = ({ controls, model }: TraceExplorationHeaderProps
           />
         )}
         <Menu.Item
-          label="Documentation"
-          ariaLabel="Documentation"
+          label={t('trace-exploration.menu.documentation', 'Documentation')}
+          ariaLabel={t('trace-exploration.menu.documentation', 'Documentation')}
           icon={'external-link-alt'}
           url="https://grafana.com/docs/grafana/next/explore/simplified-exploration/traces/"
           target="_blank"
@@ -378,7 +379,7 @@ const TraceExplorationHeader = ({ controls, model }: TraceExplorationHeaderProps
         <Stack gap={1} alignItems={'center'} wrap={'wrap'}>
           {dsVariable && (
             <Stack gap={0} alignItems={'center'}>
-              <div className={styles.datasourceLabel}>Data source</div>
+              <div className={styles.datasourceLabel}><Trans i18nKey="trace-exploration.header.data-source">Data source</Trans></div>
               <dsVariable.Component model={dsVariable} />
             </Stack>
           )}
@@ -391,7 +392,7 @@ const TraceExplorationHeader = ({ controls, model }: TraceExplorationHeaderProps
           )}
           <Dropdown overlay={menu} onVisibleChange={() => setMenuVisible(!menuVisible)}>
             <Button variant="secondary" icon="info-circle">
-              Need help
+              <Trans i18nKey="trace-exploration.header.need-help">Need help</Trans>
               <Icon className={styles.helpIcon} name={menuVisible ? 'angle-up' : 'angle-down'} size="lg" />
             </Button>
           </Dropdown>
@@ -403,7 +404,7 @@ const TraceExplorationHeader = ({ controls, model }: TraceExplorationHeaderProps
       <Stack gap={1} alignItems={'flex-start'} justifyContent={'space-between'}>
         <Stack gap={1} alignItems={'center'} wrap={'wrap'}>
           <Stack gap={0} alignItems={'center'}>
-            <div className={styles.datasourceLabel}>Filters</div>
+            <div className={styles.datasourceLabel}><Trans i18nKey="trace-exploration.header.filters">Filters</Trans></div>
             {primarySignalVariable && <primarySignalVariable.Component model={primarySignalVariable} />}
           </Stack>
           {filtersVariable && (
@@ -413,9 +414,9 @@ const TraceExplorationHeader = ({ controls, model }: TraceExplorationHeaderProps
           )}
         </Stack>
         <Stack gap={0} alignItems={'center'}>
-          <div className={styles.datasourceLabel}>Trace ID</div>
+          <div className={styles.datasourceLabel}><Trans i18nKey="trace-exploration.header.trace-id">Trace ID</Trans></div>
           <Input
-            placeholder="Enter an ID and press Enter"
+            placeholder={t('trace-exploration.header.trace-id-placeholder', 'Enter an ID and press Enter')}
             value={localTraceId ?? ''}
             suffix={
               <Stack direction="row" alignItems="center" gap={1} width="40px">
@@ -455,7 +456,7 @@ function getVariableSet(state: TraceExplorationState) {
     variables: [
       new DataSourceVariable({
         name: VAR_DATASOURCE,
-        label: 'Data source',
+        label: t('trace-exploration.variable.data-source', 'Data source'),
         value: state.initialDS,
         pluginId: 'tempo',
         isReadOnly: state.embedded,
@@ -492,7 +493,7 @@ function getVariableSet(state: TraceExplorationState) {
       }),
       new CustomVariable({
         name: VAR_DURATION_PERCENTILES,
-        label: 'Duration Percentiles',
+        label: t('trace-exploration.variable.duration-percentiles', 'Duration Percentiles'),
         value: ['0.9'], // Default to 90th percentile
         isMulti: true,
         includeAll: false,

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -20,6 +20,7 @@ import {
   SceneTimeRangeLike,
   SceneVariableSet,
 } from '@grafana/scenes';
+import { t } from '@grafana/i18n';
 import { useStyles2 } from '@grafana/ui';
 
 import {
@@ -112,7 +113,7 @@ export class Home extends SceneObjectBase<HomeState> {
                     query: `{nestedSetParent < 0 && status = error ${renderedFilters}} | count_over_time() by (resource.service.name)`,
                     step: durString,
                   },
-                  title: 'Errored services',
+                  title: t('home.errored-services', 'Errored services'),
                   type: 'errored-services',
                 }),
               }),
@@ -122,7 +123,7 @@ export class Home extends SceneObjectBase<HomeState> {
                     query: `{nestedSetParent < 0 ${renderedFilters}} | quantile_over_time(duration, 0.9) by (resource.service.name)`,
                     step: durString,
                   },
-                  title: 'Slow services',
+                  title: t('home.slow-services', 'Slow services'),
                   type: 'slowest-services',
                 }),
               }),
@@ -131,7 +132,7 @@ export class Home extends SceneObjectBase<HomeState> {
                   query: {
                     query: `{nestedSetParent<0 ${renderedFilters}} | histogram_over_time(duration)`,
                   },
-                  title: 'Slow traces',
+                  title: t('home.slow-traces', 'Slow traces'),
                   type: 'slowest-traces',
                   filter: renderedFilters,
                 }),
@@ -161,7 +162,7 @@ function getVariableSet(initialFilters: AdHocVariableFilter[], initialDS?: strin
     variables: [
       new DataSourceVariable({
         name: VAR_DATASOURCE,
-        label: 'Data source',
+        label: t('home.data-source-label', 'Data source'),
         value: initialDS,
         pluginId: 'tempo',
       }),

--- a/src/pages/Home/bookmarks/BookmarkIcon.tsx
+++ b/src/pages/Home/bookmarks/BookmarkIcon.tsx
@@ -1,3 +1,4 @@
+import { t } from '@grafana/i18n';
 import { ToolbarButton, Icon } from '@grafana/ui';
 import { TracesByServiceScene } from 'components/Explore/TracesByService/TracesByServiceScene';
 import React, { useEffect, useState } from 'react';
@@ -107,7 +108,7 @@ export const BookmarkIcon = ({ model }: SceneComponentProps<TraceExplorationScen
           <Icon name={'star'} type={'default'} size={'lg'} />
         )
       }
-      tooltip={isBookmarked ? 'Remove bookmark' : 'Bookmark'}
+      tooltip={isBookmarked ? t('bookmark-icon.remove-bookmark', 'Remove bookmark') : t('bookmark-icon.bookmark', 'Bookmark')}
       onClick={toggleBookmarkClicked}
       disabled={isLoading}
     />

--- a/src/pages/Home/bookmarks/BookmarkItem.tsx
+++ b/src/pages/Home/bookmarks/BookmarkItem.tsx
@@ -1,5 +1,6 @@
 import { EVENT_ATTR, FILTER_SEPARATOR, RESOURCE_ATTR, SPAN_ATTR } from "utils/shared";
 import React from "react";
+import { Trans } from '@grafana/i18n';
 import { capitalizeFirstChar } from "utils/utils";
 import { css } from "@emotion/css";
 import { useStyles2 } from "@grafana/ui";
@@ -39,7 +40,8 @@ export const BookmarkItem = ({ bookmark }: { bookmark: Bookmark }) => {
   return (
     <div title={filters}>
       <div>
-        <b>{capitalizeFirstChar(metric)}</b> of <b>{primarySignal.replace('_', ' ')}</b> ({actionView})
+        <Trans i18nKey="bookmark-item.description" values={{ metric: capitalizeFirstChar(metric), signal: primarySignal.replace('_', ' '), actionView }}>
+          <b>{'{{metric}}'}</b>{' of '}<b>{'{{signal}}'}</b>{' ({{actionView}})'}</Trans>
       </div>
       <div className={styles.filters}>
         {filters}

--- a/src/pages/Home/bookmarks/Bookmarks.tsx
+++ b/src/pages/Home/bookmarks/Bookmarks.tsx
@@ -1,5 +1,6 @@
 import { css } from "@emotion/css";
 import { GrafanaTheme2 } from "@grafana/data";
+import { t, Trans } from '@grafana/i18n';
 import { Button, useStyles2, LoadingPlaceholder } from "@grafana/ui";
 import React, { useEffect, useState } from "react";
 import { BookmarkItem } from "./BookmarkItem";
@@ -52,10 +53,10 @@ export const Bookmarks = () => {
     return (
       <div>
         <div className={styles.header}>
-          <h4>Or view bookmarks</h4>
+          <h4><Trans i18nKey="bookmarks.or-view-bookmarks">Or view bookmarks</Trans></h4>
         </div>
         <div className={styles.loading}>
-          <LoadingPlaceholder text="Loading bookmarks..." />
+          <LoadingPlaceholder text={t('bookmarks.loading', 'Loading bookmarks...')} />
         </div>
       </div>
     );
@@ -64,10 +65,10 @@ export const Bookmarks = () => {
   return (
     <div>
       <div className={styles.header}>
-        <h4>Or view bookmarks</h4>
+        <h4><Trans i18nKey="bookmarks.or-view-bookmarks">Or view bookmarks</Trans></h4>
       </div>
       {bookmarks.length === 0 ? (
-        <p className={styles.noBookmarks}>Bookmark your favorite queries to view them here.</p>
+        <p className={styles.noBookmarks}><Trans i18nKey="bookmarks.no-bookmarks">Bookmark your favorite queries to view them here.</Trans></p>
       ) : (
         <div className={styles.bookmarks}>
           {bookmarks.map((bookmark: Bookmark, i: number) => (
@@ -81,7 +82,7 @@ export const Bookmarks = () => {
               </div>
               <div className={styles.remove}>
                 <Button
-                  aria-label="Remove bookmark"
+                  aria-label={t('bookmarks.remove-bookmark', 'Remove bookmark')}
                   variant='secondary' 
                   fill='text' 
                   icon='trash-alt'

--- a/src/utils/exemplars.ts
+++ b/src/utils/exemplars.ts
@@ -1,5 +1,6 @@
 import { map, Observable } from 'rxjs';
 import { DataFrame, DataTopic, Field } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { CustomTransformerDefinition } from '@grafana/scenes';
 
 export const exemplarsTransformations = (
@@ -18,7 +19,7 @@ export const exemplarsTransformations = (
                 // Then, onClick we retrieve the traceId from the url and navigate to the trace exploration scene by setting the state
                 traceIDField.config.links = [
                   {
-                    title: 'View trace',
+                    title: t('exemplars.view-trace', 'View trace'),
                     url: '#${__value.raw}',
                     onClick: (event) => {
                       event.e.stopPropagation(); // Prevent the click event from propagating to the parent anchor


### PR DESCRIPTION
## Summary
- Escalate `@grafana/i18n/no-untranslated-strings` ESLint rule from `warn` to `error` (test files excluded)
- Wrap all ~167 user-facing strings with `t()` / `<Trans>` across 47 source files
- Run i18n extraction to generate `en-US` locale file with all translation keys

Closes #691

## Test plan
- [x] `yarn lint` — 0 errors (7 pre-existing non-i18n warnings only)
- [x] `yarn typecheck` — passes clean
- [x] `yarn test` — 415/415 tests pass
- [x] `yarn i18n:extract:check` — locale file up to date