### PR TITLE
fix: respect appSubUrl in trace-to-logs data links

### DIFF
--- a/src/pages/Explore/DataLinksCustomContext.test.tsx
+++ b/src/pages/Explore/DataLinksCustomContext.test.tsx
@@ -19,6 +19,7 @@ jest.mock('@grafana/data', () => {
 });
 
 jest.mock('@grafana/runtime', () => ({
+  config: { appSubUrl: '/grafana' },
   getDataSourceSrv: jest.fn(),
   usePluginFunctions: jest.fn(),
 }));
@@ -179,7 +180,7 @@ describe('DataLinksCustomContext', () => {
       const linkModel = createMockLinkModel();
       const result = capturedContext.dataLinkPostProcessor({ linkModel });
 
-      expect(result.href).toBe(mockPath);
+      expect(result.href).toBe(`/grafana${mockPath}`);
       expect(mockExtensionFn).toHaveBeenCalledWith(
         expect.objectContaining({
           targets: expect.arrayContaining([

--- a/src/pages/Explore/DataLinksCustomContext.tsx
+++ b/src/pages/Explore/DataLinksCustomContext.tsx
@@ -5,7 +5,7 @@ import {
   TimeRange,
   useDataLinksContext,
 } from '@grafana/data';
-import { getDataSourceSrv, usePluginFunctions } from '@grafana/runtime';
+import { config, getDataSourceSrv, usePluginFunctions } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import React, { useCallback, useMemo, useRef } from 'react';
 
@@ -81,7 +81,8 @@ export function DataLinksCustomContext(props: Props) {
       });
 
       if (extensionLink?.path) {
-        linkModel.href = extensionLink.path;
+        const subUrl = config.appSubUrl ?? '';
+        linkModel.href = `${subUrl}${extensionLink.path}`;
       }
     }
 


### PR DESCRIPTION
### ✨ Description

Fixes: #784

### 📖 Summary of the changes

When navigating from a trace span to logs via the DataLinksCustomContext, the link path returned by the Logs Drilldown extension was used directly without prepending config.appSubUrl. This caused broken links when Grafana is configured with a root URL (sub-path).

Now prepends appSubUrl to the extension link path, consistent with how other navigation links are constructed in PanelMenu and SpanListScene.

### 🧪 How to test?

1. Configure Grafana's `root_url` to include a sub-path (e.g., `http://example.com/grafana`)
2. Open Traces Drilldown and view a trace by its ID
3. Click a link from a span to navigate to logs
4. Observe that the link has the `/grafana` prefix
