### PR TITLE
fix: ensure AttributesSidebar displays correctly on smaller screens

### DIFF
--- a/src/components/Explore/AttributesSidebar.tsx
+++ b/src/components/Explore/AttributesSidebar.tsx
@@ -4,7 +4,7 @@ import React, { useMemo, useState, useEffect, useCallback } from 'react';
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { TabsBar, Tab, Input, Icon, IconButton, useStyles2, Badge, Checkbox, Button, useTheme2 } from '@grafana/ui';
 import { t, Trans } from '@grafana/i18n';
-import { RESOURCE_ATTR, SPAN_ATTR, ignoredAttributes } from 'utils/shared';
+import { MIN_PANEL_HEIGHT, RESOURCE_ATTR, SPAN_ATTR, ignoredAttributes } from 'utils/shared';
 import { getFiltersVariable } from 'utils/utils';
 import { SceneObject } from '@grafana/scenes';
 import { useFavoriteAttributes } from 'hooks';
@@ -488,7 +488,7 @@ function getStyles(theme: GrafanaTheme2) {
       backgroundColor: theme.colors.background.primary,
       width: '300px',
       minWidth: '300px',
-      minHeight: '500px',
+      minHeight: MIN_PANEL_HEIGHT,
       border: `1px solid ${theme.colors.border.weak}`,
       borderRadius: theme.shape.radius.default,
       alignSelf: 'stretch',

--- a/src/components/Explore/AttributesSidebar.tsx
+++ b/src/components/Explore/AttributesSidebar.tsx
@@ -307,7 +307,10 @@ export function AttributesSidebar({
   ];
 
   if (showFavorites) {
-    scopeButtons.unshift({ label: t('attributes-sidebar.scope.favorites', 'Favorites'), value: 'Favorites' as ScopeType });
+    scopeButtons.unshift({
+      label: t('attributes-sidebar.scope.favorites', 'Favorites'),
+      value: 'Favorites' as ScopeType,
+    });
   }
 
   return (
@@ -320,12 +323,21 @@ export function AttributesSidebar({
           <div className={styles.selectedAttributeLabel}>
             {isMulti ? (
               <>
-                <strong>{t('attributes-sidebar.selected-count', 'Selected ({{count}}):', { count: getSelectedAttributes().length })}</strong>{' '}
-                {getSelectedAttributes().length > 0 ? getSelectedAttributes().join(', ') : t('attributes-sidebar.none', 'None')}
+                <strong>
+                  {t('attributes-sidebar.selected-count', 'Selected ({{count}}):', {
+                    count: getSelectedAttributes().length,
+                  })}
+                </strong>{' '}
+                {getSelectedAttributes().length > 0
+                  ? getSelectedAttributes().join(', ')
+                  : t('attributes-sidebar.none', 'None')}
               </>
             ) : (
               <>
-                <strong><Trans i18nKey="attributes-sidebar.selected">Selected:</Trans></strong> {selected}
+                <strong>
+                  <Trans i18nKey="attributes-sidebar.selected">Selected:</Trans>
+                </strong>{' '}
+                {selected}
               </>
             )}
           </div>
@@ -378,7 +390,9 @@ export function AttributesSidebar({
       <ul className={styles.attributesList} onDragOver={handleListDragOver} onDragLeave={handleListDragLeave}>
         {filteredAttributes.length === 0 ? (
           <div className={styles.emptyState}>
-            {searchValue || selectedScope !== 'All' ? t('attributes-sidebar.no-match', 'No attributes match your criteria') : t('attributes-sidebar.no-available', 'No attributes available')}
+            {searchValue || selectedScope !== 'All'
+              ? t('attributes-sidebar.no-match', 'No attributes match your criteria')
+              : t('attributes-sidebar.no-available', 'No attributes available')}
           </div>
         ) : (
           filteredAttributes.map((attribute, index) => {
@@ -395,7 +409,9 @@ export function AttributesSidebar({
                 {/* Ghost element above */}
                 {showGhostAbove && (
                   <li className={styles.ghostElement} onDrop={() => handleDrop(index)}>
-                    <div className={styles.ghostContent}><Trans i18nKey="attributes-sidebar.drop-here">Drop here</Trans></div>
+                    <div className={styles.ghostContent}>
+                      <Trans i18nKey="attributes-sidebar.drop-here">Drop here</Trans>
+                    </div>
                   </li>
                 )}
 
@@ -437,7 +453,11 @@ export function AttributesSidebar({
                       variant="secondary"
                       size="sm"
                       className={`${styles.starButton} ${isFavorites ? styles.starButtonActive : ''}`}
-                      tooltip={isFavorites ? t('attributes-sidebar.remove-from-favorites', 'Remove from favorites') : t('attributes-sidebar.add-to-favorites', 'Add to favorites')}
+                      tooltip={
+                        isFavorites
+                          ? t('attributes-sidebar.remove-from-favorites', 'Remove from favorites')
+                          : t('attributes-sidebar.add-to-favorites', 'Add to favorites')
+                      }
                       onClick={(event) => toggleStar(attribute.value, event)}
                     />
                   )}
@@ -446,7 +466,9 @@ export function AttributesSidebar({
                 {/* Ghost element below */}
                 {showGhostBelow && (
                   <li className={styles.ghostElement} onDrop={() => handleDrop(index)}>
-                    <div className={styles.ghostContent}><Trans i18nKey="attributes-sidebar.drop-here-below">Drop here</Trans></div>
+                    <div className={styles.ghostContent}>
+                      <Trans i18nKey="attributes-sidebar.drop-here-below">Drop here</Trans>
+                    </div>
                   </li>
                 )}
               </React.Fragment>
@@ -466,12 +488,16 @@ function getStyles(theme: GrafanaTheme2) {
       backgroundColor: theme.colors.background.primary,
       width: '300px',
       minWidth: '300px',
+      minHeight: '500px',
       border: `1px solid ${theme.colors.border.weak}`,
       borderRadius: theme.shape.radius.default,
+      alignSelf: 'stretch',
+      overflow: 'hidden',
     }),
     header: css({
       display: 'flex',
       flexDirection: 'column',
+      flexShrink: 0,
       width: '100%',
       gap: theme.spacing(1),
       padding: theme.spacing(1),

--- a/src/components/Explore/ByFrameRepeater.tsx
+++ b/src/components/Explore/ByFrameRepeater.tsx
@@ -207,6 +207,9 @@ function getStyles() {
       display: 'flex',
       flexDirection: 'column',
       flexGrow: 1,
+      ['& div:nth-child(2)']: {
+        overflow: 'auto',
+      },
     }),
   };
 }

--- a/src/components/Explore/TracesByService/Tabs/Breakdown/AttributesBreakdownScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Breakdown/AttributesBreakdownScene.tsx
@@ -6,7 +6,7 @@ import { CustomVariable, SceneComponentProps, SceneObject, SceneObjectBase, Scen
 import { t } from '@grafana/i18n';
 import { Stack, useStyles2 } from '@grafana/ui';
 
-import { MetricFunction } from '../../../../../utils/shared';
+import { MetricFunction, MIN_PANEL_HEIGHT } from '../../../../../utils/shared';
 
 import { LayoutSwitcher } from '../../../LayoutSwitcher';
 import { AddToFiltersAction } from '../../../actions/AddToFiltersAction';
@@ -171,7 +171,7 @@ function getStyles(theme: GrafanaTheme2) {
       display: 'flex',
       paddingTop: theme.spacing(0),
       height: 'calc(100vh - 550px)',
-      minHeight: '500px',
+      minHeight: MIN_PANEL_HEIGHT,
     }),
     controls: css({
       flexGrow: 0,

--- a/src/components/Explore/TracesByService/Tabs/Breakdown/AttributesBreakdownScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Breakdown/AttributesBreakdownScene.tsx
@@ -171,6 +171,7 @@ function getStyles(theme: GrafanaTheme2) {
       display: 'flex',
       paddingTop: theme.spacing(0),
       height: 'calc(100vh - 550px)',
+      minHeight: '500px',
     }),
     controls: css({
       flexGrow: 0,

--- a/src/components/Explore/TracesByService/Tabs/Comparison/AttributesComparisonScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Comparison/AttributesComparisonScene.tsx
@@ -17,13 +17,7 @@ import {
 import { t } from '@grafana/i18n';
 import { Checkbox, getTheme, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 
-import {
-  VAR_FILTERS,
-  VAR_PRIMARY_SIGNAL,
-  explorationDS,
-  VAR_FILTERS_EXPR,
-  ALL,
-} from '../../../../../utils/shared';
+import { VAR_FILTERS, VAR_PRIMARY_SIGNAL, explorationDS, VAR_FILTERS_EXPR, ALL } from '../../../../../utils/shared';
 
 import { LayoutSwitcher } from '../../../LayoutSwitcher';
 import { AddToFiltersAction } from '../../../actions/AddToFiltersAction';
@@ -63,7 +57,7 @@ export class AttributesComparisonScene extends SceneObjectBase<AttributesCompari
 
   constructor(state: Partial<AttributesComparisonSceneState>) {
     const stored = localStorage.getItem(HIDE_BASELINE_ONLY_LS_KEY);
-    const hideBaselineOnlyPanels = state.hideBaselineOnlyPanels ?? (stored === 'true');
+    const hideBaselineOnlyPanels = state.hideBaselineOnlyPanels ?? stored === 'true';
     super({
       ...state,
       hideBaselineOnlyPanels,
@@ -90,7 +84,7 @@ export class AttributesComparisonScene extends SceneObjectBase<AttributesCompari
         localStorage.setItem(HIDE_BASELINE_ONLY_LS_KEY, String(newState.hideBaselineOnlyPanels ?? false));
         this.updateData(newState.hideBaselineOnlyPanels, true);
         // Reusing the same query runner: data is already in memory, just re-filtered.
-        this.setBody(variable)
+        this.setBody(variable);
       }
     });
 
@@ -227,7 +221,10 @@ export class AttributesComparisonScene extends SceneObjectBase<AttributesCompari
       <div className={styles.container}>
         <div className={styles.controls}>
           <AttributesDescription
-            description={t('attributes-comparison-scene.description', 'Attributes are ordered by the difference between the baseline and selection values for each value.')}
+            description={t(
+              'attributes-comparison-scene.description',
+              'Attributes are ordered by the difference between the baseline and selection values for each value.'
+            )}
             tags={[
               {
                 label: t('attributes-comparison-scene.baseline-label', 'Baseline'),
@@ -246,7 +243,12 @@ export class AttributesComparisonScene extends SceneObjectBase<AttributesCompari
             ]}
           />
           <div className={styles.controlsRight}>
-            <Tooltip content={t('attributes-comparison-scene.hide-baseline-only-tooltip', 'Hide panels that only have baseline percentage and no selection')}>
+            <Tooltip
+              content={t(
+                'attributes-comparison-scene.hide-baseline-only-tooltip',
+                'Hide panels that only have baseline percentage and no selection'
+              )}
+            >
               <div>
                 <Checkbox
                   data-testid="comparison-hide-baseline-only"
@@ -409,6 +411,7 @@ function getStyles(theme: GrafanaTheme2) {
       display: 'flex',
       paddingTop: theme.spacing(0),
       height: 'calc(100vh - 550px)',
+      minHeight: '500px',
     }),
     controls: css({
       flexGrow: 0,

--- a/src/components/Explore/TracesByService/Tabs/Comparison/AttributesComparisonScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Comparison/AttributesComparisonScene.tsx
@@ -17,7 +17,7 @@ import {
 import { t } from '@grafana/i18n';
 import { Checkbox, getTheme, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 
-import { VAR_FILTERS, VAR_PRIMARY_SIGNAL, explorationDS, VAR_FILTERS_EXPR, ALL } from '../../../../../utils/shared';
+import { VAR_FILTERS, VAR_PRIMARY_SIGNAL, explorationDS, VAR_FILTERS_EXPR, ALL, MIN_PANEL_HEIGHT } from '../../../../../utils/shared';
 
 import { LayoutSwitcher } from '../../../LayoutSwitcher';
 import { AddToFiltersAction } from '../../../actions/AddToFiltersAction';
@@ -411,7 +411,7 @@ function getStyles(theme: GrafanaTheme2) {
       display: 'flex',
       paddingTop: theme.spacing(0),
       height: 'calc(100vh - 550px)',
-      minHeight: '500px',
+      minHeight: MIN_PANEL_HEIGHT,
     }),
     controls: css({
       flexGrow: 0,

--- a/src/components/Explore/TracesByService/Tabs/Spans/SpanListScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Spans/SpanListScene.tsx
@@ -96,7 +96,11 @@ export class SpanListScene extends SceneObjectBase<SpanListSceneState> {
                       >
                         {name}
                       </div>
-                      <Link href={this.getLinkToExplore(traceId, spanId)} target={'_blank'} title={t('span-list-scene.open-in-new-tab', 'Open in new tab')}>
+                      <Link
+                        href={this.getLinkToExplore(traceId, spanId)}
+                        target={'_blank'}
+                        title={t('span-list-scene.open-in-new-tab', 'Open in new tab')}
+                      >
                         <Icon name={'external-link-alt'} size={'sm'} />
                       </Link>
                     </div>
@@ -239,7 +243,9 @@ export class SpanListScene extends SceneObjectBase<SpanListSceneState> {
     return (
       <div className={styles.container}>
         <div className={styles.header}>
-          <div className={styles.description}><Trans i18nKey="span-list-scene.description">View a list of spans for the current set of filters.</Trans></div>
+          <div className={styles.description}>
+            <Trans i18nKey="span-list-scene.description">View a list of spans for the current set of filters.</Trans>
+          </div>
         </div>
         <div className={styles.content}>
           <Stack direction="row" gap={2} width="100%">
@@ -313,6 +319,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       paddingTop: theme.spacing(0),
       height: 'calc(100vh - 550px)',
+      minHeight: '500px',
     }),
   };
 };

--- a/src/components/Explore/TracesByService/Tabs/Spans/SpanListScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Spans/SpanListScene.tsx
@@ -29,6 +29,7 @@ import {
   EMPTY_STATE_ERROR_MESSAGE,
   EMPTY_STATE_ERROR_REMEDY_MESSAGE,
   EventTraceOpened,
+  MIN_PANEL_HEIGHT,
 } from '../../../../../utils/shared';
 import { reportAppInteraction, USER_EVENTS_PAGES, USER_EVENTS_ACTIONS } from 'utils/analytics';
 import { AttributesSidebar } from 'components/Explore/AttributesSidebar';
@@ -319,7 +320,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       paddingTop: theme.spacing(0),
       height: 'calc(100vh - 550px)',
-      minHeight: '500px',
+      minHeight: MIN_PANEL_HEIGHT,
     }),
   };
 };

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -21,6 +21,8 @@ export const DEFAULT_QUERY_RANGE_HOURS = 24;
 
 export const GRID_TEMPLATE_COLUMNS = 'repeat(auto-fit, minmax(400px, 1fr))';
 
+export const MIN_PANEL_HEIGHT = '500px';
+
 export const EMPTY_STATE_ERROR_MESSAGE = 'No data for selected query';
 export const EMPTY_STATE_ERROR_REMEDY_MESSAGE = 'Please try removing some filters or changing your query.';
 


### PR DESCRIPTION
### Problem

On viewports shorter than ~850px, `height: calc(100vh - 550px)` collapses the tab content area too small for the `AttributesSidebar` to render usefully. The sidebar header could be compressed out of view, and the `ByFrameRepeater` panel body had no overflow scrolling.

### Changes

- **`AttributesSidebar`** — added `minHeight`, `alignSelf: 'stretch'`, and `overflow: 'hidden'` to the container; added `flexShrink: 0` to the header to prevent it from being compressed.
- **Breakdown / Comparison / Spans scenes** — added `minHeight: '500px'` to the `content` area so there is always a usable floor on small screens.
- **`ByFrameRepeater`** — added `overflow: 'auto'` to the panel body so it scrolls instead of clipping content.

### Test plan
- [ ] Open Breakdown / Comparison / Spans tabs at a reduced viewport height (< 850px) and verify the sidebar is fully visible and scrollable.
- [ ] Verify the sidebar header is not compressed at any viewport height.
- [ ] Verify no regressions on normal screens.

Fixes #613 