### PR TITLE
fix: gate deploy on CI success via `workflow_run`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@ run-name: Deploy main to dev,ops by @${{ github.actor }}
 
 on:
   workflow_dispatch:
-  workflow_run:
+  workflow_run: # zizmor: ignore[dangerous-triggers] only triggers from CI on main, no untrusted input
     workflows: ["CI"]
     types: [completed]
     branches: [main]

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   CD:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_repository.full_name == github.repository }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_repository.full_name == github.repository) }}
     name: Deploy plugin
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.0.0
     with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,9 +2,11 @@ name: CD
 run-name: Deploy main to dev,ops by @${{ github.actor }}
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
 
 permissions:
   contents: "write"
@@ -14,14 +16,15 @@ permissions:
 
 jobs:
   CD:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     name: Deploy plugin
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.0.0
     with:
-      branch: ${{ github.event_name == 'push' && github.ref_name || github.ref }}
+      branch: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.workflow_run.head_branch }}
       environment: dev,ops
       attestation: true
       run-playwright: false
       grafana-cloud-deployment-type: provisioned
       auto-merge-environments: dev,ops
       argo-workflow-slack-channel: "#proj-tracesdrilldown-cd"
-      plugin-version-suffix: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}
+      plugin-version-suffix: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   CD:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_repository.full_name == github.repository }}
     name: Deploy plugin
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.0.0
     with:


### PR DESCRIPTION
### ✨ Description

Gates the CD workflow on CI success so builds are no longer deployed to dev/ops before tests pass.

### 📖 Summary of the changes

Previously, CI and CD both triggered independently on push to `main` and ran in parallel — a failing CI run would not prevent CD from deploying.

- Replaced `push` trigger with `workflow_run` (fires only after the `CI` workflow completes on `main`)
- Added `if` guard: only proceeds when `workflow_run.conclusion == 'success'`
- Added `workflow_dispatch` trigger for manual re-deploys without re-running CI
- Updated `branch` and `plugin-version-suffix` refs to use the `workflow_run` event payload, with ternaries to handle both trigger paths

### 🧪 How to test?

1. Merge to `main` and verify the CD workflow only starts after CI completes successfully
2. Trigger a manual deploy via the "Run workflow" button in GitHub Actions and verify it runs without needing CI
