### PR TITLE
fix(deps): bump dompurify override to ^3.4.11

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ overrides:
   react-router: ^6.30.2
   serialize-javascript: ^7.0.5
   immutable: ^5.1.5
-  dompurify: ^3.4.9
+  dompurify: ^3.4.11
   yaml: ^2.8.3
   minimatch@^3: ~3.1.4
   minimatch@^9: ~10.2.0
@@ -3010,8 +3010,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.4.9:
-    resolution: {integrity: sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   downshift@9.3.6:
     resolution: {integrity: sha512-xEKP1vbt/k7Siu481TKibmj8EyL6iyBwaRJgb6gCsFyLeiyZ1KEJnApS9R1U71hTdK5ym0R99AOYRROcTz1PeQ==}
@@ -6322,7 +6322,7 @@ snapshots:
       d3-interpolate: 3.0.1
       d3-scale-chromatic: 3.1.0
       date-fns: 4.1.0
-      dompurify: 3.4.9
+      dompurify: 3.4.11
       eventemitter3: 5.0.1
       fast_array_intersect: 1.1.0
       history: 4.10.1
@@ -8898,7 +8898,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       csstype: 3.2.3
 
-  dompurify@3.4.9:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,7 +30,7 @@ overrides:
   react-router: ^6.30.2
   serialize-javascript: ^7.0.5
   immutable: ^5.1.5
-  dompurify: ^3.4.9
+  dompurify: ^3.4.11
   yaml: ^2.8.3
   minimatch@^3: ~3.1.4
   minimatch@^9: ~10.2.0


### PR DESCRIPTION
## Summary
- Bumps `dompurify` override from ^3.4.9 to ^3.4.11 in `pnpm-workspace.yaml`
- Fixes GHSA-cmwh-pvxp-8882 (moderate: permanent ALLOWED_ATTR pollution via setConfig())

## Test plan
- [x] `pnpm audit` passes with 0 vulnerabilities