### PR TITLE
chore: Wrap RED toggles in small screen

### DIFF
--- a/src/components/Explore/TracesByService/REDPanel.tsx
+++ b/src/components/Explore/TracesByService/REDPanel.tsx
@@ -411,6 +411,7 @@ function getStyles(theme: GrafanaTheme2) {
       width: '100%',
       display: 'flex',
       flexDirection: 'row',
+      flexWrap: 'wrap',
       padding: '8px 8px 0 8px',
       gap: '8px',
       justifyContent: 'space-between',

--- a/src/components/Explore/TracesByService/TracesByServiceScene.tsx
+++ b/src/components/Explore/TracesByService/TracesByServiceScene.tsx
@@ -477,25 +477,25 @@ function buildGraphScene(
         ? new MiniREDPanel({ embeddedMini, metric: 'errors' })
         : new MiniREDPanel({ embeddedMini, metric: 'duration' });
 
-    // All three panels are stacked vertically (one per row)
-    // Layout direction adjusts based on screen size
-    const isSmallScreen = typeof window !== 'undefined' && window.innerWidth < 700;
-
     sceneChildren.push(
       new SceneFlexLayout({
-        direction: !embeddedMini ? 'row' : isSmallScreen ? 'row' : 'column',
+        direction: embeddedMini ? 'column' : 'row',
+        minHeight: embeddedMini ? undefined : MAIN_PANEL_HEIGHT,
+        ...(embeddedMini ? { md: { direction: 'row' } } : {}),
         ySizing: 'content',
         children: [
           new SceneFlexItem({
             minHeight: embeddedMini ? MINI_PANEL_HEIGHT : MAIN_PANEL_HEIGHT,
             maxHeight: embeddedMini ? MINI_PANEL_HEIGHT : MAIN_PANEL_HEIGHT,
             width: embeddedMini ? undefined : '60%',
+            ...(embeddedMini ? {} : { md: { width: '100%' } }),
             body: new REDPanel({ embeddedMini }),
           }),
           new SceneFlexLayout({
             direction: 'column',
             minHeight: MAIN_PANEL_HEIGHT,
             maxHeight: MAIN_PANEL_HEIGHT,
+            ...(embeddedMini ? {} : { width: '40%', md: { width: '100%' } }),
             children: [
               new SceneFlexItem({
                 minHeight: MINI_PANEL_HEIGHT,


### PR DESCRIPTION
### ✨ Description

Fixes: https://github.com/grafana/traces-drilldown/issues/797

Wrap RED toggles in small screen

Before
<img width="553" height="416" alt="Screenshot 2026-06-29 at 08 16 16" src="https://github.com/user-attachments/assets/5e62cab9-c77e-4932-b307-1c4bdd43296e" />


After
<img width="563" height="406" alt="Screenshot 2026-06-29 at 08 15 58" src="https://github.com/user-attachments/assets/9c0fd588-ebef-4c01-90b1-ad5296f4f8a1" />
