### PR TITLE
feat: Exceptions tab grouping

### DIFF
--- a/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionUtils.test.ts
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionUtils.test.ts
@@ -1,5 +1,14 @@
 import { Field, FieldType } from '@grafana/data';
-import { aggregateExceptions, createTimeSeries, normalizeExceptionMessage } from './ExceptionUtils';
+import {
+  aggregateExceptions,
+  createTimeSeries,
+  getExceptionGroupingKey,
+  formatExceptionMessageTraceQLFilter,
+  getExceptionMessageFilter,
+  normalizeExceptionMessage,
+  normalizedExceptionMessageNeedsRegexMatch,
+  normalizedExceptionMessageToTraceQLRegexPattern,
+} from './ExceptionUtils';
 
 describe('ExceptionUtils', () => {
   describe('normalizeExceptionMessage', () => {
@@ -13,6 +22,119 @@ describe('ExceptionUtils', () => {
 
     it('should handle newlines and tabs', () => {
       expect(normalizeExceptionMessage('Error\nwith\tnewlines')).toBe('Error with newlines');
+    });
+
+    it('should normalize volatile identifiers in exception messages', () => {
+      expect(
+        normalizeExceptionMessage('Request 123 failed for 4f4e6f95-4a67-4fce-90b0-51e8b8fb4d4a from 10.0.0.1 at 2026-01-20T12:34:56Z')
+      ).toBe('Request <num> failed for <uuid> from <ip> at <timestamp>');
+    });
+
+    it('should collapse http(s) URLs to group messages that differ only by path', () => {
+      const a =
+        'Error: HttpException: Connection closed before full header was received, uri = https://oncall-prod-us-central-1.grafana.net/oncall/api/internal/v1/user';
+      const b =
+        'Error: HttpException: Connection closed before full header was received, uri = https://oncall-prod-us-central-2.grafana.net/oncall/mobile_app/v1/gateway/incident/api/OrgService.GetOrg';
+      const expected =
+        'Error: HttpException: Connection closed before full header was received, uri = <url>';
+      expect(normalizeExceptionMessage(a)).toBe(expected);
+      expect(normalizeExceptionMessage(b)).toBe(expected);
+    });
+  });
+
+  describe('normalizedExceptionMessageToTraceQLRegexPattern', () => {
+    it('matches raw URLs against grouped messages with <url>', () => {
+      const normalized =
+        'Error: HttpException: Connection closed before full header was received, uri = <url>';
+      const pattern = normalizedExceptionMessageToTraceQLRegexPattern(normalized);
+      expect(normalizedExceptionMessageNeedsRegexMatch(normalized)).toBe(true);
+      const re = new RegExp(pattern);
+      expect(
+        re.test(
+          'Error: HttpException: Connection closed before full header was received, uri = https://oncall-prod-us-central-1.grafana.net/oncall/api/internal/v1/user'
+        )
+      ).toBe(true);
+      expect(
+        re.test(
+          'Error: HttpException: Connection closed before full header was received, uri = https://oncall-prod-us-central-2.grafana.net/oncall/mobile_app/v1/gateway/incident/api/OrgService.GetOrg'
+        )
+      ).toBe(true);
+    });
+
+    it('matches numeric placeholders', () => {
+      const normalized = 'HTTP <num> for path item-<num>';
+      const re = new RegExp(normalizedExceptionMessageToTraceQLRegexPattern(normalized));
+      expect(re.test('HTTP 500 for path item-42')).toBe(true);
+    });
+
+    it('matches HttpException content-length messages with numeric placeholders', () => {
+      const normalized =
+        'Error: HttpException: Content size below specified contentLength. <num> bytes written but expected <num>., uri = <url>';
+      const pattern = normalizedExceptionMessageToTraceQLRegexPattern(normalized);
+      const re = new RegExp(pattern);
+
+      expect(
+        re.test(
+          'Error: HttpException: Content size below specified contentLength. 35113 bytes written but expected 5242880., uri = https://oncall-prod-us-central-1.grafana.net/oncall/api/internal/v1/user'
+        )
+      ).toBe(true);
+      expect(pattern).toContain('[0-9]+');
+      expect(pattern).not.toContain('\\d+');
+    });
+
+    it('allows flexible whitespace between literal segments', () => {
+      const normalized = 'Error happened at <timestamp>';
+      const re = new RegExp(normalizedExceptionMessageToTraceQLRegexPattern(normalized));
+      expect(re.test('Error   happened\tat 2026-05-07T09:14:00Z')).toBe(true);
+    });
+  });
+
+  describe('getExceptionGroupingKey', () => {
+    it('should include exception type, first chars, last chars, and length', () => {
+      const normalized = 'Timeout while processing event payload from gateway';
+      expect(getExceptionGroupingKey(normalized, 'TimeoutException')).toBe(
+        'TimeoutException|Timeout while proces|payload from gateway|51'
+      );
+    });
+  });
+
+  describe('getExceptionMessageFilter', () => {
+    it('uses exact match for literal messages', () => {
+      expect(getExceptionMessageFilter('Database connection failed', 'include')).toEqual({
+        value: 'Database connection failed',
+        operator: '=',
+      });
+      expect(getExceptionMessageFilter('Database connection failed', 'exclude')).toEqual({
+        value: 'Database connection failed',
+        operator: '!=',
+      });
+    });
+
+    it('uses regex match for normalized placeholder messages', () => {
+      const message = 'Error: HttpException: Connection closed before full header was received, uri = <url>';
+      const include = getExceptionMessageFilter(message, 'include');
+      expect(include.operator).toBe('=~');
+      expect(include.value).toContain('https?://');
+
+      const exclude = getExceptionMessageFilter(message, 'exclude');
+      expect(exclude.operator).toBe('!~');
+      expect(exclude.value).toBe(include.value);
+    });
+  });
+
+  describe('formatExceptionMessageTraceQLFilter', () => {
+    it('formats literal messages with exact match', () => {
+      expect(formatExceptionMessageTraceQLFilter('Database connection failed')).toBe(
+        'event.exception.message = "Database connection failed"'
+      );
+    });
+
+    it('formats placeholder messages with regex match', () => {
+      const clause = formatExceptionMessageTraceQLFilter(
+        'Error: HttpException: Connection closed before full header was received, uri = <url>'
+      );
+      expect(clause).toContain('event.exception.message =~ "');
+      expect(clause).toContain('https?://');
     });
   });
 
@@ -130,12 +252,12 @@ describe('ExceptionUtils', () => {
 
       const result = aggregateExceptions(messageField);
 
-      expect(result.messages).toEqual(['Error 1', 'Error 2']);
-      expect(result.types).toEqual(['', '']);
-      expect(result.services).toEqual(['', '']);
-      expect(result.occurrences).toEqual([1, 1]);
-      expect(result.lastSeenTimes).toEqual(['', '']);
-      expect(result.timeSeries).toEqual([[], []]);
+      expect(result.messages).toEqual(['Error <num>']);
+      expect(result.types).toEqual(['']);
+      expect(result.services).toEqual(['']);
+      expect(result.occurrences).toEqual([2]);
+      expect(result.lastSeenTimes).toEqual(['']);
+      expect(result.timeSeries).toEqual([[]]);
     });
 
     it('should normalize duplicate messages', () => {
@@ -152,6 +274,47 @@ describe('ExceptionUtils', () => {
       expect(result.occurrences[0]).toBe(2);
       expect(result.messages[1]).toBe('Different error');
       expect(result.occurrences[1]).toBe(1);
+    });
+
+    it('should group HttpException messages that differ only by request URI', () => {
+      const messageField = createMockField('exception.message', [
+        'Error: HttpException: Connection closed before full header was received, uri = https://oncall-prod-us-central-1.grafana.net/oncall/api/internal/v1/user',
+        'Error: HttpException: Connection closed before full header was received, uri = https://oncall-prod-us-central-2.grafana.net/oncall/mobile_app/v1/gateway/incident/api/OrgService.GetOrg',
+      ]);
+      const typeField = createMockField('exception.type', ['HttpException', 'HttpException']);
+
+      const result = aggregateExceptions(messageField, typeField);
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.occurrences[0]).toBe(2);
+      expect(result.messages[0]).toContain('<url>');
+      expect(result.types[0]).toBe('HttpException');
+      expect(result.groupedMessages[0]).toEqual([
+        'Error: HttpException: Connection closed before full header was received, uri = https://oncall-prod-us-central-1.grafana.net/oncall/api/internal/v1/user',
+        'Error: HttpException: Connection closed before full header was received, uri = https://oncall-prod-us-central-2.grafana.net/oncall/mobile_app/v1/gateway/incident/api/OrgService.GetOrg',
+      ]);
+    });
+
+    it('should group long similar messages by first and last 20 chars', () => {
+      const messageField = createMockField('exception.message', [
+        'Payment failed while processing customer alpha request due to timeout in upstream dependency',
+        'Payment failed while processing customer bravo request due to timeout in upstream dependency',
+        'Completely different problem in another subsystem',
+      ]);
+      const typeField = createMockField('exception.type', [
+        'TimeoutException',
+        'TimeoutException',
+        'OtherException',
+      ]);
+
+      const result = aggregateExceptions(messageField, typeField);
+
+      expect(result.messages).toHaveLength(2);
+      expect(result.messages[0]).toBe(
+        'Payment failed while processing customer alpha request due to timeout in upstream dependency'
+      );
+      expect(result.occurrences[0]).toBe(2);
+      expect(result.types[0]).toBe('TimeoutException');
     });
 
     it('should sort by occurrence count descending', () => {
@@ -189,7 +352,7 @@ describe('ExceptionUtils', () => {
     });
 
     it('should handle hours and days for older timestamps', () => {
-      const messageField = createMockField('exception.message', ['Error 1', 'Error 2']);
+      const messageField = createMockField('exception.message', ['Error one', 'Error two']);
       const timeField = createTimeField([
         1699996400000, // 1 hour ago
         1699913600000, // 1 day ago
@@ -203,9 +366,9 @@ describe('ExceptionUtils', () => {
 
     it('should create time series for each exception', () => {
       const messageField = createMockField('exception.message', [
-        'Error 1',
-        'Error 1',
-        'Error 2',
+        'Error alpha',
+        'Error alpha',
+        'Error beta',
       ]);
       const timeField = createTimeField([1000, 2000, 3000]);
 

--- a/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionUtils.ts
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionUtils.ts
@@ -2,10 +2,60 @@ import { Field } from "@grafana/data";
 import { SceneObject } from "@grafana/scenes";
 
 import { calculateBucketSize } from "utils/dates";
+import { escapeTraceQlStringLiteral } from "utils/filters-renderer";
 import { getDatasourceVariable } from "utils/utils";
+
+const GROUPING_EDGE_LENGTH = 20;
+type PlaceholderPattern = {
+  token: '<url>' | '<uuid>' | '<ip>' | '<hex>' | '<timestamp>' | '<id>' | '<num>';
+  normalizeRegex: RegExp;
+  regexFragment: string;
+};
+
+const PLACEHOLDER_PATTERNS: PlaceholderPattern[] = [
+  {
+    token: '<url>',
+    normalizeRegex: /\bhttps?:\/\/[^\s]+/gi,
+    regexFragment: 'https?://\\S+',
+  },
+  {
+    token: '<uuid>',
+    normalizeRegex: /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi,
+    regexFragment: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}',
+  },
+  {
+    token: '<ip>',
+    normalizeRegex: /\b(?:\d{1,3}\.){3}\d{1,3}\b/g,
+    regexFragment: '(?:[0-9]{1,3}\\.){3}[0-9]{1,3}',
+  },
+  {
+    token: '<hex>',
+    normalizeRegex: /\b0x[0-9a-f]+\b/gi,
+    regexFragment: '0x[0-9a-fA-F]+',
+  },
+  {
+    token: '<timestamp>',
+    normalizeRegex: /\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?\b/g,
+    regexFragment: '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]+)?Z?',
+  },
+  {
+    token: '<id>',
+    normalizeRegex: /\b([a-z][a-z0-9._-]*id)=([a-z0-9_-]+)\b/gi,
+    regexFragment: '[a-zA-Z0-9_-]+',
+  },
+  {
+    token: '<num>',
+    normalizeRegex: /\b\d+\b/g,
+    regexFragment: '[0-9]+',
+  },
+];
+
+const PLACEHOLDER_TOKEN_REGEX = new RegExp(`(${PLACEHOLDER_PATTERNS.map((p) => p.token).join('|')})`);
 
 export function aggregateExceptions(messageField: Field<string>, typeField?: Field<string>, timeField?: Field<number>, serviceField?: Field<string>) {
   const occurrences = new Map<string, number>();
+  const representativeMessages = new Map<string, string>();
+  const groupedMessages = new Map<string, Set<string>>();
   const types = new Map<string, string>();
   const lastSeenTimes = new Map<string, number>();
   const services = new Map<string, string>();
@@ -21,27 +71,43 @@ export function aggregateExceptions(messageField: Field<string>, typeField?: Fie
     const service = serviceField?.values[i];
     
     if (message) {
+      const rawMessage = normalizeRawExceptionMessage(message);
       const normalizedMessage = normalizeExceptionMessage(message);
-      occurrences.set(normalizedMessage, (occurrences.get(normalizedMessage) || 0) + 1);
-      
-      if (!types.has(normalizedMessage) && type) {
-        types.set(normalizedMessage, type);
+      if (!normalizedMessage) {
+        continue;
+      }
+      const groupedMessageKey = getExceptionGroupingKey(normalizedMessage, type);
+      occurrences.set(groupedMessageKey, (occurrences.get(groupedMessageKey) || 0) + 1);
+
+      if (!representativeMessages.has(groupedMessageKey)) {
+        representativeMessages.set(groupedMessageKey, normalizedMessage);
       }
 
-      if (!services.has(normalizedMessage) && service) {
-        services.set(normalizedMessage, service);
+      if (!groupedMessages.has(groupedMessageKey)) {
+        groupedMessages.set(groupedMessageKey, new Set<string>());
+      }
+      if (rawMessage) {
+        groupedMessages.get(groupedMessageKey)?.add(rawMessage);
+      }
+      
+      if (!types.has(groupedMessageKey) && type) {
+        types.set(groupedMessageKey, type);
+      }
+
+      if (!services.has(groupedMessageKey) && service) {
+        services.set(groupedMessageKey, service);
       }
 
       if (timestamp) {
         const timestampMs = typeof timestamp === 'string' ? parseFloat(timestamp) : timestamp;
-        if (!messageTimestamps.has(normalizedMessage)) {
-          messageTimestamps.set(normalizedMessage, []);
+        if (!messageTimestamps.has(groupedMessageKey)) {
+          messageTimestamps.set(groupedMessageKey, []);
         }
-        messageTimestamps.get(normalizedMessage)!.push(timestampMs);
+        messageTimestamps.get(groupedMessageKey)!.push(timestampMs);
                     
-        const currentLastSeen = lastSeenTimes.get(normalizedMessage) || 0;
+        const currentLastSeen = lastSeenTimes.get(groupedMessageKey) || 0;
         if (timestampMs > currentLastSeen) {
-          lastSeenTimes.set(normalizedMessage, timestampMs);
+          lastSeenTimes.set(groupedMessageKey, timestampMs);
         }
       }
     }
@@ -56,13 +122,14 @@ export function aggregateExceptions(messageField: Field<string>, typeField?: Fie
   const sortedEntries = Array.from(occurrences.entries()).sort((a, b) => b[1] - a[1]);
 
   return {
-    messages: sortedEntries.map(([message]) => message),
-    types: sortedEntries.map(([message]) => types.get(message) || ''),
+    messages: sortedEntries.map(([groupedMessageKey]) => representativeMessages.get(groupedMessageKey) || ''),
+    types: sortedEntries.map(([groupedMessageKey]) => types.get(groupedMessageKey) || ''),
     occurrences: sortedEntries.map(([, count]) => count),
-    services: sortedEntries.map(([message]) => services.get(message) || ''),
-    timeSeries: sortedEntries.map(([message]) => timeSeries.get(message) || []),
-    lastSeenTimes: sortedEntries.map(([message]) => {
-      const lastSeenMs = lastSeenTimes.get(message);
+    services: sortedEntries.map(([groupedMessageKey]) => services.get(groupedMessageKey) || ''),
+    timeSeries: sortedEntries.map(([groupedMessageKey]) => timeSeries.get(groupedMessageKey) || []),
+    groupedMessages: sortedEntries.map(([groupedMessageKey]) => Array.from(groupedMessages.get(groupedMessageKey) || [])),
+    lastSeenTimes: sortedEntries.map(([groupedMessageKey]) => {
+      const lastSeenMs = lastSeenTimes.get(groupedMessageKey);
       
       if (!lastSeenMs) {
         return '';
@@ -111,7 +178,96 @@ export function createTimeSeries(timestamps: number[]): Array<{time: number, cou
 
 export function normalizeExceptionMessage(message: string): string {
   if (!message) { return '' }
+  let normalized = normalizeRawExceptionMessage(message);
+  for (const pattern of PLACEHOLDER_PATTERNS) {
+    if (pattern.token === '<id>') {
+      normalized = normalized.replace(pattern.normalizeRegex, '$1=<id>');
+      continue;
+    }
+    normalized = normalized.replace(pattern.normalizeRegex, pattern.token);
+  }
+  return normalized.trim();
+}
+
+function normalizeRawExceptionMessage(message: string): string {
   return message.replace(/\s+/g, ' ').trim();
+}
+
+export function getExceptionGroupingKey(normalizedMessage: string, type?: string): string {
+  const trimmed = normalizedMessage.trim();
+  const prefix = trimmed.slice(0, GROUPING_EDGE_LENGTH);
+  const suffix = trimmed.slice(-GROUPING_EDGE_LENGTH);
+  const messageType = type ?? '';
+  return `${messageType}|${prefix}|${suffix}|${trimmed.length}`;
+}
+
+/** True when the normalized message uses placeholders that never appear verbatim in Tempo. */
+export function normalizedExceptionMessageNeedsRegexMatch(normalizedMessage: string): boolean {
+  return PLACEHOLDER_TOKEN_REGEX.test(normalizedMessage);
+}
+
+export type ExceptionMessageFilterOperator = '=' | '!=' | '=~' | '!~';
+
+export function getExceptionMessageFilter(
+  exceptionMessage: string,
+  mode: 'include' | 'exclude'
+): { value: string; operator: ExceptionMessageFilterOperator } {
+  if (normalizedExceptionMessageNeedsRegexMatch(exceptionMessage)) {
+    return {
+      value: normalizedExceptionMessageToTraceQLRegexPattern(exceptionMessage),
+      operator: mode === 'include' ? '=~' : '!~',
+    };
+  }
+
+  return {
+    value: exceptionMessage,
+    operator: mode === 'include' ? '=' : '!=',
+  };
+}
+
+/** TraceQL filter clause for {@link event.exception.message}. */
+export function formatExceptionMessageTraceQLFilter(exceptionMessage: string): string {
+  const { operator, value } = getExceptionMessageFilter(exceptionMessage, 'include');
+  return `event.exception.message ${operator} "${escapeTraceQlStringLiteral(value)}"`;
+}
+
+/**
+ * Builds a TraceQL regex pattern (for =~) that matches any raw exception.message
+ * consistent with {@link normalizeExceptionMessage}.
+ */
+export function normalizedExceptionMessageToTraceQLRegexPattern(normalizedMessage: string): string {
+  let remaining = normalizedMessage;
+  let pattern = '';
+
+  while (remaining.length > 0) {
+    let bestIdx = -1;
+    let best: PlaceholderPattern | null = null;
+
+    for (const tokenPattern of PLACEHOLDER_PATTERNS) {
+      const idx = remaining.indexOf(tokenPattern.token);
+      if (idx !== -1 && (bestIdx === -1 || idx < bestIdx)) {
+        bestIdx = idx;
+        best = tokenPattern;
+      }
+    }
+
+    if (bestIdx === -1 || !best) {
+      pattern += escapeRegexLiteral(remaining);
+      break;
+    }
+
+    pattern += escapeRegexLiteral(remaining.slice(0, bestIdx));
+    pattern += best.regexFragment;
+    remaining = remaining.slice(bestIdx + best.token.length);
+  }
+
+  return `^${pattern}$`;
+}
+
+function escapeRegexLiteral(value: string): string {
+  return value
+    .replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')
+    .replace(/\s+/g, '\\s+');
 }
 
 export function getDatasourceUidOrThrow(scene: SceneObject) {

--- a/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionsScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionsScene.tsx
@@ -24,7 +24,7 @@ import {
   filterStreamingProgressTransformations,
 } from '../../../../../utils/shared';
 import { buildExceptionsQuery } from 'components/Explore/queries/exceptions';
-import { aggregateExceptions } from './ExceptionUtils';
+import { aggregateExceptions, ExceptionMessageFilterOperator } from './ExceptionUtils';
 import { ExceptionsTable, ExceptionRow } from './ExceptionsTable';
 import { getFiltersVariable, getTraceByServiceScene } from 'utils/utils';
 import { addToFilters } from 'components/Explore/actions/AddToFiltersAction';
@@ -110,6 +110,15 @@ export class ExceptionsScene extends SceneObjectBase<ExceptionsSceneState> {
       data.series.length > 0
     ) {
       const exceptionRows = this.extractExceptionRows(data);
+      if (exceptionRows.length === 0) {
+        this.setState({
+          dataState: 'empty',
+          exceptionsCount: 0,
+          exceptionRows: [],
+        });
+        return;
+      }
+
       const exceptionsCount = exceptionRows.reduce((total, row) => total + row.occurrences, 0);
 
       this.setState({
@@ -126,10 +135,11 @@ export class ExceptionsScene extends SceneObjectBase<ExceptionsSceneState> {
       return [];
     }
 
-    const messageField = df.fields.find((f) => f.name === 'exception.message');
-    const typeField = df.fields.find((f) => f.name === 'exception.type');
-    const serviceField = df.fields.find((f) => f.name === 'service.name');
-    const timeField = df.fields.find((f) => f.name === 'time');
+    const findField = (names: string[]) => df.fields.find((field) => names.includes(field.name));
+    const messageField = findField(['exception.message', 'event.exception.message']);
+    const typeField = findField(['exception.type', 'event.exception.type']);
+    const serviceField = findField(['service.name', 'resource.service.name']);
+    const timeField = findField(['time']);
 
     if (!messageField || !messageField.values.length) {
       return [];
@@ -140,6 +150,7 @@ export class ExceptionsScene extends SceneObjectBase<ExceptionsSceneState> {
     return aggregated.messages.map((message, index) => ({
       type: aggregated.types[index] || 'Unknown',
       message,
+      groupedMessages: aggregated.groupedMessages[index] || [],
       service: aggregated.services[index] || '',
       lastSeen: aggregated.lastSeenTimes[index] || '',
       occurrences: aggregated.occurrences[index] || 0,
@@ -156,7 +167,12 @@ export class ExceptionsScene extends SceneObjectBase<ExceptionsSceneState> {
     const theme = useTheme2();
     const { dataState, exceptionRows } = model.useState();
 
-    const handleFilterClick = (key: string, value: string, operator: '=' | '!=' = '=', append = false) => {
+    const handleFilterClick = (
+      key: string,
+      value: string,
+      operator: ExceptionMessageFilterOperator = '=',
+      append = false
+    ) => {
       const filtersVariable = getFiltersVariable(model);
       addToFilters(filtersVariable, key, value, operator, append);
       

--- a/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionsTable.test.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionsTable.test.tsx
@@ -35,6 +35,7 @@ describe('ExceptionsTable', () => {
     {
       type: 'SQLException',
       message: 'Database connection failed',
+      groupedMessages: ['Database connection failed'],
       service: 'user-service',
       lastSeen: '5m ago',
       occurrences: 42,
@@ -46,6 +47,7 @@ describe('ExceptionsTable', () => {
     {
       type: 'NullPointerException',
       message: 'Object reference not set to an instance of an object',
+      groupedMessages: ['Object reference not set to an instance of an object'],
       service: 'payment-service',
       lastSeen: '1h ago',
       occurrences: 15,
@@ -160,6 +162,7 @@ describe('ExceptionsTable', () => {
       {
         type: 'Error',
         message: 'Test error',
+        groupedMessages: ['Test error'],
         service: '',
         lastSeen: '1m ago',
         occurrences: 1,
@@ -178,6 +181,7 @@ describe('ExceptionsTable', () => {
       {
         type: 'Error',
         message: 'Test error',
+        groupedMessages: ['Test error'],
         service: 'test-service',
         lastSeen: '',
         occurrences: 1,
@@ -196,6 +200,7 @@ describe('ExceptionsTable', () => {
       {
         type: 'Error',
         message: 'This is a very long exception message that should be truncated in the UI but still fully accessible via tooltip when the user hovers over it',
+        groupedMessages: ['This is a very long exception message that should be truncated in the UI but still fully accessible via tooltip when the user hovers over it'],
         service: 'test-service',
         lastSeen: '1m ago',
         occurrences: 1,
@@ -212,6 +217,7 @@ describe('ExceptionsTable', () => {
     const manyRows: ExceptionRow[] = Array.from({ length: 10 }, (_, i) => ({
       type: `Error${i}`,
       message: `Message ${i}`,
+      groupedMessages: [`Message ${i}`],
       service: `service-${i}`,
       lastSeen: `${i}m ago`,
       occurrences: i + 1,
@@ -224,6 +230,65 @@ describe('ExceptionsTable', () => {
     expect(screen.getByText('Error9')).toBeInTheDocument();
     expect(screen.getByText('Message 0')).toBeInTheDocument();
     expect(screen.getByText('Message 9')).toBeInTheDocument();
+  });
+
+  it('should render grouped message tooltip trigger and content for grouped rows', () => {
+    const groupedRows: ExceptionRow[] = [
+      {
+        type: 'HttpException',
+        message: 'Error: HttpException: Connection closed before full header was received, uri = <url>',
+        groupedMessages: [
+          'Error: HttpException: Connection closed before full header was received, uri = https://oncall-prod-us-central-1.grafana.net/oncall/api/internal/v1/user',
+          'Error: HttpException: Connection closed before full header was received, uri = https://oncall-prod-us-central-2.grafana.net/oncall/mobile_app/v1/gateway/incident/api/OrgService.GetOrg',
+        ],
+        service: 'oncall',
+        lastSeen: '1m ago',
+        occurrences: 2,
+        timeSeries: [],
+      },
+    ];
+
+    render(<ExceptionsTable rows={groupedRows} theme={mockTheme} scene={mockScene} />);
+
+    expect(screen.getByRole('button', { name: 'Show grouped exception messages' })).toBeInTheDocument();
+    expect(screen.getByText('Grouped messages')).toBeInTheDocument();
+    expect(screen.getByText(/oncall-prod-us-central-1/)).toBeInTheDocument();
+    expect(screen.getByText(/oncall-prod-us-central-2/)).toBeInTheDocument();
+  });
+
+  it('should use regex operators for include/exclude on normalized grouped messages', () => {
+    const groupedRows: ExceptionRow[] = [
+      {
+        type: 'HttpException',
+        message: 'Error: HttpException: Connection closed before full header was received, uri = <url>',
+        groupedMessages: [
+          'Error: HttpException: Connection closed before full header was received, uri = https://oncall-prod-us-central-1.grafana.net/oncall/api/internal/v1/user',
+          'Error: HttpException: Connection closed before full header was received, uri = https://oncall-prod-us-central-2.grafana.net/oncall/mobile_app/v1/gateway/incident/api/OrgService.GetOrg',
+        ],
+        service: 'oncall',
+        lastSeen: '1m ago',
+        occurrences: 2,
+        timeSeries: [],
+      },
+    ];
+
+    render(<ExceptionsTable rows={groupedRows} theme={mockTheme} scene={mockScene} onFilterClick={mockOnFilterClick} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Include exception message' }));
+    expect(mockOnFilterClick).toHaveBeenCalledWith(
+      'event.exception.message',
+      expect.stringContaining('https?://'),
+      '=~',
+      true
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Exclude exception message' }));
+    expect(mockOnFilterClick).toHaveBeenCalledWith(
+      'event.exception.message',
+      expect.stringContaining('https?://'),
+      '!~',
+      true
+    );
   });
 });
 

--- a/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionsTable.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionsTable.tsx
@@ -7,9 +7,12 @@ import { SparklineCell } from './SparklineCell';
 import { ExceptionAccordionContent } from './accordion/ExceptionAccordion';
 import { SceneObject } from '@grafana/scenes';
 
+import { ExceptionMessageFilterOperator, getExceptionMessageFilter } from './ExceptionUtils';
+
 export interface ExceptionRow {
   type: string;
   message: string;
+  groupedMessages: string[];
   service: string;
   lastSeen: string;
   occurrences: number;
@@ -20,7 +23,12 @@ interface ExceptionsTableProps {
   rows: ExceptionRow[];
   theme: GrafanaTheme2;
   scene: SceneObject;
-  onFilterClick?: (key: string, value: string, operator?: '=' | '!=', append?: boolean) => void;
+  onFilterClick?: (
+    key: string,
+    value: string,
+    operator?: ExceptionMessageFilterOperator,
+    append?: boolean
+  ) => void;
 }
 
 // Component to conditionally show tooltip only when text is truncated
@@ -75,18 +83,58 @@ const TruncatedMessage = ({ message, onClick, className }: { message: string; on
   return content;
 };
 
+const getSharedPrefixAndMessageRemainders = (messages: string[]) => {
+  if (messages.length < 2) {
+    return { sharedPrefix: '', remainders: messages };
+  }
+
+  const [first, ...rest] = messages;
+  let sharedPrefix = first;
+
+  for (const message of rest) {
+    let i = 0;
+    const max = Math.min(sharedPrefix.length, message.length);
+    while (i < max && sharedPrefix[i] === message[i]) {
+      i++;
+    }
+    sharedPrefix = sharedPrefix.slice(0, i);
+    if (!sharedPrefix) {
+      break;
+    }
+  }
+
+  const lastBoundary = Math.max(
+    sharedPrefix.lastIndexOf(' '),
+    sharedPrefix.lastIndexOf(','),
+    sharedPrefix.lastIndexOf(':'),
+    sharedPrefix.lastIndexOf('/')
+  );
+  if (lastBoundary > 0) {
+    sharedPrefix = sharedPrefix.slice(0, lastBoundary + 1);
+  }
+
+  sharedPrefix = sharedPrefix.trimEnd();
+
+  if (!sharedPrefix) {
+    return { sharedPrefix: '', remainders: messages };
+  }
+
+  const remainders = messages.map((message) => {
+    const remainder = message.startsWith(sharedPrefix) ? message.slice(sharedPrefix.length).trimStart() : message;
+    return remainder || message;
+  });
+
+  return { sharedPrefix, remainders };
+};
+
 export const ExceptionsTable = ({ rows, theme, onFilterClick, scene }: ExceptionsTableProps) => {
   const styles = useStyles2(getStyles);
   const [expandedRow, setExpandedRow] = useState<number | null>(null);
 
-  const handleIncludeClick = (message: string, e: React.MouseEvent) => {
+  const handleMessageFilterClick = (message: string, mode: 'include' | 'exclude', e: React.MouseEvent) => {
     e.stopPropagation();
-    onFilterClick?.('event.exception.message', message, '=', true);
-  };
-
-  const handleExcludeClick = (message: string, e: React.MouseEvent) => {
-    e.stopPropagation();
-    onFilterClick?.('event.exception.message', message, '!=', true);
+    const { value, operator } = getExceptionMessageFilter(message, mode);
+    onFilterClick?.('event.exception.message', value, operator, true);
   };
 
   const handleRowClick = (index: number) => {
@@ -121,6 +169,10 @@ export const ExceptionsTable = ({ rows, theme, onFilterClick, scene }: Exception
         <tbody>
           {rows.map((row, index) => {
             const isExpanded = expandedRow === index;
+            const hasGroupedMessages = row.groupedMessages.length > 1;
+            const { sharedPrefix, remainders } = hasGroupedMessages
+              ? getSharedPrefixAndMessageRemainders(row.groupedMessages)
+              : { sharedPrefix: '', remainders: [] as string[] };
             return (
               <React.Fragment key={index}>
                 <tr 
@@ -150,14 +202,53 @@ export const ExceptionsTable = ({ rows, theme, onFilterClick, scene }: Exception
                           >
                             {row.type}
                           </div>
-                          <TruncatedMessage
-                            message={row.message}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleRowClick(index);
-                            }}
-                            className={styles.exceptionMessage}
-                          />
+                          <div className={styles.exceptionMessageRow}>
+                            <TruncatedMessage
+                              message={row.message}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleRowClick(index);
+                              }}
+                              className={styles.exceptionMessage}
+                            />
+                            {hasGroupedMessages && (
+                              <Tooltip
+                                placement="top"
+                                content={
+                                  <div className={styles.groupedMessagesTooltip}>
+                                    <div className={styles.groupedMessagesTooltipTitle}>
+                                      <Trans i18nKey="exceptions-table.grouped-messages-title">Grouped messages</Trans>
+                                    </div>
+                                      {sharedPrefix && (
+                                        <div className={styles.groupedMessagesSharedPrefix}>
+                                          <span className={styles.groupedMessagesLabel}>
+                                            <Trans i18nKey="exceptions-table.grouped-messages-common-prefix">Common</Trans>:
+                                          </span>{' '}
+                                          {sharedPrefix}
+                                        </div>
+                                      )}
+                                    <ul className={styles.groupedMessagesList}>
+                                      {remainders.map((groupedMessage, groupedMessageIndex) => (
+                                        <li key={`${groupedMessage}-${groupedMessageIndex}`}>{groupedMessage}</li>
+                                      ))}
+                                    </ul>
+                                  </div>
+                                }
+                              >
+                                <button
+                                  type="button"
+                                  className={styles.groupedMessagesButton}
+                                  onClick={(e) => e.stopPropagation()}
+                                  aria-label={t(
+                                    'exceptions-table.grouped-messages-aria-label',
+                                    'Show grouped exception messages'
+                                  )}
+                                >
+                                  <Icon name="info-circle" size="sm" />
+                                </button>
+                              </Tooltip>
+                            )}
+                          </div>
                           <div className={styles.exceptionMeta}>
                             {row.service && (
                               <span className={styles.metaItem}>
@@ -176,14 +267,14 @@ export const ExceptionsTable = ({ rows, theme, onFilterClick, scene }: Exception
                         <div className={styles.filterButtonsContainer}>
                           <button
                             className={styles.filterButton}
-                            onClick={(e) => handleIncludeClick(row.message, e)}
+                            onClick={(e) => handleMessageFilterClick(row.message, 'include', e)}
                             aria-label={t('exceptions-table.include-aria-label', 'Include exception message')}
                           >
                             <Trans i18nKey="exceptions-table.include">Include</Trans>
                           </button>
                           <button
                             className={styles.filterButton}
-                            onClick={(e) => handleExcludeClick(row.message, e)}
+                            onClick={(e) => handleMessageFilterClick(row.message, 'exclude', e)}
                             aria-label={t('exceptions-table.exclude-aria-label', 'Exclude exception message')}
                           >
                             <Trans i18nKey="exceptions-table.exclude">Exclude</Trans>
@@ -365,12 +456,52 @@ const getStyles = (theme: GrafanaTheme2) => {
         color: theme.colors.text.link,
       },
     }),
+    exceptionMessageRow: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(0.5),
+      minWidth: 0,
+    }),
     exceptionMeta: css({
       display: 'flex',
       alignItems: 'center',
       gap: theme.spacing(1),
       color: theme.colors.text.secondary,
       marginTop: theme.spacing(0.25),
+    }),
+    groupedMessagesButton: css({
+      display: 'inline-flex',
+      flexShrink: 0,
+      padding: 0,
+      border: 'none',
+      background: 'transparent',
+      color: theme.colors.text.secondary,
+      cursor: 'pointer',
+      '&:hover': {
+        color: theme.colors.text.primary,
+      },
+    }),
+    groupedMessagesTooltip: css({
+      maxWidth: '860px',
+    }),
+    groupedMessagesTooltipTitle: css({
+      fontWeight: theme.typography.fontWeightMedium,
+      marginBottom: theme.spacing(0.5),
+    }),
+    groupedMessagesSharedPrefix: css({
+      marginBottom: theme.spacing(0.5),
+      color: theme.colors.text.secondary,
+    }),
+    groupedMessagesLabel: css({
+      fontWeight: theme.typography.fontWeightMedium,
+      color: theme.colors.text.primary,
+    }),
+    groupedMessagesList: css({
+      margin: 0,
+      paddingLeft: theme.spacing(2),
+      '> li': {
+        marginBottom: theme.spacing(0.25),
+      },
     }),
     metaItem: css({
       display: 'flex',

--- a/src/components/Explore/TracesByService/Tabs/Exceptions/accordion/ExceptionAccordion.test.ts
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/accordion/ExceptionAccordion.test.ts
@@ -62,6 +62,31 @@ describe('ExceptionAccordion helpers', () => {
 
       expect(expr).not.toContain('event.exception.type');
     });
+
+    it('uses regex match when normalized message contains placeholders', () => {
+      const expr = buildExceptionFilterExpr({
+        exceptionMessage: 'Error: HttpException: Connection closed before full header was received, uri = <url>',
+        exceptionType: 'HttpException',
+        scene,
+      });
+
+      expect(expr).toContain('event.exception.message =~ "');
+      expect(expr).not.toContain('event.exception.message = "Error: HttpException');
+      expect(expr).toContain('https?://\\\\S+');
+      expect(expr).toContain('event.exception.type = "HttpException"');
+    });
+
+    it('uses numeric character classes for <num> placeholder regex', () => {
+      const expr = buildExceptionFilterExpr({
+        exceptionMessage:
+          'Error: HttpException: Content size below specified contentLength. <num> bytes written but expected <num>., uri = <url>',
+        exceptionType: 'HttpException',
+        scene,
+      });
+
+      expect(expr).toContain('[0-9]+');
+      expect(expr).not.toContain('\\\\d+');
+    });
   });
 });
 

--- a/src/components/Explore/TracesByService/Tabs/Exceptions/accordion/ExceptionAccordion.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/accordion/ExceptionAccordion.tsx
@@ -9,6 +9,7 @@ import { SceneObject } from '@grafana/scenes';
 import { AttributesSidebar } from 'components/Explore/AttributesSidebar';
 import { escapeTraceQlStringLiteral, renderTraceQLLabelFilters } from 'utils/filters-renderer';
 import { getFiltersVariable, getPrimarySignalVariable, getSpanListColumnsVariable, getTraceByServiceScene } from 'utils/utils';
+import { formatExceptionMessageTraceQLFilter } from '../ExceptionUtils';
 import { ExceptionRow } from '../ExceptionsTable';
 import { ExceptionComparison } from './ExceptionComparison';
 import { ExceptionTraceResults } from './ExceptionTraceResults';
@@ -129,10 +130,9 @@ export const buildExceptionFilterExpr = ({
   const primarySignalExpr = (getPrimarySignalVariable(scene).state.value as string) || 'true';
   const filtersExpr = renderTraceQLLabelFilters(getFiltersVariable(scene).state.filters);
 
-  const escapedMessage = escapeTraceQlStringLiteral(exceptionMessage);
   const typeFilter = exceptionType && exceptionType !== 'Unknown' ? ` && event.exception.type = "${escapeTraceQlStringLiteral(exceptionType)}"` : '';
 
-  return `{${primarySignalExpr} && ${filtersExpr} && status = error && event.exception.message = "${escapedMessage}"${typeFilter}}`;
+  return `{${primarySignalExpr} && ${filtersExpr} && status = error && ${formatExceptionMessageTraceQLFilter(exceptionMessage)}${typeFilter}}`;
 };
 
 const getAccordionStyles = (theme: GrafanaTheme2) => {

--- a/src/components/Explore/TracesByService/Tabs/Exceptions/accordion/ExceptionComparison.test.ts
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/accordion/ExceptionComparison.test.ts
@@ -7,9 +7,9 @@ describe('buildDistribution', () => {
   it('builds sorted distribution with percent-of-total and percent-of-max', () => {
     const attributeKey = 'resource.service.name';
     const series: DataFrame[] = [
-      createFrame([createField('time', [1, 2], {}, 'time'), createField('value', [10], { [attributeKey]: '"svc-a"' }, 'number')]),
-      createFrame([createField('time', [1, 2], {}, 'time'), createField('value', [1], { [attributeKey]: '"svc-c"' }, 'number')]),
-      createFrame([createField('time', [1, 2], {}, 'time'), createField('value', [5], { [attributeKey]: '"svc-b"' }, 'number')]),
+      createFrame([createField('time', Array.from({ length: 10 }, (_, i) => i), {}, 'time'), createField(attributeKey, Array(10).fill('svc-a'), {}, 'string')]),
+      createFrame([createField('time', Array.from({ length: 1 }, (_, i) => i), {}, 'time'), createField(attributeKey, ['svc-c'], {}, 'string')]),
+      createFrame([createField('time', Array.from({ length: 5 }, (_, i) => i), {}, 'time'), createField(attributeKey, Array(5).fill('svc-b'), {}, 'string')]),
     ];
 
     const items = buildDistribution(series, attributeKey, 10);
@@ -24,7 +24,7 @@ describe('buildDistribution', () => {
   it('adds an Other bucket when exceeding maxRows', () => {
     const attributeKey = 'resource.service.name';
     const series: DataFrame[] = Array.from({ length: 8 }, (_, i) =>
-      createFrame([createField('time', [1], {}, 'time'), createField('value', [1], { [attributeKey]: `"svc-${i}"` }, 'number')])
+      createFrame([createField('time', [1], {}, 'time'), createField(attributeKey, [`svc-${i}`], {}, 'string')])
     );
 
     const items = buildDistribution(series, attributeKey, 3);
@@ -33,14 +33,57 @@ describe('buildDistribution', () => {
     expect(items[3].count).toBe(5);
   });
 
-  it('returns empty when all counts are zero', () => {
+  it('returns empty when no series rows are available', () => {
     const attributeKey = 'resource.service.name';
-    const series: DataFrame[] = [
-      createFrame([createField('time', [1], {}, 'time'), createField('value', [0], { [attributeKey]: '"svc-a"' }, 'number')]),
-    ];
+    const series: DataFrame[] = [];
 
     const items = buildDistribution(series, attributeKey, 10);
     expect(items).toEqual([]);
+  });
+
+  it('aggregates value frequencies from row-based select results', () => {
+    const attributeKey = 'resource.service.name';
+    const series: DataFrame[] = [
+      createFrame([
+        createField('time', [1, 2, 3, 4], {}, 'time'),
+        createField(attributeKey, ['svc-a', 'svc-b', 'svc-a', ''], {}, 'string'),
+      ]),
+    ];
+
+    const items = buildDistribution(series, attributeKey, 10);
+    expect(items.map((item) => item.value)).toEqual(['svc-a', 'svc-b', 'Unknown']);
+    expect(items.map((item) => item.count)).toEqual([2, 1, 1]);
+  });
+
+  it('keeps single-row select results', () => {
+    const attributeKey = 'resource.service.name';
+    const series: DataFrame[] = [
+      createFrame([
+        createField('time', [1], {}, 'time'),
+        createField(attributeKey, ['svc-a'], {}, 'string'),
+      ]),
+    ];
+
+    const items = buildDistribution(series, attributeKey, 10);
+    expect(items).toEqual([
+      expect.objectContaining({
+        value: 'svc-a',
+        count: 1,
+      }),
+    ]);
+  });
+  
+  it('falls back to Unknown when the selected attribute field is missing', () => {
+    const attributeKey = 'resource.service.name';
+    const series: DataFrame[] = [createFrame([createField('time', [1, 2], {}, 'time'), createField('name', ['op-a', 'op-b'], {}, 'string')])];
+
+    const items = buildDistribution(series, attributeKey, 10);
+    expect(items).toEqual([
+      expect.objectContaining({
+        value: 'Unknown',
+        count: 2,
+      }),
+    ]);
   });
 });
 

--- a/src/components/Explore/TracesByService/Tabs/Exceptions/accordion/ExceptionComparison.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/accordion/ExceptionComparison.tsx
@@ -44,7 +44,8 @@ class ExceptionDistributionPanel extends SceneObjectBase<ExceptionDistributionPa
             queryType: 'traceql',
             tableType: 'spans',
             query: state.query,
-            limit: 200,
+            limit: 400,
+            spss: 10,
             filters: [],
           },
         ],
@@ -78,7 +79,7 @@ class ExceptionDistributionPanel extends SceneObjectBase<ExceptionDistributionPa
           }
 
           const series = panelData.series ?? [];
-          const items = buildDistribution(series, this.state.attributeKey);
+          const items = buildDistribution(series, this.state.attributeKey, MAX_ROWS);
           this.setState({ loadingState: state, items, error: undefined });
         })
       );
@@ -129,14 +130,7 @@ class ExceptionDistributionPanel extends SceneObjectBase<ExceptionDistributionPa
 }
 
 export function buildDistribution(series: DataFrame[], attributeKey: string, maxRows = MAX_ROWS): DistributionItem[] {
-  const rawItems = series
-    .map((df) => {
-      const value = getSeriesValue(df, attributeKey) ?? 'Unknown';
-      const count = getSeriesCount(df);
-      return { value, count };
-    })
-    .filter((i) => i.count > 0)
-    .sort((a, b) => b.count - a.count);
+  const rawItems = getRowCounts(series, attributeKey).sort((a, b) => b.count - a.count);
 
   const total = rawItems.reduce((acc, i) => acc + i.count, 0);
   const max = rawItems[0]?.count ?? 0;
@@ -159,27 +153,55 @@ export function buildDistribution(series: DataFrame[], attributeKey: string, max
   }));
 }
 
-export function getSeriesValue(df: DataFrame, attributeKey: string) {
-  const valueField = df.fields.find((f) => f.name !== 'time');
-  const raw = valueField?.labels?.[attributeKey];
-  return raw ? raw.replace(/"/g, '') : undefined;
-}
+function getRowCounts(series: DataFrame[], attributeKey: string): Array<{ value: string; count: number }> {
+  const counts = new Map<string, number>();
 
-function getSeriesCount(df: DataFrame) {
-  const valueField = df.fields.find((f) => f.name !== 'time' && f.type === 'number');
-  const vals = valueField?.values;
-  if (!vals) {
-    return 0;
-  }
+  for (const df of series) {
+    const attributeField = getAttributeField(df, attributeKey);
+    if (!attributeField?.values) {
+      if (df.length > 0) {
+        counts.set('Unknown', (counts.get('Unknown') ?? 0) + df.length);
+      }
+      continue;
+    }
 
-  // Query results can be a single-point series or a vector of points; summing handles both shapes consistently.
-  let sum = 0;
-  for (const v of vals) {
-    if (typeof v === 'number' && !isNaN(v)) {
-      sum += v;
+    for (const raw of attributeField.values) {
+      const value = normalizeSeriesValue(raw) ?? 'Unknown';
+      counts.set(value, (counts.get(value) ?? 0) + 1);
     }
   }
-  return sum;
+
+  return Array.from(counts.entries()).map(([value, count]) => ({ value, count }));
+}
+
+function normalizeSeriesValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  const normalized = String(value).replace(/"/g, '').trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function getAttributeKeyCandidates(attributeKey: string) {
+  const candidates = [attributeKey];
+  if (attributeKey.startsWith('resource.')) {
+    candidates.push(attributeKey.slice('resource.'.length));
+  }
+  if (attributeKey.startsWith('span.')) {
+    candidates.push(attributeKey.slice('span.'.length));
+  }
+  return candidates;
+}
+
+function getAttributeField(df: DataFrame, attributeKey: string) {
+  for (const key of getAttributeKeyCandidates(attributeKey)) {
+    const field = df.fields.find((f) => f.name === key);
+    if (field) {
+      return field;
+    }
+  }
+  return undefined;
 }
 
 function getStyles(theme: GrafanaTheme2) {
@@ -288,7 +310,7 @@ export const ExceptionComparison = ({
     }
 
     return attributeKeys.map((attributeKey) => {
-      const query = `${baseFilter} | count_over_time() by (${attributeKey})`;
+      const query = `${baseFilter} | select(${attributeKey})`;
       return new ExceptionDistributionPanel({
         title: attributeKey,
         attributeKey,

--- a/src/components/Explore/actions/AddToFiltersAction.test.tsx
+++ b/src/components/Explore/actions/AddToFiltersAction.test.tsx
@@ -190,4 +190,15 @@ describe('addToFilters', () => {
       ],
     });
   });
+
+  it('should add regex include filter with =~ operator', () => {
+    addToFilters(variable, 'event.exception.message', '^https?://\\\\S+$', '=~');
+
+    expect(variable.setState).toHaveBeenCalledWith({
+      filters: [
+        { key: 'otherKey', operator: '=', value: 'value2' },
+        { key: 'event.exception.message', operator: '=~', value: '^https?://\\\\S+$' },
+      ],
+    });
+  });
 });

--- a/src/components/Explore/actions/AddToFiltersAction.tsx
+++ b/src/components/Explore/actions/AddToFiltersAction.tsx
@@ -96,7 +96,13 @@ function getStyles(theme: GrafanaTheme2) {
   };
 }
 
-export const addToFilters = (variable: AdHocFiltersVariable, label: string, value: string, operator: '=' | '!=' = '=', append = false) => {
+export const addToFilters = (
+  variable: AdHocFiltersVariable,
+  label: string,
+  value: string,
+  operator: '=' | '!=' | '=~' | '!~' = '=',
+  append = false
+) => {
   // TODO: Replace it with new API introduced in https://github.com/grafana/scenes/issues/1103
   // At the moment AdHocFiltersVariable doesn't support pushing new history entry on change
   history.pushState(null, '');

--- a/src/locales/cs-CZ/grafana-exploretraces-app.json
+++ b/src/locales/cs-CZ/grafana-exploretraces-app.json
@@ -111,7 +111,10 @@
       "occurrences-tooltip": ""
     },
     "include": "",
-    "include-aria-label": ""
+    "include-aria-label": "",
+    "grouped-messages-aria-label": "",
+    "grouped-messages-common-prefix": "",
+    "grouped-messages-title": ""
   },
   "exemplars": {
     "view-trace": ""

--- a/src/locales/de-DE/grafana-exploretraces-app.json
+++ b/src/locales/de-DE/grafana-exploretraces-app.json
@@ -109,7 +109,10 @@
       "occurrences-tooltip": ""
     },
     "include": "",
-    "include-aria-label": ""
+    "include-aria-label": "",
+    "grouped-messages-aria-label": "",
+    "grouped-messages-common-prefix": "",
+    "grouped-messages-title": ""
   },
   "exemplars": {
     "view-trace": ""

--- a/src/locales/en-US/grafana-exploretraces-app.json
+++ b/src/locales/en-US/grafana-exploretraces-app.json
@@ -100,6 +100,9 @@
   "exceptions-table": {
     "exclude": "Exclude",
     "exclude-aria-label": "Exclude exception message",
+    "grouped-messages-aria-label": "Show grouped exception messages",
+    "grouped-messages-common-prefix": "Common",
+    "grouped-messages-title": "Grouped messages",
     "header": {
       "exception-details": "Exception Details",
       "exception-details-tooltip": "Exception type, message, service, and last seen timestamp. Use the include/exclude buttons to include or exclude exception messages, or click on type or message to filter.",

--- a/src/locales/es-ES/grafana-exploretraces-app.json
+++ b/src/locales/es-ES/grafana-exploretraces-app.json
@@ -109,7 +109,10 @@
       "occurrences-tooltip": ""
     },
     "include": "",
-    "include-aria-label": ""
+    "include-aria-label": "",
+    "grouped-messages-aria-label": "",
+    "grouped-messages-common-prefix": "",
+    "grouped-messages-title": ""
   },
   "exemplars": {
     "view-trace": ""

--- a/src/locales/fr-FR/grafana-exploretraces-app.json
+++ b/src/locales/fr-FR/grafana-exploretraces-app.json
@@ -109,7 +109,10 @@
       "occurrences-tooltip": ""
     },
     "include": "",
-    "include-aria-label": ""
+    "include-aria-label": "",
+    "grouped-messages-aria-label": "",
+    "grouped-messages-common-prefix": "",
+    "grouped-messages-title": ""
   },
   "exemplars": {
     "view-trace": ""

--- a/src/locales/hu-HU/grafana-exploretraces-app.json
+++ b/src/locales/hu-HU/grafana-exploretraces-app.json
@@ -109,7 +109,10 @@
       "occurrences-tooltip": ""
     },
     "include": "",
-    "include-aria-label": ""
+    "include-aria-label": "",
+    "grouped-messages-aria-label": "",
+    "grouped-messages-common-prefix": "",
+    "grouped-messages-title": ""
   },
   "exemplars": {
     "view-trace": ""

--- a/src/locales/id-ID/grafana-exploretraces-app.json
+++ b/src/locales/id-ID/grafana-exploretraces-app.json
@@ -108,7 +108,10 @@
       "occurrences-tooltip": ""
     },
     "include": "",
-    "include-aria-label": ""
+    "include-aria-label": "",
+    "grouped-messages-aria-label": "",
+    "grouped-messages-common-prefix": "",
+    "grouped-messages-title": ""
   },
   "exemplars": {
     "view-trace": ""

--- a/src/locales/it-IT/grafana-exploretraces-app.json
+++ b/src/locales/it-IT/grafana-exploretraces-app.json
@@ -109,7 +109,10 @@
       "occurrences-tooltip": ""
     },
     "include": "",
-    "include-aria-label": ""
+    "include-aria-label": "",
+    "grouped-messages-aria-label": "",
+    "grouped-messages-common-prefix": "",
+    "grouped-messages-title": ""
   },
   "exemplars": {
     "view-trace": ""

--- a/src/locales/ja-JP/grafana-exploretraces-app.json
+++ b/src/locales/ja-JP/grafana-exploretraces-app.json
@@ -108,7 +108,10 @@
       "occurrences-tooltip": ""
     },
     "include": "",
-    "include-aria-label": ""
+    "include-aria-label": "",
+    "grouped-messages-aria-label": "",
+    "grouped-messages-common-prefix": "",
+    "grouped-messages-title": ""
   },
   "exemplars": {
     "view-trace": ""

--- a/src/locales/ko-KR/grafana-exploretraces-app.json
+++ b/src/locales/ko-KR/grafana-exploretraces-app.json
@@ -108,7 +108,10 @@
       "occurrences-tooltip": ""
     },
     "include": "",
-    "include-aria-label": ""
+    "include-aria-label": "",
+    "grouped-messages-aria-label": "",
+    "grouped-messages-common-prefix": "",
+    "grouped-messages-title": ""
   },
   "exemplars": {
     "view-trace": ""

--- a/src/locales/nl-NL/grafana-exploretraces-app.json
+++ b/src/locales/nl-NL/grafana-exploretraces-app.json
@@ -109,7 +109,10 @@
       "occurrences-tooltip": ""
     },
     "include": "",
-    "include-aria-label": ""
+    "include-aria-label": "",
+    "grouped-messages-aria-label": "",
+    "grouped-messages-common-prefix": "",
+    "grouped-messages-title": ""
   },
   "exemplars": {
     "view-trace": ""

--- a/src/locales/pl-PL/grafana-exploretraces-app.json
+++ b/src/locales/pl-PL/grafana-exploretraces-app.json
@@ -111,7 +111,10 @@
       "occurrences-tooltip": ""
     },
     "include": "",
-    "include-aria-label": ""
+    "include-aria-label": "",
+    "grouped-messages-aria-label": "",
+    "grouped-messages-common-prefix": "",
+    "grouped-messages-title": ""
   },
   "exemplars": {
     "view-trace": ""

--- a/src/locales/pt-BR/grafana-exploretraces-app.json
+++ b/src/locales/pt-BR/grafana-exploretraces-app.json
@@ -109,7 +109,10 @@
       "occurrences-tooltip": ""
     },
     "include": "",
-    "include-aria-label": ""
+    "include-aria-label": "",
+    "grouped-messages-aria-label": "",
+    "grouped-messages-common-prefix": "",
+    "grouped-messages-title": ""
   },
   "exemplars": {
     "view-trace": ""

--- a/src/locales/pt-PT/grafana-exploretraces-app.json
+++ b/src/locales/pt-PT/grafana-exploretraces-app.json
@@ -109,7 +109,10 @@
       "occurrences-tooltip": ""
     },
     "include": "",
-    "include-aria-label": ""
+    "include-aria-label": "",
+    "grouped-messages-aria-label": "",
+    "grouped-messages-common-prefix": "",
+    "grouped-messages-title": ""
   },
   "exemplars": {
     "view-trace": ""

--- a/src/locales/ru-RU/grafana-exploretraces-app.json
+++ b/src/locales/ru-RU/grafana-exploretraces-app.json
@@ -111,7 +111,10 @@
       "occurrences-tooltip": ""
     },
     "include": "",
-    "include-aria-label": ""
+    "include-aria-label": "",
+    "grouped-messages-aria-label": "",
+    "grouped-messages-common-prefix": "",
+    "grouped-messages-title": ""
   },
   "exemplars": {
     "view-trace": ""

--- a/src/locales/sv-SE/grafana-exploretraces-app.json
+++ b/src/locales/sv-SE/grafana-exploretraces-app.json
@@ -109,7 +109,10 @@
       "occurrences-tooltip": ""
     },
     "include": "",
-    "include-aria-label": ""
+    "include-aria-label": "",
+    "grouped-messages-aria-label": "",
+    "grouped-messages-common-prefix": "",
+    "grouped-messages-title": ""
   },
   "exemplars": {
     "view-trace": ""

--- a/src/locales/tr-TR/grafana-exploretraces-app.json
+++ b/src/locales/tr-TR/grafana-exploretraces-app.json
@@ -109,7 +109,10 @@
       "occurrences-tooltip": ""
     },
     "include": "",
-    "include-aria-label": ""
+    "include-aria-label": "",
+    "grouped-messages-aria-label": "",
+    "grouped-messages-common-prefix": "",
+    "grouped-messages-title": ""
   },
   "exemplars": {
     "view-trace": ""

--- a/src/locales/zh-Hans/grafana-exploretraces-app.json
+++ b/src/locales/zh-Hans/grafana-exploretraces-app.json
@@ -108,7 +108,10 @@
       "occurrences-tooltip": ""
     },
     "include": "",
-    "include-aria-label": ""
+    "include-aria-label": "",
+    "grouped-messages-aria-label": "",
+    "grouped-messages-common-prefix": "",
+    "grouped-messages-title": ""
   },
   "exemplars": {
     "view-trace": ""

--- a/src/locales/zh-Hant/grafana-exploretraces-app.json
+++ b/src/locales/zh-Hant/grafana-exploretraces-app.json
@@ -108,7 +108,10 @@
       "occurrences-tooltip": ""
     },
     "include": "",
-    "include-aria-label": ""
+    "include-aria-label": "",
+    "grouped-messages-aria-label": "",
+    "grouped-messages-common-prefix": "",
+    "grouped-messages-title": ""
   },
   "exemplars": {
     "view-trace": ""


### PR DESCRIPTION
### ✨ Description

Groups similar exception messages in the Exceptions tab so noisy variants (URLs, IDs, numbers, long messages with shared prefix/suffix) collapse into one row. Include/exclude and accordion drill-down use regex filters when the displayed message contains normalization placeholders.

How exceptions are grouped:

- Normalize each exception.message: collapse whitespace, then replace volatile bits with fixed tokens like < url >, < uuid >, < ip >, < hex >, < timestamp >, < id >, < num >.
- Group key = exception.type (if present) + first 20 characters of the normalized text + last 20 + full normalized length. Same key → one table row.
- Aggregate occurrence counts and time series into that row; keep every distinct raw message in groupedMessages for the tooltip.

Rows are then sorted by occurrence count (desc).

### 🧪 How to test?

1. Select errors RED metric
2. Selection exceptions tab
3. Observe exceptions are now grouped

I don't want to share an image because most places seem to have exception info I'd rather not share!! Msg me for a url example if you like. I'm testing with an App O11y env.

