### PR TITLE
chore(ci/cd): update to 10.1.0

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   ci-cd:
     name: CI / CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v9.0.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v10.1.0
     permissions:
       contents: write
       id-token: write
@@ -23,7 +23,6 @@ jobs:
       # On push to main: deploy to dev,ops (CI runs first inside the CD workflow).
       # On PRs and workflow_dispatch: run CI only, no publish/deploy.
       environment: ${{ (github.event_name == 'push' && github.ref_name == 'main') && 'dev,ops' || 'none' }}
-      attestation: true
       grafana-cloud-deployment-type: provisioned
       auto-merge-environments: dev,ops
       argo-workflow-slack-channel: "#proj-tracesdrilldown-cd"
@@ -32,7 +31,6 @@ jobs:
       run-playwright-docker: true
       upload-playwright-artifacts: true
       run-playwright-with-skip-grafana-dev-image: true
-      run-playwright-with-skip-grafana-react-19-preview-image: true
       playwright-report-path: e2e/test-reports/
       playwright-docker-compose-file: devenv/docker-compose.e2e.yaml
       playwright-grafana-url: http://localhost:3030

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
   CD:
     name: Deploy plugin
     needs: bump-version
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v9.0.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v10.1.0
     permissions:
       contents: write
       id-token: write
@@ -42,14 +42,16 @@ jobs:
       pull-requests: read
     with:
       environment: prod
-      attestation: true
       grafana-cloud-deployment-type: provisioned
       auto-merge-environments: dev,ops
 
       argo-workflow-slack-channel: '#proj-tracesdrilldown-cd'
 
-      # Playwright
       run-playwright: false
+      # Publish the github release automatically, turn draft off
+      github-draft-release: false
+
+      # Playwright
       run-playwright-docker: true
       upload-playwright-artifacts: true # IMPORTANT: we must ensure there are no unmasked secrets in the E2E tests
       run-playwright-with-skip-grafana-dev-image: true


### PR DESCRIPTION
### ✨ Description

- Bump reusable plugin CI/CD workflows from [`plugin-ci-workflows@ci-cd-workflows/v9.0.0`](https://github.com/grafana/plugin-ci-workflows/releases/tag/ci-cd-workflows%2Fv9.0.0) to [`v10.1.0`](https://github.com/grafana/plugin-ci-workflows/releases/tag/ci-cd-workflows%2Fv10.1.0) in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) and [`.github/workflows/cd.yml`](.github/workflows/cd.yml).
- Picks up v10 fixes (including the v10.0.0 Playwright regression fix) and v10.1.0 docs publishing behavior: prod docs now open a PR on `grafana/website` instead of pushing directly.
- Remove Attestation it is no longer supported.
- Add github-draft-release: false