### PR TITLE
chore: upgrade pnpm from v10 to v11

### DIFF
--- a/.github/workflows/is-compatible.yml
+++ b/.github/workflows/is-compatible.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Setup Node.js environment
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/package.json
+++ b/package.json
@@ -119,29 +119,5 @@
     "uplot": "^1.6.32",
     "uuid": "^14.0.0"
   },
-  "pnpm": {
-    "overrides": {
-      "@remix-run/router": "^1.23.2",
-      "lodash": "^4.18.0",
-      "react-router": "^6.30.2",
-      "serialize-javascript": "^7.0.5",
-      "flatted": "^3.4.0",
-      "immutable": "^5.1.5",
-      "dompurify": "^3.4.0",
-      "picomatch@^2": "~2.3.2",
-      "picomatch@^4": "^4.0.4",
-      "yaml": "^2.8.3",
-      "minimatch@^3": "~3.1.4",
-      "minimatch@^9": "~10.2.0",
-      "minimatch@^10": "^10.2.3",
-      "undici": "^7.24.0",
-      "brace-expansion@^1": "^1.1.13",
-      "brace-expansion@^5": "^5.0.5",
-      "@types/react": "^18.3.28",
-      "@types/react-dom": "^18.3.7",
-      "uuid": "^14.0.0",
-      "@tootallnate/once": ">=3.0.1"
-    }
-  },
-  "packageManager": "pnpm@10.33.1+sha512.05ba3c1d5d1c18f68df06470d74055e62d41fc110a0c660db1b2dfb2785327f04cf0f68345d4609bc52089e7fa0343c31593b2f9594e2c5d5da426230acc9820"
+  "packageManager": "pnpm@11.4.0+sha512.f0febc7e37552ab485494a914241b338e0b3580b93d54ce31f00933015880863129038a1b4ae4e414a0ee63ac35bf21197e990172c4a68256450b5636310968f"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,12 +1,33 @@
 packages:
   - '.'
 
-ignoredBuiltDependencies:
-  - core-js
+blockExoticSubdeps: false
 
-onlyBuiltDependencies:
-  - '@parcel/watcher'
-  - '@swc/core'
-  - esbuild
-  - protobufjs
-  - unrs-resolver
+overrides:
+  '@remix-run/router': ^1.23.2
+  lodash: ^4.18.0
+  react-router: ^6.30.2
+  serialize-javascript: ^7.0.5
+  flatted: ^3.4.0
+  immutable: ^5.1.5
+  dompurify: ^3.4.0
+  picomatch@^2: ~2.3.2
+  picomatch@^4: ^4.0.4
+  yaml: ^2.8.3
+  minimatch@^3: ~3.1.4
+  minimatch@^9: ~10.2.0
+  minimatch@^10: ^10.2.3
+  undici: ^7.24.0
+  brace-expansion@^1: ^1.1.13
+  brace-expansion@^5: ^5.0.5
+  '@types/react': ^18.3.28
+  '@types/react-dom': ^18.3.7
+  uuid: ^14.0.0
+  '@tootallnate/once': '>=3.0.1'
+
+allowBuilds:
+  '@parcel/watcher': true
+  '@swc/core': true
+  esbuild: true
+  protobufjs: true
+  unrs-resolver: true


### PR DESCRIPTION
pnpm 11 is a major version with a redesigned configuration system.
The `pnpm` key in `package.json` is silently ignored in v11, so
overrides must be migrated to `pnpm-workspace.yaml`. The
`pnpm/action-setup` GitHub Action also needs v6 for pnpm 11 support.

Changes:
- **package.json**: Removed `pnpm.overrides` block, bumped `packageManager` to `pnpm@11.4.0`
- **pnpm-workspace.yaml**: Added `overrides` (moved from `package.json`), replaced `onlyBuiltDependencies` with `allowBuilds` map, set `blockExoticSubdeps` to `false` (react-data-grid git dep in `@grafana/ui`)
- **is-compatible.yml**: Bumped `pnpm/action-setup` from v4 to v6.0.8

Notable new pnpm 11 defaults to be aware of:
- `minimumReleaseAge: 1440` — newly-published packages are quarantined for 24h before resolution
- `strictDepBuilds: true` — build scripts blocked unless explicitly allowed via `allowBuilds`
- `verifyDepsBeforeRun: install` — auto-runs install if deps are stale before script execution

### How to test

- `pnpm install`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test:ci`
- `pnpm run build`
- Verify security overrides are applied: `pnpm why dompurify`, `pnpm why serialize-javascript` — all resolve to at least the override floor versions

See also: [logs-drilldown#1909](https://github.com/grafana/logs-drilldown/pull/1909), [profiles-drilldown#992](https://github.com/grafana/profiles-drilldown/pull/992)