### PR TITLE
chore: Stop using the fallback to config.featureToggles

### DIFF
--- a/src/featureFlags/featureFlags.tsx
+++ b/src/featureFlags/featureFlags.tsx
@@ -2,9 +2,8 @@ import type { FeatureToggles } from '@grafana/data';
 import { useBooleanFlagDetails } from '@openfeature/react-sdk';
 import { OpenFeature } from '@openfeature/web-sdk';
 
-import { PLUGIN_OPEN_FEATURE_DOMAIN } from './openFeature';
-
-import { config } from '@grafana/runtime';
+// Grafana core feature flag domain
+const GRAFANA_OPEN_FEATURE_DOMAIN = 'internal-grafana-core';
 
 /**
  * Grafana registry-backed flags via OpenFeature. Call sites must sit under
@@ -22,10 +21,7 @@ export const KG_ANNOTATIONS_FEATURE_FLAG_KEY = 'kgAnnotationsInExploreTraces' as
 
 /** Reads the current flag value synchronously from the OpenFeature client. */
 export function isKgAnnotationsFeatureEnabled(): boolean {
-  const client = OpenFeature.getClient(PLUGIN_OPEN_FEATURE_DOMAIN);
-  const fromOpenFeature = client.getBooleanValue(KG_ANNOTATIONS_FEATURE_FLAG_KEY, false);
-  const fromBootConfig = readBootBooleanFeatureToggle(KG_ANNOTATIONS_FEATURE_FLAG_KEY, false);
-  return fromOpenFeature || fromBootConfig;
+  return OpenFeature.getClient(GRAFANA_OPEN_FEATURE_DOMAIN).getBooleanValue(KG_ANNOTATIONS_FEATURE_FLAG_KEY, false);
 }
 
 export function useFlagTracesDrilldownTimeSeeker(): boolean {
@@ -34,17 +30,4 @@ export function useFlagTracesDrilldownTimeSeeker(): boolean {
 
 export function useFlagQueryLibrary(): boolean {
   return useBooleanFlagDetails(queryLibraryKey, false).value;
-}
-
-/**
- * Reads a boolean from Grafana’s boot `config.featureToggles` without asserting the whole object’s shape.
- * Only actual booleans count; anything else falls back to `defaultValue` (avoids treating `"true"` etc. as on).
- */
-function readBootBooleanFeatureToggle(flagKey: string, defaultValue: boolean): boolean {
-  const togglesUnknown: unknown = config.featureToggles;
-  if (togglesUnknown == null || typeof togglesUnknown !== 'object') {
-    return defaultValue;
-  }
-  const raw = (togglesUnknown as Record<string, unknown>)[flagKey];
-  return typeof raw === 'boolean' ? raw : defaultValue;
 }


### PR DESCRIPTION
### ✨ Description

Moves the check for the `kgAnnotationsInExploreTraces` feature flag to use only the OpenFeature client, from Grafana core. 


