### PR TITLE
chore(header): use ToolbarButton for the plugin info button

### DIFF
--- a/src/components/App/header/PluginInfo.tsx
+++ b/src/components/App/header/PluginInfo.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { usePluginContext, GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
-import { Button, Dropdown, Menu, useStyles2 } from '@grafana/ui';
+import { Dropdown, Menu, ToolbarButton, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'utils/analytics';
@@ -14,8 +14,7 @@ const DOCUMENTATION_URL = 'https://grafana.com/docs/grafana/next/explore/simplif
 const FEEDBACK_FORM_URL = 'https://grafana.qualtrics.com/jfe/form/SV_9LUZ21zl3x4vUcS';
 
 const commitSha = process.env.COMMIT_SHA;
-const pluginCommitUrl =
-  commitSha && commitSha !== 'local' ? `${PLUGIN_REPO}/commit/${commitSha}` : undefined;
+const pluginCommitUrl = commitSha && commitSha !== 'local' ? `${PLUGIN_REPO}/commit/${commitSha}` : undefined;
 
 const { buildInfo: grafanaBuildInfo } = config;
 
@@ -109,12 +108,11 @@ function InfoMenu() {
 export function PluginInfo() {
   return (
     <Dropdown overlay={<InfoMenu />} placement="bottom-end">
-      <Button
+      <ToolbarButton
         aria-label={t('plugin-info.button.title', 'Plugin info')}
         icon="info-circle"
-        variant="secondary"
+        variant="canvas"
         tooltip={t('plugin-info.button.tooltip', 'Plugin info')}
-        tooltipPlacement="top"
         title={t('plugin-info.button.title', 'Plugin info')}
         data-testid="plugin-info-button"
       />


### PR DESCRIPTION
### ✨ Description

Related issue(s): follows [grafana/profiles-drilldown#1065](https://github.com/grafana/profiles-drilldown/pull/1065) (itself following [grafana/logs-drilldown#2009](https://github.com/grafana/logs-drilldown/pull/2009))

The plugin info button was the only control in the header's right-hand row rendered as a plain `Button variant="secondary"`. Every neighbour — save search, load search, and the scene time/refresh pickers — is a `ToolbarButton variant="canvas"`. This switches it over so the row is built from one component.

**This is a consistency change, not a visual fix — please size your review accordingly.** In Grafana 12.3 `Button variant="secondary"` and `ToolbarButton variant="canvas"` resolve to identical computed styles (`background rgba(204,204,220,0.1)`, `border 1px solid rgba(204,204,220,0.08)`, `radius 6px` in dark, and the light equivalents). The only rendered difference is width, **32px → 36px**, from `ToolbarButton`'s padding.

- [x] This pull request was substantially generated with AI assistance ([GenAI policy](https://github.com/grafana/traces-drilldown/blob/main/docs/genai.md))

### 🧪 How to test?

1. There should be no visual change and the info icon looks the same
<img width="1895" height="178" alt="Screenshot 2026-07-27 at 7 11 50 AM" src="https://github.com/user-attachments/assets/6ce0be56-c12f-488f-a581-8aa1216c935f" />

