### PR TITLE
fix: dataframe for root cause latency could also be SearchResponse

### DIFF
--- a/src/components/Explore/TracesByService/Tabs/Structure/StructureScene.test.ts
+++ b/src/components/Explore/TracesByService/Tabs/Structure/StructureScene.test.ts
@@ -1,0 +1,34 @@
+import { parseTraces } from './StructureScene';
+import { dumpTree, mergeTraces } from '../../../../../utils/trace-merge/merge';
+import { SearchResponse } from '../../../../../types';
+
+import serviceStructResponse from '../../../../../utils/trace-merge/test-responses/service-struct.json';
+
+describe('parseTraces', () => {
+  const response = serviceStructResponse as SearchResponse;
+
+  it('parses a frame containing a SearchResponse object', () => {
+    const frame = JSON.stringify(response);
+
+    expect(parseTraces(frame)).toEqual(response.traces);
+  });
+
+  it('parses a frame containing a raw TraceSearchMetadata[] array', () => {
+    const frame = JSON.stringify(response.traces);
+
+    expect(parseTraces(frame)).toEqual(response.traces);
+  });
+
+  it('returns an empty array when a SearchResponse has no traces', () => {
+    const frame = JSON.stringify({ metrics: {} });
+
+    expect(parseTraces(frame)).toEqual([]);
+  });
+
+  it('produces the same merged tree regardless of frame shape', () => {
+    const fromResponse = mergeTraces(parseTraces(JSON.stringify(response)));
+    const fromArray = mergeTraces(parseTraces(JSON.stringify(response.traces)));
+
+    expect(dumpTree(fromArray, 0)).toEqual(dumpTree(fromResponse, 0));
+  });
+});

--- a/src/components/Explore/TracesByService/Tabs/Structure/StructureScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Structure/StructureScene.tsx
@@ -21,7 +21,7 @@ import {
   VAR_LATENCY_PARTIAL_THRESHOLD_EXPR,
   VAR_LATENCY_THRESHOLD_EXPR,
 } from '../../../../../utils/shared';
-import { TraceSearchMetadata } from '../../../../../types';
+import { SearchResponse, TraceSearchMetadata } from '../../../../../types';
 import { mergeTraces } from '../../../../../utils/trace-merge/merge';
 import { createDataFrame, Field, FieldType, GrafanaTheme2, LinkModel, LoadingState } from '@grafana/data';
 import { TreeNode } from '../../../../../utils/trace-merge/tree-node';
@@ -70,8 +70,8 @@ export class StructureTabScene extends SceneObjectBase<ServicesTabSceneState> {
         if (state.data?.state === LoadingState.Done && state.data?.series.length) {
           const frame = state.data?.series[0].fields[0].values[0];
           if (frame) {
-            const response = JSON.parse(frame) as TraceSearchMetadata[];
-            const tree = mergeTraces(response);
+            const traces = parseTraces(frame);
+            const tree = mergeTraces(traces);
             tree.children.sort((a, b) => countSpans(b) - countSpans(a));
 
             this.setState({
@@ -343,6 +343,14 @@ export class StructureTabScene extends SceneObjectBase<ServicesTabSceneState> {
       </Stack>
     );
   };
+}
+
+// The query result frame can be either a raw array of traces (TraceSearchMetadata[])
+// or a full SearchResponse object with a `traces` field, depending on the Tempo API
+// endpoint that served it. Normalise both shapes to a plain array of traces.
+export function parseTraces(frame: string): TraceSearchMetadata[] {
+  const parsed = JSON.parse(frame) as SearchResponse | TraceSearchMetadata[];
+  return Array.isArray(parsed) ? parsed : (parsed.traces ?? []);
 }
 
 function buildQuery(metric: MetricFunction) {

--- a/src/components/Explore/TracesByService/Tabs/Structure/StructureScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Structure/StructureScene.tsx
@@ -349,8 +349,8 @@ export class StructureTabScene extends SceneObjectBase<ServicesTabSceneState> {
 // or a full SearchResponse object with a `traces` field, depending on the Tempo API
 // endpoint that served it. Normalise both shapes to a plain array of traces.
 export function parseTraces(frame: string): TraceSearchMetadata[] {
-  const parsed = JSON.parse(frame) as SearchResponse | TraceSearchMetadata[];
-  return Array.isArray(parsed) ? parsed : (parsed.traces ?? []);
+  const parsed = JSON.parse(frame) as SearchResponse | TraceSearchMetadata[] | null;
+  return Array.isArray(parsed) ? parsed : (parsed?.traces ?? []);
 }
 
 function buildQuery(metric: MetricFunction) {


### PR DESCRIPTION
### ✨ Description

Fixes: https://github.com/grafana/grafana/issues/120285

PR fixes the root cause latency dashboard for traces drilldown.

### 📖 Summary of the changes

The dataframe response for the root cause latency dashboard could have SearchResponse as type in a subkey, which was previously not considered.

### 🧪 How to test?

Apply and observe that root cause latency dashboards shows data.