### PR TITLE
fix: update Crowdin workflows to use fromJSON secrets output

### DIFF
--- a/.github/workflows/i18n-crowdin-create-tasks.yml
+++ b/.github/workflows/i18n-crowdin-create-tasks.yml
@@ -23,5 +23,5 @@ jobs:
       - name: Create tasks in Crowdin
         uses: grafana/grafana-github-actions/crowdin-create-tasks@main
         with:
-          crowdin_token: ${{ env.CROWDIN_TOKEN }}
+          crowdin_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).CROWDIN_TOKEN }}
           crowdin_project_id: 50

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Download from Crowdin
         uses: grafana/grafana-github-actions/crowdin-download@main
         with:
-          crowdin_token: ${{ env.CROWDIN_TOKEN }}
+          crowdin_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).CROWDIN_TOKEN }}
           crowdin_project_id: 50
           pr_labels: 'i18n'
           github_repo_token: ${{ steps.get-github-app-token.outputs.token }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -30,5 +30,5 @@ jobs:
       - name: Upload to Crowdin
         uses: grafana/grafana-github-actions/crowdin-upload@main
         with:
-          crowdin_token: ${{ env.CROWDIN_TOKEN }}
+          crowdin_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).CROWDIN_TOKEN }}
           crowdin_project_id: 50


### PR DESCRIPTION
## Summary

Fixes #774

[grafana/shared-workflows#1957](https://github.com/grafana/shared-workflows/pull/1957) (merged June 4, 2026) removed env-var export from the `get-vault-secrets` action. Secrets are now only available via JSON output.

All three Crowdin workflows were using the old `${{ env.CROWDIN_TOKEN }}` pattern, which now resolves to an empty string and causes the Crowdin CLI to fail with:

```
❌ Configuration file is invalid. Check the following parameters in your configuration file:
    - Required option 'api_token' is missing
```

## Changes

Updated the `crowdin_token` input in all three workflows to use the new JSON output pattern:

- `.github/workflows/i18n-crowdin-upload.yml`
- `.github/workflows/i18n-crowdin-download.yml`
- `.github/workflows/i18n-crowdin-create-tasks.yml`

**Before:**
```yaml
crowdin_token: ${{ env.CROWDIN_TOKEN }}
```

**After:**
```yaml
crowdin_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).CROWDIN_TOKEN }}
```