### PR TITLE
chore: fix CVE via pnpm override

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,8 @@
       "brace-expansion@^5": "^5.0.5",
       "@types/react": "^18.3.28",
       "@types/react-dom": "^18.3.7",
-      "uuid": "^14.0.0"
+      "uuid": "^14.0.0",
+      "@tootallnate/once": ">=3.0.1"
     }
   },
   "packageManager": "pnpm@10.33.1+sha512.05ba3c1d5d1c18f68df06470d74055e62d41fc110a0c660db1b2dfb2785327f04cf0f68345d4609bc52089e7fa0343c31593b2f9594e2c5d5da426230acc9820"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ overrides:
   '@types/react': ^18.3.28
   '@types/react-dom': ^18.3.7
   uuid: ^14.0.0
+  '@tootallnate/once': '>=3.0.1'
 
 importers:
 
@@ -2040,8 +2041,8 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@tootallnate/once@2.0.0':
-    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+  '@tootallnate/once@3.0.1':
+    resolution: {integrity: sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==}
     engines: {node: '>= 10'}
 
   '@tsconfig/node10@1.0.12':
@@ -8292,7 +8293,7 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@tootallnate/once@2.0.0': {}
+  '@tootallnate/once@3.0.1': {}
 
   '@tsconfig/node10@1.0.12': {}
 
@@ -10343,7 +10344,7 @@ snapshots:
 
   http-proxy-agent@5.0.0:
     dependencies:
-      '@tootallnate/once': 2.0.0
+      '@tootallnate/once': 3.0.1
       agent-base: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:


### PR DESCRIPTION
### ✨ Description

Fix `pnpm audit` warning for `@tootallnate/once` (low severity, incorrect control flow scoping when `AbortSignal` is used).

### 📖 Summary of the changes

Added a pnpm override for `@tootallnate/once@>=3.0.1` to resolve the vulnerability. This is a dev-only transitive dependency pulled in via `jest-environment-jsdom > jsdom > http-proxy-agent`. The v3.0.1 package is ESM-only but compatible since the project requires Node >=22 (which supports `require()` of ESM modules).

### 🧪 How to test?

1. `pnpm audit` — should report 0 vulnerabilities
2. `pnpm test:ci` — all 416 tests pass
