### PR TITLE
fix: add webpack alias

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import { Configuration, DefinePlugin } from 'webpack';
 import { merge } from 'webpack-merge';
 import packageJson from './package.json';
@@ -12,6 +14,12 @@ const config = async (env): Promise<Configuration> => {
   const baseConfig = await grafanaConfig(env);
 
   return merge(baseConfig, {
+    resolve: {
+      alias: {
+        // Ensure single instance when using pnpm to prevent i18n state duplication
+        '@grafana/i18n': path.resolve(process.cwd(), 'node_modules/@grafana/i18n'),
+      },
+    },
     plugins: [
       new DefinePlugin({
         'process.env.VERSION': JSON.stringify(packageJson.version),


### PR DESCRIPTION
### ✨ Description

After migrating to pnpm, the plugin can fail to load with `t() was called before i18n was initialized` errors. This is caused by pnpm's symlinked `node_modules` structure causing webpack to bundle multiple copies of `@grafana/i18n`, which breaks the shared module state that the i18n system relies on.

### 📖 Summary of the changes

Added a webpack resolve alias for `@grafana/i18n` in `webpack.config.ts` to force all imports (from both plugin code and `@grafana/scenes`) to resolve to the same absolute path. This ensures webpack bundles only one copy, preserving the shared `tFunc` state that `initPluginTranslations()` sets.

Ported from grafana/metrics-drilldown#985.

### 🧪 How to test?

1. Run the plugin locally with `pnpm dev`
2. Verify the plugin loads without i18n errors
3. Verify translations work correctly (e.g., time picker tooltips)