### PR TITLE
docs: Add GenAI policy, contributor guide updates and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: '[BUG]:'
+labels: bug, needs-triage
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment**
+Grafana version, Tempo version, Traces Drilldown plugin version, and browser (if relevant).
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**AI disclosure** (optional)
+See the [Generative AI Contribution Policy](https://github.com/grafana/traces-drilldown/blob/main/docs/genai.md).
+
+- [ ] This issue was substantially generated with AI assistance.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: '[FEAT]:'
+labels: enhancement
+assignees: ''
+---
+
+**Description of the new feature**
+What problem does this feature solve? What are the pain points or missing capabilities?
+
+**Acceptance Criteria**
+A concise description of requirements.
+
+**AI disclosure** (optional)
+See the [Generative AI Contribution Policy](https://github.com/grafana/traces-drilldown/blob/main/docs/genai.md).
+
+- [ ] This feature request was substantially generated with AI assistance.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ Related issue(s): <!-- Link to the issue this PR is related to but does not reso
 
 <!-- Summary of the most important changes, the choices made (and why) and any other relevant info that will help your reviewers -->
 
-- [ ] This pull request was substantially generated with AI assistance ([GenAI policy](../docs/genai.md))
+- [ ] This pull request was substantially generated with AI assistance ([GenAI policy](https://github.com/grafana/traces-drilldown/blob/main/docs/genai.md))
 
 ### 🧪 How to test?
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ Related issue(s): <!-- Link to the issue this PR is related to but does not reso
 
 <!-- Summary of the most important changes, the choices made (and why) and any other relevant info that will help your reviewers -->
 
-- [ ] This pull request was substantially generated with AI assistance ([GenAI policy](docs/genai.md))
+- [ ] This pull request was substantially generated with AI assistance ([GenAI policy](../docs/genai.md))
 
 ### 🧪 How to test?
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,8 @@ Related issue(s): <!-- Link to the issue this PR is related to but does not reso
 
 <!-- Summary of the most important changes, the choices made (and why) and any other relevant info that will help your reviewers -->
 
+- [ ] This pull request was substantially generated with AI assistance ([GenAI policy](docs/genai.md))
+
 ### 🧪 How to test?
 
 <!-- Steps required to test the PR or pointer to the automated tests -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,8 @@
 | File | What it's for |
 |------|----------------|
 | **`AGENTS.md`** (this file) | **Entry point.** Tempo & TraceQL workflow, expected vs bug, Scenes patterns, security. Points to every other doc below. |
+| **`CONTRIBUTING.md`** | **Human contributors.** Dev setup, issues vs PRs, i18n, PR checklist, link to GenAI policy. |
+| **`docs/genai.md`** | **AI-assisted contributions.** Disclosure, acceptable use, Traces Drilldown-specific pitfalls. |
 | **`.config/AGENTS/instructions.md`** | **Plugin tooling only** — webpack, `plugin.json`, E2E, rules about `.config`. |
 | **`docs/project-intent.md`** | **Why** we built the app — philosophy, principles. Use when reasoning about tradeoffs or scope. |
 | **`docs/application-structure.md`** | **How the product is organized** — user journeys, screens, tabs, trace view, links in/out. Use when changing UI or URL behavior. |
@@ -26,6 +28,7 @@
 | **Build / plugin** — plugin.json, webpack, .config, E2E | `.config/AGENTS/instructions.md` | project-intent, application-structure |
 | **Shipped user docs** — get-started, concepts, structure | Relevant file in `docs/sources/` + `docs/README.md` | Others unless aligning to UI |
 | **Bug in traces / TraceQL / RED / data** | This file (Tempo links) + code | application-structure only if UI or URL involved |
+| **AI-assisted contribution** — drafting or reviewing with GenAI | `docs/genai.md` | AGENTS.md, CONTRIBUTING.md unless filing a PR |
 
 **Default:** Stay shallow; open another doc only when the task clearly fits. For renames, lint, or single-file UI tweaks, skip application-structure and other deep docs.
 
@@ -54,7 +57,7 @@
 
 **Plugin (build, .config, E2E):** See **`.config/AGENTS/instructions.md`** — do not modify `.config`.
 
-- **Commands** — After code changes: `yarn lint`, `yarn typecheck`.
+- **Commands** — After code changes: `pnpm lint`, `pnpm typecheck`.
 - **Edits** — Large replacements (many lines) are fewer tool calls when they succeed but often fail on whitespace/formatting. Smaller, incremental steps match more reliably. Prefer smaller steps for big or multi-part changes; one large replace is fine when the snippet is short and you have the exact content from the file.
 - **Avoid** — Reading whole large files for a small change (see Code anchors; grep first). One giant multi-file replace without verifying exact content.
 - **Frontend security** — Follow workspace rules: HTML sanitization (DOMPurify), safe URL APIs / `textUtil.sanitizeUrl` and whatever else you think is necessary.
@@ -72,3 +75,5 @@ Traces Drilldown uses [@grafana/scenes](https://grafana.com/developers/scenes/) 
 ## Usage
 
 Start with the **How these files fit together** table above, then open the doc that matches your task.
+
+**Human contributors:** follow [CONTRIBUTING.md](CONTRIBUTING.md) for how to file issues, open pull requests, run local checks, and use AI tools responsibly. The full GenAI policy is in [docs/genai.md](docs/genai.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,22 @@
 
 The Grafana Traces Drilldown app lets users navigate and visualize trace data stored in Tempo without complex queries.
 
-We love accepting contributions!
-If your change is minor, please feel free submit
-a [pull request](https://help.github.com/articles/about-pull-requests/).
-If your change is larger, or adds a feature, please file an issue beforehand so
-that we can discuss the change. You're welcome to file an implementation pull
-request immediately as well, although we generally lean towards discussing the
-change and then reviewing the implementation separately.
+We love accepting contributions! To help us create a safe and positive community experience, we require all participants to adhere to the [Grafana Code of Conduct](https://github.com/grafana/grafana/blob/main/CODE_OF_CONDUCT.md).
+
+If your change is minor, please feel free to submit a [pull request](https://help.github.com/articles/about-pull-requests/). If your change is larger, or adds a feature, please file an issue beforehand so that we can discuss the change. You're welcome to file an implementation pull request immediately as well, although we generally lean towards discussing the change and then reviewing the implementation separately.
+
+## Filing issues
+
+Use [GitHub Issues](https://github.com/grafana/traces-drilldown/issues/new) to report bugs, ask questions, or propose larger changes.
+
+| Situation | What to do |
+|-----------|------------|
+| **Bug** — something is broken or regressed | [Open a bug report](https://github.com/grafana/traces-drilldown/issues/new?template=bug_report.md) with reproduction steps, expected vs actual behavior, Grafana/Tempo versions, and screenshots or recordings if helpful. |
+| **Small fix** — typo, clear one-file change, docs tweak | Open a pull request directly; link a related issue if one exists. |
+| **Feature or larger change** — new UI, behavior change, refactor | [Open a feature request](https://github.com/grafana/traces-drilldown/issues/new?template=feature_request.md) to discuss scope, or open a draft PR with context in the description. |
+| **Documentation only** | Open a PR and add the `type/doc` label. |
+
+For bugs, check [Tempo](https://grafana.com/docs/tempo/latest/) and [TraceQL](https://grafana.com/docs/tempo/latest/traceql/) behavior first — a trace missing outside the selected time window may be expected, not a plugin bug.
 
 ## Contribute to documentation
 
@@ -25,3 +34,40 @@ the `grafana/docs` image which internally uses Hugo to generate the static site.
 
 > **Note** The `make docs` command uses a lot of memory. If it is crashing, make sure to increase the memory allocated to Docker
 > and try again.
+
+## Contribute code
+
+### Development environment
+
+1. Install dependencies: `pnpm install --frozen-lockfile --ignore-scripts`
+2. Start the dev build: `pnpm dev` (or `pnpm start` to install and watch)
+3. Run Grafana + Tempo locally: `pnpm server` (Grafana at http://localhost:3000)
+
+See [AGENTS.md](AGENTS.md) for architecture, Scenes patterns, and Tempo/TraceQL expectations. Plugin build and E2E details live in [`.config/AGENTS/instructions.md`](.config/AGENTS/instructions.md).
+
+### Before you open a pull request
+
+- Fill out the [pull request template](.github/pull_request_template.md) with a clear summary and test steps.
+- Use a [conventional commit](https://www.conventionalcommits.org/) style PR title (enforced by CI).
+- Run `pnpm lint`, `pnpm typecheck`, and `pnpm test:ci` locally.
+- Add or update tests when behavior changes. Prefer focused unit tests (Jest) or Playwright E2E when UI flows are affected.
+- Do not modify files under `.config/` unless you are following the plugin-tools guidance in `.config/AGENTS/instructions.md`.
+
+### Internationalization (i18n)
+
+User-facing strings must use Grafana i18n APIs — `t` or `Trans` from `@grafana/i18n` with a stable `i18nKey`, not hard-coded text in components.
+
+After adding or changing copy:
+
+1. Run `pnpm i18n-extract` to update `src/locales/en-US/grafana-exploretraces-app.json`.
+2. Commit the extracted English locale file with your PR.
+
+CI runs an i18n verification workflow on pull requests. Translations for other locales are managed via Crowdin and synced after changes merge to `main`; you do not need to hand-edit non-English locale files in most PRs.
+
+## Using AI and coding assistants
+
+Generative AI tools can help you explore the codebase, draft code, and write documentation. **You are always responsible for what you submit.**
+
+Read the full [Generative AI Contribution Policy](docs/genai.md) for acceptable use, disclosure, Traces Drilldown-specific guidance (TraceQL, Scenes, tests), and rules for agentic tools. Point coding assistants at [AGENTS.md](AGENTS.md) for technical conventions.
+
+When AI generated the bulk of a pull request, check the disclosure box in the pull request template.

--- a/docs/genai.md
+++ b/docs/genai.md
@@ -1,0 +1,75 @@
+# Generative AI Contribution Policy
+
+Generative AI (GenAI) tools such as large language model (LLM) assistants can help you write code, documentation, and proposals for Grafana Traces Drilldown. This policy explains what is an acceptable use of GenAI tools when contributing to the project.
+
+## Core principle
+
+**The human contributor is always in control and fully responsible for their contribution.**
+
+GenAI is a tool that assists you. It is not a substitute for your own understanding, judgment, or accountability. By submitting a contribution, you vouch for it as your own work, regardless of which tools helped you produce it. You are expected to understand, review, and provide rationale for everything you submit.
+
+## Acceptable use
+
+You are welcome to use GenAI tools to:
+
+- Write or refactor code and documentation, as long as you actively review and refine the output.
+- Understand the Traces Drilldown codebase, Grafana Scenes, Tempo, or TraceQL before contributing or reviewing.
+- Draft issues, proposals, or design documents that you then verify and shape into your own reasoning.
+- Suggest tests, formatting, or lint fixes that you verify locally with `pnpm lint`, `pnpm typecheck`, and `pnpm test:ci`.
+
+In all cases, you remain the author. You read the output, you correct it, and you ensure your contribution meets the project's standards before submitting an issue, pull request, or comment.
+
+## Not acceptable
+
+Do not:
+
+- Submit unreviewed, bulk AI-generated content to pull requests, issues, or proposals. If you did not read and understand it, do not submit it.
+- Use GenAI as a substitute for human judgment in code review. An AI tool may help you understand a change, but the review and its conclusions must be yours.
+- File automated, bot-driven issues or pull requests from tools that have not been approved by the Traces Drilldown team. This policy covers humans using AI assistance, not autonomous agents acting on their own, including agentic IDE tools that file pull requests without human review.
+- Paste generated text into a discussion without adding your own analysis and context.
+- Wire up an AI agent to respond automatically to reviewers or other community members on your behalf. If you want help from GenAI in a discussion, use it yourself and post in your own words, rather than connecting it directly to maintainers.
+- Submit pull requests without using the [pull request template](../.github/pull_request_template.md), or file bugs without reproduction steps and expected vs actual behavior.
+
+Maintainers may close low-effort AI-generated contributions. When they do, they should explain why and, where appropriate, offer guidance on how to improve the contribution. Repeated low-effort submissions will trigger stricter review, and maintainers may block repeat offenders from contributing.
+
+## Approved automation
+
+Some automated tools are explicitly approved and are an acceptable exception to the rule against bot-driven contributions. Examples include Dependabot, Copilot, release-please, and other repository automation maintained by the team. The team may approve more over time. Contributions from these tools are clearly marked as bot-generated so that reviewers can tell them apart from human contributions.
+
+## Disclosure
+
+When GenAI generates the **bulk** of a contribution, disclose it. For pull requests, check the **"This pull request was substantially generated with AI assistance"** box in the [pull request template](../.github/pull_request_template.md). For issues, use the optional AI disclosure in the [bug](../.github/ISSUE_TEMPLATE/bug_report.md) or [feature](../.github/ISSUE_TEMPLATE/feature_request.md) template. Minor, incidental help such as autocomplete or small edits does not need to be disclosed.
+
+Disclosure is not a mark against your contribution. It helps reviewers know where to focus, and it keeps expectations clear for everyone.
+
+## Traces Drilldown-specific guidance
+
+LLMs frequently hallucinate TraceQL syntax, Grafana Scenes APIs, Tempo lookup behavior, and RED metric semantics. To reduce these errors, point the tool at authoritative sources rather than relying on its training data:
+
+- [AGENTS.md][agents] for architecture, Scenes patterns, and expected vs buggy behavior.
+- [docs/application-structure.md][application-structure] for UI layout, tabs, and URL state.
+- [Tempo documentation][tempo-docs] and [TraceQL][traceql-docs] for trace search and query semantics.
+
+Always validate AI-generated code against the real component definitions and the project's checks before submitting. Run `pnpm lint`, `pnpm typecheck`, and `pnpm test:ci` locally. Use `pnpm lint:fix` for formatting when appropriate; do not commit unrelated drive-by changes.
+
+### Tests and formatting
+
+- Add tests that cover behavior you changed. Do not paste large blocks of shallow or incorrect AI-generated tests just to increase coverage.
+- Prefer focused Jest unit tests or Playwright E2E when UI flows are affected.
+- Match existing conventions in surrounding code. Keep scope tight — avoid unrelated refactors, new dependencies, or edits under `.config/` unless required and agreed.
+
+### User-facing strings
+
+New or changed UI copy must use translation keys (`t`, `Trans` from `@grafana/i18n`), not hard-coded strings. After editing copy, run `pnpm i18n-extract` and commit the updated `src/locales/en-US/grafana-exploretraces-app.json`. CI verifies i18n markup; other locales are synced via Crowdin after merge to `main`.
+
+For larger changes or new features, file an [issue][new-issue] first so we can discuss scope. A proposal must reflect your own reasoning. AI may help you draft it, but you own the argument in the discussion.
+
+### Guidance for AI agents
+
+If you use an agentic tool, point it at [AGENTS.md][agents] first. Agents should prefer small, focused diffs; grep before reading entire large files; and respect frontend security practices (sanitized HTML/URLs, no unsafe DOM APIs).
+
+[agents]: ../AGENTS.md
+[application-structure]: application-structure.md
+[tempo-docs]: https://grafana.com/docs/tempo/latest/
+[traceql-docs]: https://grafana.com/docs/tempo/latest/traceql/
+[new-issue]: https://github.com/grafana/traces-drilldown/issues/new

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -34,7 +34,7 @@
     "updated": "%TODAY%",
     "links": [
       {
-        "name": "Github",
+        "name": "GitHub",
         "url": "https://github.com/grafana/traces-drilldown"
       },
       {

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -35,11 +35,11 @@
     "links": [
       {
         "name": "Github",
-        "url": "https://github.com/grafana/explore-traces"
+        "url": "https://github.com/grafana/traces-drilldown"
       },
       {
         "name": "Report bug",
-        "url": "https://github.com/grafana/explore-traces/issues/new"
+        "url": "https://github.com/grafana/traces-drilldown/issues/new?template=bug_report.md"
       }
     ]
   },


### PR DESCRIPTION
### ✨ Description

Expands CONTRIBUTING.md with the Grafana Code of Conduct, when to file issues vs open PRs, local dev setup, PR checklist, and i18n workflow.

Adds docs/genai.md for AI-assisted contributions (disclosure, acceptable use, TraceQL/Scenes guidance) and links it from AGENTS.md and the PR template.

Adds .github/ISSUE_TEMPLATE/ bug and feature templates (aligned with logs-drilldown), with optional AI disclosure. Updates src/plugin.json GitHub links from explore-traces to traces-drilldown.