### PR TITLE
feat: Support create alert

### DIFF
--- a/src/components/Explore/TracesByService/Tabs/Breakdown/AttributesBreakdownScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Breakdown/AttributesBreakdownScene.tsx
@@ -1,20 +1,34 @@
 import { css } from '@emotion/css';
+import { DataFrame, GrafanaTheme2, type TimeRange } from '@grafana/data';
+import { usePluginComponent } from '@grafana/runtime';
+import type { Panel } from '@grafana/schema';
 import React, { useEffect } from 'react';
-
-import { DataFrame, GrafanaTheme2 } from '@grafana/data';
-import { CustomVariable, SceneComponentProps, SceneObject, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+import {
+  CustomVariable,
+  SceneComponentProps,
+  SceneObject,
+  SceneObjectBase,
+  SceneObjectState,
+  VizPanel,
+} from '@grafana/scenes';
 import { t } from '@grafana/i18n';
 import { Stack, useStyles2 } from '@grafana/ui';
 
 import { MetricFunction, MIN_PANEL_HEIGHT } from '../../../../../utils/shared';
 
 import { LayoutSwitcher } from '../../../LayoutSwitcher';
+import {
+  getPanelDataForAlert,
+  type AlertPanelTarget,
+  type PanelDataRequestPayload,
+} from '../../../actions/createAlert/getPanelDataForAlert';
 import { AddToFiltersAction } from '../../../actions/AddToFiltersAction';
 import { buildNormalLayout } from '../../../layouts/attributeBreakdown';
 import {
   getAttributesAsOptions,
   getGroupByVariable,
   getPercentilesVariable,
+  getPrimarySignalVariable,
   getTraceByServiceScene,
   getTraceExplorationScene,
 } from 'utils/utils';
@@ -24,8 +38,12 @@ import { PercentilesSelect } from './PercentilesSelect';
 import { AttributesSidebar } from 'components/Explore/AttributesSidebar';
 import { useFavoriteAttributes } from 'hooks/useFavoriteAttributes';
 
+const CREATE_ALERT_FROM_PANEL_PLUGIN_ID = 'grafana/alerting/create-alert-from-panel/v1';
+
 interface AttributesBreakdownSceneState extends SceneObjectState {
   body?: SceneObject;
+  /** Grafana alerting modal payload — owned here so panel menu unmount never drops it. */
+  createAlertPayload?: PanelDataRequestPayload;
 }
 
 export class AttributesBreakdownScene extends SceneObjectBase<AttributesBreakdownSceneState> {
@@ -39,12 +57,25 @@ export class AttributesBreakdownScene extends SceneObjectBase<AttributesBreakdow
 
   private _onActivate() {
     const variable = getGroupByVariable(this);
+    const traceExploration = getTraceExplorationScene(this);
 
     variable.subscribeToState(() => {
       this.setBody(variable);
     });
 
     getTraceByServiceScene(this).subscribeToState(() => {
+      this.setBody(variable);
+    });
+
+    getPrimarySignalVariable(this).subscribeToState(() => {
+      this.setBody(variable);
+    });
+
+    traceExploration.getMetricVariable().subscribeToState(() => {
+      this.setBody(variable);
+    });
+
+    getPercentilesVariable(this).subscribeToState(() => {
       this.setBody(variable);
     });
 
@@ -59,11 +90,31 @@ export class AttributesBreakdownScene extends SceneObjectBase<AttributesBreakdow
     );
   }
 
+  public openBreakdownCreateAlert(vizPanel: VizPanel, targets: AlertPanelTarget[]) {
+    const data = getPanelDataForAlert(vizPanel, targets);
+    if (!data) {
+      return;
+    }
+    reportAppInteraction(USER_EVENTS_PAGES.analyse_traces, USER_EVENTS_ACTIONS.analyse_traces.create_alert_clicked, {
+      title: data.panel.title,
+    });
+    this.setState({ createAlertPayload: data });
+  }
+
+  public clearBreakdownCreateAlert() {
+    this.setState({ createAlertPayload: undefined });
+  }
+
   private setBody = (variable: CustomVariable) => {
     this.setState({
-      body: buildNormalLayout(this, variable, (frame: DataFrame) => [
-        new AddToFiltersAction({ frame, labelKey: variable.getValueText(), onClick: this.onAddToFiltersClick }),
-      ]),
+      body: buildNormalLayout(
+        this,
+        variable,
+        (frame: DataFrame) => [
+          new AddToFiltersAction({ frame, labelKey: variable.getValueText(), onClick: this.onAddToFiltersClick }),
+        ],
+        (vizPanel, targets) => this.openBreakdownCreateAlert(vizPanel, targets)
+      ),
     });
   };
 
@@ -87,7 +138,7 @@ export class AttributesBreakdownScene extends SceneObjectBase<AttributesBreakdow
 
     const { value: groupByValue } = getGroupByVariable(model).useState();
     const groupBy = groupByValue as string;
-    const { body } = model.useState();
+    const { body, createAlertPayload } = model.useState();
     const styles = useStyles2(getStyles);
 
     const { attributes } = getTraceByServiceScene(model).useState();
@@ -118,6 +169,7 @@ export class AttributesBreakdownScene extends SceneObjectBase<AttributesBreakdow
 
     return (
       <div className={styles.container}>
+        <BreakdownCreateAlertModalBridge payload={createAlertPayload} scene={model} />
         <div className={styles.controls}>
           <AttributesDescription
             description={description}
@@ -156,6 +208,40 @@ export class AttributesBreakdownScene extends SceneObjectBase<AttributesBreakdow
       </div>
     );
   };
+}
+
+// Renders the create-alert plugin modal from scene state, not from the panel menu subtree.
+// This avoids a lost modal when the menu popover closes/unmounts right after clicking "Create alert".
+function BreakdownCreateAlertModalBridge({
+  payload,
+  scene,
+}: {
+  payload: PanelDataRequestPayload | undefined;
+  scene: AttributesBreakdownScene;
+}) {
+  const { component: ModalComponent, isLoading } = usePluginComponent<{
+    panel: Panel;
+    range: TimeRange;
+    onDismiss: () => void;
+  }>(CREATE_ALERT_FROM_PANEL_PLUGIN_ID);
+
+  useEffect(() => {
+    if (payload && !isLoading && !ModalComponent) {
+      scene.clearBreakdownCreateAlert();
+    }
+  }, [ModalComponent, isLoading, payload, scene]);
+
+  if (!payload || !ModalComponent || isLoading) {
+    return null;
+  }
+
+  return (
+    <ModalComponent
+      panel={payload.panel}
+      range={payload.range}
+      onDismiss={() => scene.clearBreakdownCreateAlert()}
+    />
+  );
 }
 
 function getStyles(theme: GrafanaTheme2) {

--- a/src/components/Explore/actions/createAlert/getPanelDataForAlert.test.ts
+++ b/src/components/Explore/actions/createAlert/getPanelDataForAlert.test.ts
@@ -1,0 +1,99 @@
+import { sceneGraph, SceneQueryRunner, type VizPanel } from '@grafana/scenes';
+
+import { getPanelDataForAlert } from './getPanelDataForAlert';
+import { VAR_DATASOURCE_EXPR } from '../../../../utils/shared';
+
+jest.mock('@grafana/scenes', () => {
+  class MockSceneQueryRunner {
+    state: Record<string, unknown>;
+
+    constructor(state: Record<string, unknown>) {
+      this.state = state;
+    }
+  }
+
+  return {
+    sceneGraph: {
+      getData: jest.fn(),
+      findObject: jest.fn(),
+      findDescendents: jest.fn(),
+      getTimeRange: jest.fn(),
+      interpolate: jest.fn(),
+    },
+    SceneQueryRunner: MockSceneQueryRunner,
+    VizPanel: class MockVizPanel {},
+  };
+});
+
+const mockedSceneGraph = sceneGraph as unknown as {
+  getData: jest.Mock;
+  findObject: jest.Mock;
+  findDescendents: jest.Mock;
+  getTimeRange: jest.Mock;
+  interpolate: jest.Mock;
+};
+
+const createVizPanel = (): VizPanel =>
+  ({
+    state: {
+      pluginId: 'timeseries',
+      title: 'Panel ${service}',
+      options: {},
+      fieldConfig: {},
+    },
+  }) as unknown as VizPanel;
+
+describe('getPanelDataForAlert', () => {
+  beforeEach(() => {
+    mockedSceneGraph.getData.mockReturnValue({});
+    mockedSceneGraph.findObject.mockReturnValue(undefined);
+    mockedSceneGraph.findDescendents.mockReturnValue([]);
+    mockedSceneGraph.getTimeRange.mockReturnValue({ state: { value: { from: 'now-1h', to: 'now' } } });
+    mockedSceneGraph.interpolate.mockImplementation((_: unknown, value: unknown) => {
+      if (typeof value !== 'string') {
+        return value;
+      }
+      if (value === VAR_DATASOURCE_EXPR) {
+        return 'tempo-from-variable';
+      }
+      return value.replace('${service}', 'checkout');
+    });
+  });
+
+  it('prefers explicit alertTargets over query runner queries', () => {
+    mockedSceneGraph.findObject.mockReturnValue(
+      new SceneQueryRunner({
+        queries: [{ refId: 'A', query: '{runner_query}' }],
+        datasource: { uid: 'tempo-runner' },
+        maxDataPoints: 64,
+      })
+    );
+
+    const result = getPanelDataForAlert(createVizPanel(), [{ query: '{${service}=checkout}' }]);
+
+    expect(result).not.toBeNull();
+    expect(result?.panel.targets).toEqual([{ query: '{checkout=checkout}' }]);
+    expect(result?.panel.targets).not.toEqual([{ query: '{runner_query}' }]);
+    expect(result?.panel.maxDataPoints).toBe(64);
+  });
+
+  it('interpolates datasource via variable path for explicit alertTargets', () => {
+    const result = getPanelDataForAlert(createVizPanel(), [{ query: '{service.name="checkout"}' }]);
+
+    expect(result).not.toBeNull();
+    expect(result?.panel.datasource).toEqual({ uid: 'tempo-from-variable' });
+  });
+
+  it('returns null when neither explicit targets nor query runner targets exist', () => {
+    mockedSceneGraph.findObject.mockReturnValue(
+      new SceneQueryRunner({
+        queries: [],
+        datasource: { uid: 'tempo-runner' },
+      })
+    );
+
+    const result = getPanelDataForAlert(createVizPanel());
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/components/Explore/actions/createAlert/getPanelDataForAlert.ts
+++ b/src/components/Explore/actions/createAlert/getPanelDataForAlert.ts
@@ -1,0 +1,96 @@
+import type { TimeRange } from '@grafana/data';
+import type { Panel } from '@grafana/schema';
+import { sceneGraph, VizPanel, SceneQueryRunner, type SceneObject } from '@grafana/scenes';
+
+import { VAR_DATASOURCE_EXPR } from '../../../../utils/shared';
+
+export interface PanelDataRequestPayload {
+  panel: Panel;
+  range: TimeRange;
+}
+
+/** Grafana panel targets include datasource-specific fields (e.g. TraceQL `query`). */
+export type AlertPanelTarget = Record<string, unknown>;
+
+function interpolateQueryTarget(vizPanel: VizPanel, query: AlertPanelTarget): AlertPanelTarget {
+  const q = { ...query };
+  if (typeof q.query === 'string') {
+    q.query = sceneGraph.interpolate(vizPanel, q.query);
+  }
+  if (typeof q.expr === 'string') {
+    q.expr = sceneGraph.interpolate(vizPanel, q.expr);
+  }
+  if (typeof q.legendFormat === 'string') {
+    q.legendFormat = sceneGraph.interpolate(vizPanel, q.legendFormat);
+  }
+  return q;
+}
+
+function interpolateDatasource(vizPanel: VizPanel, ds: Panel['datasource']): Panel['datasource'] {
+  if (!ds || typeof ds !== 'object') {
+    return ds;
+  }
+  const uid = ds.uid;
+  return {
+    ...ds,
+    uid: uid ? sceneGraph.interpolate(vizPanel, uid) : uid,
+  };
+}
+
+function findQueryRunner(data: SceneObject): SceneQueryRunner | undefined {
+  const direct = sceneGraph.findObject(data, (o) => o instanceof SceneQueryRunner);
+  if (direct instanceof SceneQueryRunner) {
+    return direct;
+  }
+  const fromDescendents = sceneGraph.findDescendents(data, SceneQueryRunner);
+  return fromDescendents[0];
+}
+
+/** Builds alerting payload from a VizPanel (TraceQL / Tempo metrics queries). */
+export function getPanelDataForAlert(
+  vizPanel: VizPanel,
+  alertTargets?: AlertPanelTarget[]
+): PanelDataRequestPayload | null {
+  const data = sceneGraph.getData(vizPanel);
+  if (!data) {
+    return null;
+  }
+
+  const queryRunner = findQueryRunner(data);
+  const timeRange = sceneGraph.getTimeRange(vizPanel);
+  const range = timeRange.state.value;
+
+  let targets: AlertPanelTarget[] = [];
+  let datasource: Panel['datasource'];
+  let maxDataPoints: number | undefined;
+
+  // Prefer explicit targets (e.g. breakdown tiles with attribute=value). Otherwise sceneGraph
+  // finds the layout StepQueryRunner and we would send the aggregate query without per-series filters.
+  if (alertTargets?.length) {
+    targets = alertTargets.map((q) => interpolateQueryTarget(vizPanel, q));
+    datasource = interpolateDatasource(vizPanel, { uid: VAR_DATASOURCE_EXPR });
+    maxDataPoints = queryRunner?.state.maxDataPoints;
+  } else if (queryRunner) {
+    targets = (queryRunner.state.queries ?? []).map((q) => interpolateQueryTarget(vizPanel, q as AlertPanelTarget));
+    datasource = interpolateDatasource(vizPanel, queryRunner.state.datasource as Panel['datasource']);
+    maxDataPoints = queryRunner.state.maxDataPoints;
+  }
+
+  if (!targets.length) {
+    return null;
+  }
+
+  const titleRaw = vizPanel.state.title;
+  const panel: Panel = {
+    type: vizPanel.state.pluginId,
+    title: titleRaw ? sceneGraph.interpolate(vizPanel, titleRaw) : titleRaw,
+    targets: targets as Panel['targets'],
+    datasource,
+    options: vizPanel.state.options,
+    fieldConfig: vizPanel.state.fieldConfig as Panel['fieldConfig'],
+    ...(vizPanel.state.description && { description: vizPanel.state.description }),
+    ...(maxDataPoints && { maxDataPoints }),
+  };
+
+  return { panel, range };
+}

--- a/src/components/Explore/layouts/attributeBreakdown.ts
+++ b/src/components/Explore/layouts/attributeBreakdown.ts
@@ -14,21 +14,23 @@ import { t } from '@grafana/i18n';
 import { LayoutSwitcher } from '../LayoutSwitcher';
 import { explorationDS, GRID_TEMPLATE_COLUMNS, MetricFunction } from '../../../utils/shared';
 import { ByFrameRepeater } from '../ByFrameRepeater';
-import { formatLabelValue, getLabelValue, getOpenTrace, getTraceExplorationScene } from '../../../utils/utils';
+import { getLabelValue, getOpenTrace, getTraceExplorationScene } from '../../../utils/utils';
 import { map, Observable } from 'rxjs';
 import { DataFrame, PanelData, reduceField, ReducerID } from '@grafana/data';
-import { generateMetricsQuery, getMetricsTempoQuery } from '../queries/generateMetricsQuery';
+import { generateMetricsQueryForBreakdownTile, getMetricsTempoQuery } from '../queries/generateMetricsQuery';
 import { barsPanelConfig } from '../panels/barsPanel';
 import { linesPanelConfig } from '../panels/linesPanel';
 import { StepQueryRunner } from '../queries/StepQueryRunner';
 import { syncYAxis } from '../behaviors/syncYaxis';
 import { exemplarsTransformations } from '../../../utils/exemplars';
-import { PanelMenu } from '../panels/PanelMenu';
+import type { AlertPanelTarget } from '../actions/createAlert/getPanelDataForAlert';
+import { PanelMenu, type PanelMenuCreateAlertHandler } from '../panels/PanelMenu';
 
 export function buildNormalLayout(
   scene: SceneObject,
   variable: CustomVariable,
-  actionsFn: (df: DataFrame) => VizPanelState['headerActions']
+  actionsFn: (df: DataFrame) => VizPanelState['headerActions'],
+  onBreakdownCreateAlert?: PanelMenuCreateAlertHandler
 ) {
   const traceExploration = getTraceExplorationScene(scene);
   const metric = traceExploration.getMetricVariable().getValue() as MetricFunction;
@@ -81,7 +83,7 @@ export function buildNormalLayout(
           children: [],
         }),
         groupBy: true,
-        getLayoutChild: getLayoutChild(panels, getLabelValue, variable, metric, actionsFn),
+        getLayoutChild: getLayoutChild(scene, panels, getLabelValue, variable, metric, actionsFn, onBreakdownCreateAlert),
       }),
       new ByFrameRepeater({
         body: new SceneCSSGridLayout({
@@ -91,18 +93,20 @@ export function buildNormalLayout(
           children: [],
         }),
         groupBy: true,
-        getLayoutChild: getLayoutChild(panels, getLabelValue, variable, metric, actionsFn),
+        getLayoutChild: getLayoutChild(scene, panels, getLabelValue, variable, metric, actionsFn, onBreakdownCreateAlert),
       }),
     ],
   });
 }
 
 export function getLayoutChild(
+  scene: SceneObject,
   panels: Record<string, SceneCSSGridItem>,
   getTitle: (df: DataFrame, labelName: string) => string,
   variable: CustomVariable,
   metric: MetricFunction,
-  actionsFn: (df: DataFrame) => VizPanelState['headerActions']
+  actionsFn: (df: DataFrame) => VizPanelState['headerActions'],
+  onBreakdownCreateAlert?: PanelMenuCreateAlertHandler
 ) {
   return (data: PanelData, frame: DataFrame) => {
     const existingGridItem = frame.name ? panels[frame.name] : undefined;
@@ -125,17 +129,31 @@ export function getLayoutChild(
       return existingGridItem;
     }
 
-    const query = sceneGraph.interpolate(
-      variable,
-      generateMetricsQuery({
-        metric,
-        extraFilters: `${variable.getValueText()}=${formatLabelValue(getLabelValue(frame))}`,
-      })
-    );
+    const scopedQuery = generateMetricsQueryForBreakdownTile(metric, variable.getValueText(), frame);
+    const traceExploration = getTraceExplorationScene(scene);
+    const query = sceneGraph.interpolate(traceExploration, scopedQuery);
+
+    const alertTargets: AlertPanelTarget[] = [
+      {
+        refId: 'A',
+        query,
+        queryType: 'traceql',
+        tableType: 'spans',
+        limit: 100,
+        spss: 10,
+        filters: [],
+      },
+    ];
 
     const panel = (metric === 'duration' ? linesPanelConfig().setUnit('s') : barsPanelConfig(metric))
       .setTitle(getTitle(frame, variable.getValueText()))
-      .setMenu(new PanelMenu({ query, labelValue: getLabelValue(frame) }))
+      .setMenu(
+        new PanelMenu({
+          query,
+          alertTargets,
+          onBreakdownCreateAlert,
+        })
+      )
       .setData(dataNode);
 
     const actions = actionsFn(frame);

--- a/src/components/Explore/panels/PanelMenu.tsx
+++ b/src/components/Explore/panels/PanelMenu.tsx
@@ -1,4 +1,5 @@
 import { PanelMenuItem, toURLRange, urlUtil } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { t } from '@grafana/i18n';
 import {
   SceneObjectBase,
@@ -7,16 +8,22 @@ import {
   SceneComponentProps,
   sceneGraph,
   SceneObjectState,
+  VizPanel,
 } from '@grafana/scenes';
 import React from 'react';
-import { config } from '@grafana/runtime';
 import { reportAppInteraction, USER_EVENTS_PAGES, USER_EVENTS_ACTIONS } from 'utils/analytics';
+import type { AlertPanelTarget } from '../actions/createAlert/getPanelDataForAlert';
 import { getCurrentStep, getDataSource, getTraceExplorationScene } from 'utils/utils';
+
+export type PanelMenuCreateAlertHandler = (vizPanel: VizPanel, targets: AlertPanelTarget[]) => void;
 
 interface PanelMenuState extends SceneObjectState {
   body?: VizPanelMenu;
   query?: string;
-  labelValue?: string;
+  /** Per-panel TraceQL targets for alerting (breakdown tiles). */
+  alertTargets?: AlertPanelTarget[];
+  /** Parent breakdown scene handles modal + analytics so menu unmount does not drop the modal. */
+  onBreakdownCreateAlert?: PanelMenuCreateAlertHandler;
 }
 
 export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPanelMenu, SceneObject {
@@ -35,6 +42,22 @@ export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPan
           onClick: () => onExploreClick(),
         },
       ];
+
+      if (this.state.alertTargets?.length && this.state.onBreakdownCreateAlert) {
+        items.push({
+          text: t('panel-menu.create-alert', 'Create alert'),
+          iconClassName: 'bell',
+          onClick: () => {
+            const vizPanel = sceneGraph.findObject(this, (o) => o instanceof VizPanel) as VizPanel | undefined;
+            const targets = this.state.alertTargets;
+            const handler = this.state.onBreakdownCreateAlert;
+            if (!vizPanel || !targets?.length || !handler) {
+              return;
+            }
+            handler(vizPanel, targets);
+          },
+        });
+      }
 
       this.setState({
         body: new VizPanelMenu({
@@ -56,14 +79,14 @@ export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPan
     }
   }
 
-  public static Component = ({ model }: SceneComponentProps<PanelMenu>) => {
+  public static readonly Component = ({ model }: SceneComponentProps<PanelMenu>) => {
     const { body } = model.useState();
 
-    if (body) {
-      return <body.Component model={body} />;
+    if (!body) {
+      return null;
     }
 
-    return <></>;
+    return <body.Component model={body} />;
   };
 }
 

--- a/src/components/Explore/panels/PanelMenu.tsx
+++ b/src/components/Explore/panels/PanelMenu.tsx
@@ -1,5 +1,5 @@
 import { PanelMenuItem, toURLRange, urlUtil } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { config, usePluginComponent } from '@grafana/runtime';
 import { t } from '@grafana/i18n';
 import {
   SceneObjectBase,
@@ -10,16 +10,19 @@ import {
   SceneObjectState,
   VizPanel,
 } from '@grafana/scenes';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { reportAppInteraction, USER_EVENTS_PAGES, USER_EVENTS_ACTIONS } from 'utils/analytics';
 import type { AlertPanelTarget } from '../actions/createAlert/getPanelDataForAlert';
 import { getCurrentStep, getDataSource, getTraceExplorationScene } from 'utils/utils';
+
+const CREATE_ALERT_FROM_PANEL_PLUGIN_ID = 'grafana/alerting/create-alert-from-panel/v1';
 
 export type PanelMenuCreateAlertHandler = (vizPanel: VizPanel, targets: AlertPanelTarget[]) => void;
 
 interface PanelMenuState extends SceneObjectState {
   body?: VizPanelMenu;
   query?: string;
+  isCreateAlertAvailable?: boolean;
   /** Per-panel TraceQL targets for alerting (breakdown tiles). */
   alertTargets?: AlertPanelTarget[];
   /** Parent breakdown scene handles modal + analytics so menu unmount does not drop the modal. */
@@ -28,40 +31,14 @@ interface PanelMenuState extends SceneObjectState {
 
 export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPanelMenu, SceneObject {
   constructor(state: Partial<PanelMenuState>) {
-    super(state);
+    super({
+      isCreateAlertAvailable: false,
+      ...state,
+    });
     this.addActivationHandler(() => {
-      const items: PanelMenuItem[] = [
-        {
-          text: t('panel-menu.navigation', 'Navigation'),
-          type: 'group',
-        },
-        {
-          text: t('panel-menu.explore', 'Explore'),
-          iconClassName: 'compass',
-          href: getExploreHref(this),
-          onClick: () => onExploreClick(),
-        },
-      ];
-
-      if (this.state.alertTargets?.length && this.state.onBreakdownCreateAlert) {
-        items.push({
-          text: t('panel-menu.create-alert', 'Create alert'),
-          iconClassName: 'bell',
-          onClick: () => {
-            const vizPanel = sceneGraph.findObject(this, (o) => o instanceof VizPanel) as VizPanel | undefined;
-            const targets = this.state.alertTargets;
-            const handler = this.state.onBreakdownCreateAlert;
-            if (!vizPanel || !targets?.length || !handler) {
-              return;
-            }
-            handler(vizPanel, targets);
-          },
-        });
-      }
-
       this.setState({
         body: new VizPanelMenu({
-          items,
+          items: buildPanelMenuItems(this, this.state.isCreateAlertAvailable ?? false),
         }),
       });
     });
@@ -81,6 +58,21 @@ export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPan
 
   public static readonly Component = ({ model }: SceneComponentProps<PanelMenu>) => {
     const { body } = model.useState();
+    const { component: CreateAlertModal } = usePluginComponent(CREATE_ALERT_FROM_PANEL_PLUGIN_ID);
+
+    useEffect(() => {
+      const isCreateAlertAvailable = Boolean(CreateAlertModal);
+      if (model.state.isCreateAlertAvailable === isCreateAlertAvailable) {
+        return;
+      }
+
+      model.setState({
+        isCreateAlertAvailable,
+        body: new VizPanelMenu({
+          items: buildPanelMenuItems(model, isCreateAlertAvailable),
+        }),
+      });
+    }, [CreateAlertModal, model]);
 
     if (!body) {
       return null;
@@ -110,3 +102,36 @@ const getExploreHref = (model: SceneObject<PanelMenuState>) => {
 const onExploreClick = () => {
   reportAppInteraction(USER_EVENTS_PAGES.analyse_traces, USER_EVENTS_ACTIONS.analyse_traces.open_in_explore_clicked);
 };
+
+function buildPanelMenuItems(model: SceneObject<PanelMenuState>, isCreateAlertAvailable: boolean): PanelMenuItem[] {
+  const items: PanelMenuItem[] = [
+    {
+      text: t('panel-menu.navigation', 'Navigation'),
+      type: 'group',
+    },
+    {
+      text: t('panel-menu.explore', 'Explore'),
+      iconClassName: 'compass',
+      href: getExploreHref(model),
+      onClick: () => onExploreClick(),
+    },
+  ];
+
+  if (isCreateAlertAvailable && model.state.alertTargets?.length && model.state.onBreakdownCreateAlert) {
+    items.push({
+      text: t('panel-menu.create-alert', 'Create alert'),
+      iconClassName: 'bell',
+      onClick: () => {
+        const vizPanel = sceneGraph.findObject(model, (o) => o instanceof VizPanel) as VizPanel | undefined;
+        const targets = model.state.alertTargets;
+        const handler = model.state.onBreakdownCreateAlert;
+        if (!vizPanel || !targets?.length || !handler) {
+          return;
+        }
+        handler(vizPanel, targets);
+      },
+    });
+  }
+
+  return items;
+}

--- a/src/components/Explore/panels/PanelMenu.tsx
+++ b/src/components/Explore/panels/PanelMenu.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/css';
 import { PanelMenuItem, toURLRange, urlUtil } from '@grafana/data';
 import { config, usePluginComponent } from '@grafana/runtime';
 import { t } from '@grafana/i18n';
@@ -11,7 +12,9 @@ import {
   VizPanel,
 } from '@grafana/scenes';
 import React, { useEffect } from 'react';
+import { useStyles2 } from '@grafana/ui';
 import { reportAppInteraction, USER_EVENTS_PAGES, USER_EVENTS_ACTIONS } from 'utils/analytics';
+import { useFlagTempoAlerting } from '../../../featureFlags/featureFlags';
 import type { AlertPanelTarget } from '../actions/createAlert/getPanelDataForAlert';
 import { getCurrentStep, getDataSource, getTraceExplorationScene } from 'utils/utils';
 
@@ -59,9 +62,11 @@ export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPan
   public static readonly Component = ({ model }: SceneComponentProps<PanelMenu>) => {
     const { body } = model.useState();
     const { component: CreateAlertModal } = usePluginComponent(CREATE_ALERT_FROM_PANEL_PLUGIN_ID);
+    const isTempoAlertingEnabled = useFlagTempoAlerting();
+    const styles = useStyles2(getStyles);
 
     useEffect(() => {
-      const isCreateAlertAvailable = Boolean(CreateAlertModal);
+      const isCreateAlertAvailable = Boolean(CreateAlertModal) && isTempoAlertingEnabled;
       if (model.state.isCreateAlertAvailable === isCreateAlertAvailable) {
         return;
       }
@@ -72,13 +77,17 @@ export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPan
           items: buildPanelMenuItems(model, isCreateAlertAvailable),
         }),
       });
-    }, [CreateAlertModal, model]);
+    }, [CreateAlertModal, isTempoAlertingEnabled, model]);
 
     if (!body) {
       return null;
     }
 
-    return <body.Component model={body} />;
+    return (
+      <div className={styles.menu}>
+        <body.Component model={body} />
+      </div>
+    );
   };
 }
 
@@ -134,4 +143,15 @@ function buildPanelMenuItems(model: SceneObject<PanelMenuState>, isCreateAlertAv
   }
 
   return items;
+}
+
+function getStyles() {
+  return {
+    menu: css({
+      '& [role="menuitem"]': {
+        justifyContent: 'flex-start',
+        textAlign: 'left',
+      },
+    }),
+  };
 }

--- a/src/components/Explore/panels/PanelMenu.tsx
+++ b/src/components/Explore/panels/PanelMenu.tsx
@@ -131,7 +131,7 @@ function buildPanelMenuItems(model: SceneObject<PanelMenuState>, isCreateAlertAv
       text: t('panel-menu.create-alert', 'Create alert'),
       iconClassName: 'bell',
       onClick: () => {
-        const vizPanel = sceneGraph.findObject(model, (o) => o instanceof VizPanel) as VizPanel | undefined;
+        const vizPanel = sceneGraph.getAncestor(model, VizPanel);
         const targets = model.state.alertTargets;
         const handler = model.state.onBreakdownCreateAlert;
         if (!vizPanel || !targets?.length || !handler) {

--- a/src/components/Explore/queries/generateMetricsQuery.test.ts
+++ b/src/components/Explore/queries/generateMetricsQuery.test.ts
@@ -1,4 +1,6 @@
-import { generateMetricsQuery, getMetricsTempoQuery } from './generateMetricsQuery';
+import { FieldType, type DataFrame } from '@grafana/data';
+
+import { generateMetricsQuery, generateMetricsQueryForBreakdownTile, getMetricsTempoQuery } from './generateMetricsQuery';
 import { ALL } from '../../../utils/shared';
 
 describe('generateMetricsQuery', () => {
@@ -41,6 +43,50 @@ describe('generateMetricsQuery', () => {
       groupByKey: ALL,
     });
     expect(result).toEqual('{${primarySignal} && ${filters}} | rate() ');
+  });
+
+  it('should omit != nil when appendGroupByNilGuard is false', () => {
+    const result = generateMetricsQuery({
+      metric: 'rate',
+      groupByKey: 'serviceName',
+      extraFilters: 'serviceName="foo"',
+      appendGroupByNilGuard: false,
+    });
+    expect(result).toEqual('{${primarySignal} && ${filters} && serviceName="foo"} | rate() by(serviceName)');
+  });
+});
+
+describe('generateMetricsQueryForBreakdownTile', () => {
+  const frameWithServiceLabel: DataFrame = {
+    name: 'slice',
+    length: 1,
+    fields: [
+      {
+        name: 'Value',
+        type: FieldType.number,
+        values: [1],
+        labels: { 'resource.service.name': 'checkout' },
+        config: {},
+      },
+    ],
+  };
+
+  it('matches aggregate query when group-by is All', () => {
+    expect(generateMetricsQueryForBreakdownTile('rate', ALL, frameWithServiceLabel)).toEqual(
+      generateMetricsQuery({ metric: 'rate' })
+    );
+  });
+
+  it('matches aggregate query when group-by attribute is empty', () => {
+    expect(generateMetricsQueryForBreakdownTile('rate', '', frameWithServiceLabel)).toEqual(
+      generateMetricsQuery({ metric: 'rate' })
+    );
+  });
+
+  it('adds equality filter and by() without redundant != nil when value is pinned', () => {
+    expect(generateMetricsQueryForBreakdownTile('rate', 'resource.service.name', frameWithServiceLabel)).toEqual(
+      '{${primarySignal} && ${filters} && resource.service.name="checkout"} | rate() by(resource.service.name)'
+    );
   });
 });
 

--- a/src/components/Explore/queries/generateMetricsQuery.ts
+++ b/src/components/Explore/queries/generateMetricsQuery.ts
@@ -1,13 +1,27 @@
+import type { DataFrame } from '@grafana/data';
+
 import { ALL, MetricFunction, VAR_FILTERS_EXPR, VAR_DURATION_PERCENTILES_EXPR } from '../../../utils/shared';
+import { formatLabelValue, getLabelValue } from '../../../utils/utils';
 
 interface QueryOptions {
   metric: MetricFunction;
   extraFilters?: string;
   groupByKey?: string;
   sample?: boolean;
+  /**
+   * When grouping without pinning a value, TraceQL needs `key != nil` so spans missing that attribute are excluded.
+   * When extraFilters already fixes the attribute (e.g. `key=value`), that predicate is redundant — set to false.
+   */
+  appendGroupByNilGuard?: boolean;
 }
 
-export function generateMetricsQuery({ metric, groupByKey, extraFilters, sample = false }: QueryOptions) {
+export function generateMetricsQuery({
+  metric,
+  groupByKey,
+  extraFilters,
+  sample = false,
+  appendGroupByNilGuard = true,
+}: QueryOptions) {
   // Generate span set filters
   let filters = `${VAR_FILTERS_EXPR}`;
 
@@ -19,7 +33,7 @@ export function generateMetricsQuery({ metric, groupByKey, extraFilters, sample 
     filters += ` && ${extraFilters}`;
   }
 
-  if (groupByKey && groupByKey !== ALL) {
+  if (groupByKey && groupByKey !== ALL && appendGroupByNilGuard) {
     filters += ` && ${groupByKey} != nil`;
   }
 
@@ -45,6 +59,23 @@ export function generateMetricsQuery({ metric, groupByKey, extraFilters, sample 
   const sampleStr = sample ? ' with(sample=true)' : '';
 
   return `{${filters}} | ${metricFn} ${groupBy}${sampleStr}`;
+}
+
+/** TraceQL metrics query for one breakdown tile (group-by attribute + series value), or aggregate when group-by is unset / All. */
+export function generateMetricsQueryForBreakdownTile(
+  metric: MetricFunction,
+  groupByAttribute: string,
+  frame: DataFrame
+): string {
+  if (groupByAttribute && groupByAttribute !== ALL) {
+    return generateMetricsQuery({
+      metric,
+      groupByKey: groupByAttribute,
+      extraFilters: `${groupByAttribute}=${formatLabelValue(getLabelValue(frame, groupByAttribute))}`,
+      appendGroupByNilGuard: false,
+    });
+  }
+  return generateMetricsQuery({ metric });
 }
 
 export function getMetricsTempoQuery(options: QueryOptions) {

--- a/src/featureFlags/featureFlags.tsx
+++ b/src/featureFlags/featureFlags.tsx
@@ -10,6 +10,7 @@ const GRAFANA_OPEN_FEATURE_DOMAIN = 'internal-grafana-core';
  * `OpenFeaturePluginScope` from `./openFeature`.
  */
 const queryLibraryKey = 'queryLibrary' satisfies keyof FeatureToggles;
+const tempoAlertingKey = 'tempoAlerting' as keyof FeatureToggles;
 
 /** `pkg/services/featuremgmt/registry.go` — widen until available in `@grafana/data` types (FeatureToggles). */
 const TRACES_DRILLDOWN_TIME_SEEKER = 'tracesDrilldownTimeSeeker' as const;
@@ -30,4 +31,8 @@ export function useFlagTracesDrilldownTimeSeeker(): boolean {
 
 export function useFlagQueryLibrary(): boolean {
   return useBooleanFlagDetails(queryLibraryKey, false).value;
+}
+
+export function useFlagTempoAlerting(): boolean {
+  return useBooleanFlagDetails(tempoAlertingKey, false).value;
 }

--- a/src/locales/en-US/grafana-exploretraces-app.json
+++ b/src/locales/en-US/grafana-exploretraces-app.json
@@ -172,6 +172,7 @@
     "label": "Open in Traces Drilldown"
   },
   "panel-menu": {
+    "create-alert": "Create alert",
     "explore": "Explore",
     "navigation": "Navigation"
   },

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -60,7 +60,8 @@
       "exposedComponents": [
         "grafana-asserts-app/entity-assertions-widget/v1",
         "grafana-adaptivetraces-app/span-latency/v1",
-        "grafana/query-library-context/v1"
+        "grafana/query-library-context/v1",
+        "grafana/alerting/create-alert-from-panel/v1"
       ]
     }
   },

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -39,6 +39,7 @@ export const USER_EVENTS_ACTIONS = {
     stop_investigation: 'stop_investigation',
     open_trace: 'open_trace',
     open_in_explore_clicked: 'open_in_explore_clicked',
+    create_alert_clicked: 'create_alert_clicked',
     span_list_columns_changed: 'span_list_columns_changed',
     toggle_bookmark_clicked: 'toggle_bookmark_clicked',
     primary_signal_changed: 'primary_signal_changed',


### PR DESCRIPTION
### ✨ Description

Fixes: https://github.com/grafana/traces-drilldown/issues/656

Adds support for creating an alert from attribute panels.

### 🧪 How to test?

1. Go to breakdown tab
2. Open panel menu for any panel
3. Select `Create alert`

Note: seeing the `Create alert` panel menu item is gated behind the `tempoAlerting` feature flag.

<img width="460" height="287" alt="Screenshot 2026-05-06 at 10 01 10" src="https://github.com/user-attachments/assets/fe6333bb-840e-49b6-bd67-2df1134272ee" />
<img width="621" height="180" alt="Screenshot 2026-05-06 at 10 01 17" src="https://github.com/user-attachments/assets/88c17e90-d958-4134-b972-abcd8eae286d" />
<img width="1048" height="671" alt="Screenshot 2026-05-06 at 10 01 59" src="https://github.com/user-attachments/assets/a2655fde-d562-474c-8461-50f6e174972f" />

