### PR TITLE
fix: Scroll to top when opening a linked span

### DIFF
--- a/src/components/Explore/TracesByService/Tabs/Structure/StructureScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Structure/StructureScene.tsx
@@ -255,8 +255,16 @@ export class StructureTabScene extends SceneObjectBase<ServicesTabSceneState> {
       case 'rate':
         description = (
           <>
-            <div><Trans i18nKey="structure-scene.rate-description">Analyse the service structure of the traces that match the current filters.</Trans></div>
-            <div><Trans i18nKey="structure-scene.rate-panel-info">Each panel represents an aggregate view compiled using spans from multiple traces.</Trans></div>
+            <div>
+              <Trans i18nKey="structure-scene.rate-description">
+                Analyse the service structure of the traces that match the current filters.
+              </Trans>
+            </div>
+            <div>
+              <Trans i18nKey="structure-scene.rate-panel-info">
+                Each panel represents an aggregate view compiled using spans from multiple traces.
+              </Trans>
+            </div>
           </>
         );
         emptyMsg = 'server';
@@ -264,8 +272,16 @@ export class StructureTabScene extends SceneObjectBase<ServicesTabSceneState> {
       case 'errors':
         description = (
           <>
-            <div><Trans i18nKey="structure-scene.errors-description">Analyse the errors structure of the traces that match the current filters.</Trans></div>
-            <div><Trans i18nKey="structure-scene.errors-panel-info">Each panel represents an aggregate view compiled using spans from multiple traces.</Trans></div>
+            <div>
+              <Trans i18nKey="structure-scene.errors-description">
+                Analyse the errors structure of the traces that match the current filters.
+              </Trans>
+            </div>
+            <div>
+              <Trans i18nKey="structure-scene.errors-panel-info">
+                Each panel represents an aggregate view compiled using spans from multiple traces.
+              </Trans>
+            </div>
           </>
         );
         emptyMsg = 'error';
@@ -273,8 +289,16 @@ export class StructureTabScene extends SceneObjectBase<ServicesTabSceneState> {
       case 'duration':
         description = (
           <>
-            <div><Trans i18nKey="structure-scene.duration-description">Analyse the structure of slow spans from the traces that match the current filters.</Trans></div>
-            <div><Trans i18nKey="structure-scene.duration-panel-info">Each panel represents an aggregate view compiled using spans from multiple traces.</Trans></div>
+            <div>
+              <Trans i18nKey="structure-scene.duration-description">
+                Analyse the structure of slow spans from the traces that match the current filters.
+              </Trans>
+            </div>
+            <div>
+              <Trans i18nKey="structure-scene.duration-panel-info">
+                Each panel represents an aggregate view compiled using spans from multiple traces.
+              </Trans>
+            </div>
           </>
         );
         emptyMsg = 'slow';
@@ -290,7 +314,10 @@ export class StructureTabScene extends SceneObjectBase<ServicesTabSceneState> {
         </Text>
         <Text textAlignment={'center'} variant="body">
           <div className={styles.longText}>
-            <Trans i18nKey="structure-scene.no-data-message">The structure tab shows {{ emptyMsg }} spans beneath what you are currently investigating. Currently, there are no descendant {{ emptyMsg }} spans beneath the spans you are investigating.</Trans>
+            <Trans i18nKey="structure-scene.no-data-message">
+              The structure tab shows {{ emptyMsg }} spans beneath what you are currently investigating. Currently,
+              there are no descendant {{ emptyMsg }} spans beneath the spans you are investigating.
+            </Trans>
           </div>
         </Text>
         <Stack gap={0.5} alignItems={'center'}>
@@ -362,9 +389,7 @@ function buildQuery(metric: MetricFunction) {
       break;
   }
 
-  const rootSelectors = `${VAR_FILTERS_EXPR} ${
-    selectionQuery.length ? `&& ${selectionQuery}` : ''
-  }`;
+  const rootSelectors = `${VAR_FILTERS_EXPR} ${selectionQuery.length ? `&& ${selectionQuery}` : ''}`;
 
   // ({${rootSelectors}} &>> { ${metricQuery} }) # finds trees of spans in error or with high duration
   //    || ({${rootSelectors}})                  # finds single spans in error or with high duration
@@ -391,6 +416,8 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       flexDirection: 'column',
       gap: theme.spacing.x1,
+      maxHeight: '100vh',
+      overflow: 'auto',
       // Hide the minimap and header components
       'div[class*="panel-content"] > div': {
         overflow: 'auto',

--- a/src/pages/Explore/Drawer.tsx
+++ b/src/pages/Explore/Drawer.tsx
@@ -75,6 +75,10 @@ export function Drawer({
   // Adds body class while open so the toolbar nav can hide some actions while drawer is open
   useBodyClassWhileOpen();
 
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'instant' });
+  }, []);
+
   const content = <div className={styles.content}>{children}</div>;
   const overrideWidth = drawerWidth ?? drawerSizes[size].width;
   const minWidth = drawerSizes[size].minWidth;


### PR DESCRIPTION
## Scroll to top when opening trace drawer from structure scene

When a user clicks a linked span in the Structure tab, the trace drawer opens but the page may be scrolled down, leaving the drawer header out of view. This change ensures the window scrolls back to the top whenever the drawer is opened.

**Changes:**
- `Drawer.tsx` — adds a `useEffect` that calls `window.scrollTo({ top: 0, behavior: 'instant' })` on mount, so the drawer header is always visible when the drawer opens.
- `StructureScene.tsx` — adds `maxHeight: 100vh` and `overflow: auto` to the structure panel container, constraining its height so the page doesn't accumulate excessive scroll depth in the first place. Also includes minor JSX formatting cleanup.

Fixes #595 