### PR TITLE
docs: sync Traces Drilldown docs with v2.0.3 UI

### DIFF
--- a/docs/sources/concepts/_index.md
+++ b/docs/sources/concepts/_index.md
@@ -30,7 +30,7 @@ The Traces Drilldown app lets you explore rate, error, and duration (RED) metric
 | ---------------------------------------- | -------- | -------------------------------------------------------------- |
 | Unusual spikes in activity               | Rate     | Number of requests per second                                  |
 | Overall issues in your tracing ecosystem | Errors   | Number of those requests that are failing                      |
-| Response times and latency issues        | Duration | Amount of time those requests take, represented as a histogram |
+| Response times and latency issues        | Duration | Amount of time those requests take, represented as a heat map  |
 
 For more information about the RED method, refer to [The RED Method: how to instrument your services](https://grafana.com/blog/2018/08/02/the-red-method-how-to-instrument-your-services/).
 

--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -64,7 +64,7 @@ For example, you want to uncover the source of errors in your spans. You need to
 To identify the trouble spot, you want to use raw tracing data instead of only the root span, which is the first span of every trace.
 Select **All spans** in the Filters, then choose the **Errors** metric.
 
-![Select All spans to view all raw span data and Errors as your metric](/media/docs/explore-traces/traces-drilldown-allspans-errors-red-v1.2.png 'Select All spans to view all raw span data and Errors as your metric')
+![Select All spans to view all raw span data and Errors as your metric](/media/docs/explore-traces/2.0/screenshot-grafana-traces-drilldown-allspans-errors-v2.0.3.png 'Select All spans to view all raw span data and Errors as your metric')
 
 ### Handle errors
 

--- a/docs/sources/investigate/add-filters.md
+++ b/docs/sources/investigate/add-filters.md
@@ -32,7 +32,7 @@ The list of filters expands as you investigate and explore your tracing data usi
 1. Choose filters to focus on problem areas. Each selected filter is added to the **Filters** bar at the top of the page. You can select filters on the **Comparison** and **Breakdown** tabs in the following ways:
    - Select **Include** to add a matching filter (`=`) or **Exclude** to add a negating filter (`!=`).
    - Use the **Filters** bar near the top.
-   - Attributes shown with a filter icon in the **Attributes** sidebar are already applied in your current **Filters**. The **Attributes** sidebar helps you pick and favorite attributes used for grouping, comparison, and **Trace list** columns. Refer to the [UI reference](../../ui-reference/).
+   - Attributes shown with a filter icon in the **Attributes** sidebar are already applied in your current **Filters**. The **Attributes** sidebar helps you pick and favorite attributes used for grouping, comparison, and trace list columns. Refer to the [UI reference](../../ui-reference/).
 
 ![Change filters for your investigation](/media/docs/explore-traces/2.0/add-filters-span-duration-gt-200ms.png)
 
@@ -65,9 +65,7 @@ To remove a filter, select **Remove filter** (**X**) at the end of the filter yo
 
 Use the time picker at the top right to modify the data shown in Traces Drilldown.
 
-You can select a time range of up to 24 hours in duration.
-By default, this time range can be any 24-hour period in your configured trace data retention period.
-The default retention period is 30 days.
-Your configuration may vary from these values.
+The time range you can query depends on your Tempo data source configuration, including your trace retention period and the range allowed for TraceQL metrics.
+Longer time ranges scan more data and can take longer to return results.
 
 For more information about the time range picker, refer to [Use dashboards](ref:use-dashboards).

--- a/docs/sources/investigate/analyze-tracing-data.md
+++ b/docs/sources/investigate/analyze-tracing-data.md
@@ -11,7 +11,7 @@ weight: 500
 
 # Analyze tracing data
 
-To further analyze filtered spans, use tabs that change with the selected metric, such as **Breakdown**, **Comparison**, **Service structure**, **Root cause errors**, **Root cause latency**, **Exceptions**, and **Trace list**.
+To further analyze filtered spans, use tabs that change with the selected metric, such as **Breakdown**, **Comparison**, **Service structure**, **Root cause errors**, **Root cause latency**, **Exceptions**, and the trace list tab (**Traces**, **Errored traces**, or **Slow traces**).
 
 When you select a RED metric, the tabs change to match the context.
 
@@ -32,7 +32,7 @@ Use the **Attributes** sidebar to select the attribute for **Group by**.
 You can search, scope by **Resource** or **Span**, and use **Favorites** for quick access.
 Attributes already in your **Filters** are listed at the top of the **Attributes** sidebar.
 
-![Errors metric showing the Breakdown tab without filters](/media/docs/explore-traces/traces-drilldown-breakdown-tab-v1.2.png)
+![Errors metric showing the Breakdown tab without filters](/media/docs/explore-traces/2.0/screenshot-grafana-traces-drilldown-breakdown-tab-v2.0.3.png)
 
 By default, the selected attribute is your first **Favorite** or `resource.service.name`.
 You can reorder **Favorites** to change this default.
@@ -47,6 +47,11 @@ If you deselect all values, Traces Drilldown applies `p90` by default.
 The percentile choice drives what Duration values are summarized and shown in the **Breakdown** tab.
 The selector appears only when **Duration** is selected.
 
+### Create an alert from a panel
+
+You can create an alert rule directly from a **Breakdown** panel when Tempo alerting is available.
+Open the panel menu and select **Create alert** to open Grafana Alerting pre-populated with the panel's query, so you can be notified when the metric crosses a threshold.
+
 ## Use the Comparison tab
 
 The **Comparison** tab helps you surface and rank which span attributes are most correlated with the selected metric so you can spot what's driving your trace-level issues.
@@ -58,13 +63,15 @@ It lists attribute‑value pairs in descending order of that difference, so the 
 
 - If you're viewing the **Rate** or **Errors** metrics, the **selection** contains all spans with errors, while the **baseline** contains all spans without errors.
 
-- If you're viewing the **Duration** metric, by default the **selection** contains the slowest spans above the 90th percentile, while the **baseline** contains all other spans. You can manually adjust the selection on the duration heatmap.
+- If you're viewing the **Duration** metric, by default the **selection** contains the slowest spans above the 90th percentile, while the **baseline** contains all other spans. You can manually adjust the selection on the duration heat map by clicking and dragging, or select **Select slowest traces** to reset the selection to the slowest spans.
 
 The behavior of the comparison also differs depending upon the RED metric you've chosen.
 For example, if you're viewing **Errors** metrics, the comparison shows the attribute values that correlate with errors.
 However, if you're viewing **Duration** metrics, the comparison shows the attributes that correlate with high latency.
 
 Use the **Attributes** sidebar to switch between **All** (overall differences) and a specific attribute (per‑value differences). Favorites, search, and scope controls work the same as in **Breakdown**.
+
+Select **Hide baseline-only** to hide attribute values that appear only in the baseline, so you can focus on the values present in your selection.
 
 ### Focus on individual attributes with **Inspect**
 
@@ -108,7 +115,7 @@ Use the **Exceptions** tab to see which exception messages are occurring within 
 
 Examples:
 
-- Inspect individual exceptions by clicking a message to open the **Trace list** pre-filtered for that message, so you can inspect individual traces immediately.
+- Inspect individual exceptions by clicking a message to open the **Errored traces** tab pre-filtered for that message, so you can inspect individual traces immediately.
 - Narrow exceptions by service, environment, namespace, or any span/resource attribute by combining with the **Filters** bar.
 
 ![Exceptions tab](/media/docs/explore-traces/2.0/analyze-exceptions-tab.png)
@@ -130,7 +137,7 @@ If you notice a rise in the Errors metric, you can use the **Exceptions** tab to
 1. Select **Errors** as the metric.
 2. Open the **Exceptions** tab.
 3. The top row shows `Payment request failed. Too many requests (error code 429)` with rising occurrences and a spiky sparkline.
-4. Click the message to jump to the Trace list pre-filtered by that exception.
+4. Click the message to jump to the **Errored traces** tab pre-filtered by that exception.
 5. Sort by Duration to find the most impacted requests, then open a trace to inspect retries and upstream dependencies.
 
 
@@ -144,17 +151,15 @@ The **Adaptive Traces** tab appears when both of the following conditions are me
 When these conditions are met, the tab displays span latency data for the selected tail-sampling policy, helping you understand how the policy affects trace collection and latency distribution within the current time range.
 
 If Adaptive Traces isn't enabled or no tail-sampling policy filter is applied, the tab doesn't appear.
-## Use the Trace list tab
+## Use the trace list tab
 
-Each RED metric has a trace list:
+Each RED metric has its own trace list tab:
 
-- **Rate** provides a tab that lists **Traces**.
-- **Errors** provides a list of traces with errors.
-- **Duration** provides a list of **Slow traces**.
+- **Rate** provides the **Traces** tab.
+- **Errors** provides the **Errored traces** tab.
+- **Duration** provides the **Slow traces** tab.
 
-From this view, you can add additional attributes to new columns using **Add extra columns**.
-
-Use the **Attributes** sidebar to add columns. Select multiple attributes to include them as table columns. Use **Search attributes** and **Favorites** to find attributes.
+Use the **Attributes** sidebar to add attributes as extra table columns. Select multiple attributes to include them as columns, and use **Search attributes** and **Favorites** to find attributes.
 Attributes already in your **Filters** are listed at the top of the **Attributes** sidebar.
 
 <!-- TODO: Uncomment when Grafana 13 ships and tracesDrilldownTimeSeeker toggle reaches GA.
@@ -181,9 +186,8 @@ The time range seeker requires the `tracesDrilldownTimeSeeker` feature toggle. R
 
 Use the time picker at the top right to modify the data shown in Traces Drilldown.
 
-You can select a time range of up to 24 hours in duration.
-This time range can be any 24-hour period in your configured trace data retention period.
-The default is 30 days.
+The time range you can query depends on your Tempo data source configuration, including your trace retention period and the range allowed for TraceQL metrics.
+Longer time ranges scan more data and can take longer to return results.
 
 For more information about the time range picker, refer to [Use dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/use-dashboards/#set-dashboard-time-range).
 

--- a/docs/sources/investigate/choose-red-metric.md
+++ b/docs/sources/investigate/choose-red-metric.md
@@ -14,7 +14,7 @@ weight: 300
 Traces Drilldown uses RED metrics generated from your tracing data to guide your investigation.
 In this context, RED metrics mean:
 
-* **Rates** show the rate of incoming spans per second.
+* **Rate** shows the rate of incoming spans per second.
 * **Errors** show spans that are failing.
 * **Duration** displays the amount of time those spans take; represented as a heat map that shows response time and latency.
 

--- a/docs/sources/investigate/choose-span-data.md
+++ b/docs/sources/investigate/choose-span-data.md
@@ -15,10 +15,11 @@ Tracing data is highly structured and annotated and reflects events that happen 
 You can choose the type of services you want to observe and think about.
 
 By default, Traces Drilldown displays information about root spans.
-You can change this by using the selector in the filter bar.
+You can change this by using the primary signal selector in the filter bar.
+**Root spans** and **All spans** appear as buttons, and the remaining primary signals are available from the adjacent drop-down.
 
-- Use **Root spans** for trace‑level insights and faster performance (one span/trace). Root spans show only traces where the root span has an error value.
-- Use **All spans** when you need to drill down into every operation within those traces. All spans show traces containing errors anywhere in the call chain, for example, database errors or downstream service failures.
+- Use **Root spans** for trace‑level insights and faster performance (one span per trace). When you select the **Errors** metric, this shows traces whose root span has an error status.
+- Use **All spans** when you need to drill down into every operation within those traces. When you select the **Errors** metric, this shows traces that contain errors anywhere in the call chain, for example, database errors or downstream service failures.
 
 For most observability use cases, start with root spans to get accurate service-level metrics, then switch to all spans when you need to investigate specific internal operations or errors deeper in the call chain.
 
@@ -58,3 +59,13 @@ Errors can cascade through downstream services, and error counts differ from err
 {{< /admonition >}}
 
 ![The Rate metric view showing All spans selected](/media/docs/explore-traces/2.0/choose-span-data-all-spans.png)
+
+## Use other primary signals
+
+**Root spans** and **All spans** appear as buttons in the filter bar. Select the drop-down next to them to choose one of these additional primary signals:
+
+- **Server spans**: Explore server-specific segments of traces (spans where `kind` is `server`).
+- **Consumer spans**: Analyze interactions initiated by consumer services (spans where `kind` is `consumer`).
+- **Database calls**: Evaluate performance issues in database interactions (spans that have a `span.db.system.name` attribute).
+
+Each primary signal applies a filter that scopes every metric, tab, and breakdown to the matching spans.

--- a/docs/sources/investigate/view-exemplars.md
+++ b/docs/sources/investigate/view-exemplars.md
@@ -6,7 +6,7 @@ keywords:
   - Investigate
 title: View exemplars
 menuTitle: View exemplars
-weight: 600
+weight: 800
 ---
 
 # View exemplars
@@ -28,7 +28,10 @@ For more information, refer to [Introduction to exemplars](/docs/grafana/<GRAFAN
 In Traces Drilldown, exemplar data is represented by a small diamond next to the bar graphs.
 You can view the exemplar information by hovering the cursor over the small diamond.
 
-As you view metrics in the **Breakdown**, **Service structure**, or other investigation tabs, look for small diamond icons next to the bar chart metrics.
+Exemplars appear on the **Rate** and **Errors** bar charts, including the per-attribute charts in the **Breakdown** tab.
+The **Duration** heat map doesn't display exemplars.
+
+As you view **Rate** or **Errors** metrics in the **Breakdown**, **Service structure**, or other investigation tabs, look for small diamond icons next to the bar chart metrics.
 
 When you hover your cursor over a diamond, a tooltip appears showing:
 

--- a/docs/sources/ui-reference/_index.md
+++ b/docs/sources/ui-reference/_index.md
@@ -12,7 +12,7 @@ refs:
       destination: /docs/grafana-cloud/visualizations/dashboards/use-dashboards/#set-dashboard-time-range
 title: Traces Drilldown UI reference
 menuTitle: UI reference
-weight: 600
+weight: 700
 ---
 
 # Traces Drilldown UI reference
@@ -21,20 +21,20 @@ Grafana Traces Drilldown helps you focus your tracing data exploration.
 Some sections change based on the metric you choose.
 For details on workflows, refer to [Analyze tracing data](../investigate/analyze-tracing-data/).
 
-![Numbered sections of the Traces Drilldown app](/media/docs/explore-traces/traces-drilldown-screen-parts-numbered-v1.2.png)
+![Numbered sections of the Traces Drilldown app](/media/docs/explore-traces/2.0/screenshot-grafana-traces-drilldown-screen-parts-numbered-v2.0.3.png)
 
 1. **Data source selection**:
-   At the top left, you select the data source for your traces. In this example, the data source is set to `grafanacloud-traces`.
+   At the top left, you select the data source for your traces, either a Grafana Cloud Traces or Tempo data source.
 
 1. **Filters**:
    The filter bar helps you refine the data displayed.
-   You can select the type of trace data, either **Root spans** or **All spans**. You can also add specific label values to narrow the scope of your investigation.
+   You can select the primary signal (**Root spans** or **All spans**, plus **Server spans**, **Consumer spans**, or **Database calls** from the adjacent drop-down). You can also add specific label values to narrow the scope of your investigation.
 
 1. **Select metric type**:
    Choose between **Rate**, **Errors**, or **Duration** metrics. In this example, the **Rate** metric is selected, showing the number of spans per second.
    - The **Rate** graph (top left) shows the rate of spans over time.
    - The **Errors** graph (top right) displays the error rate over time, with red bars indicating errors.
-   - The **Duration** heatmap (bottom right) visualizes the distribution of span durations and can help identify latency patterns.
+   - The **Duration** heat map (bottom right) visualizes the distribution of span durations and can help identify latency patterns.
 
 <!-- TODO: Uncomment when Grafana 13 ships and tracesDrilldownTimeSeeker toggle reaches GA.
 1. **Time range seeker**:
@@ -55,13 +55,13 @@ For details on workflows, refer to [Analyze tracing data](../investigate/analyze
    Each metric type has its own set of tabs that help you explore your tracing data. These tabs differ depending on the metric type you've selected.
    For example, when you use **Rate**, the investigation tabs show **Breakdown**, **Service structure**, **Comparison**, and **Traces**.
    - **Exceptions** (**Errors** only): Group exception messages with counts, trend sparkline, emitting service, and last-seen.
-    - Percentiles (Duration only): Choose `p50`, `p75`, `p90`, `p95`, `p99` for Duration views. Default: `p90`. If you clear all, `p90` applies automatically.
+   - Percentiles (Duration only): Choose `p50`, `p75`, `p90`, `p95`, `p99` for Duration views. Default: `p90`. If you clear all, `p90` applies automatically.
 
 1. **Include and Exclude**:
    Each attribute group includes **Include** and **Exclude** buttons. Select **Include** to add a matching filter (`=`) or **Exclude** to add a negating filter (`!=`) to your current investigation.
 
 1. **Time range selector**:
-   At the top right, you can adjust the time range for displayed data using the time picker. In this example, the time range is set to the last 24 hours. Refer to [Set dashboard time range](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/use-dashboards/#set-dashboard-time-range) for more information.
+   At the top right, you can adjust the time range for displayed data using the time picker. In this example, the time range is set to the last 1 hour. Refer to [Set dashboard time range](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/use-dashboards/#set-dashboard-time-range) for more information.
 
    You can also open a specific trace by ID by entering the trace ID into the **Trace ID** input and pressing Enter. Refer to [Open a trace by ID](../investigate/analyze-tracing-data/#open-a-trace-by-id) for more information.
 
@@ -74,7 +74,23 @@ For details on workflows, refer to [Analyze tracing data](../investigate/analyze
 
     Click the star icon to add or remove a favorite. Drag and drop favorites to reorder them. Switch between scopes: **Favorites**, **All**, **Resource**, **Span**. A filter icon marks attributes already applied in the **Filters** bar.
 
-    In **Breakdown** and **Comparison** views, selecting an attribute sets the current **Group by** attribute. In **Trace list** view, select multiple attributes to add or remove table columns. The app saves favorites in your browser.
+    In **Breakdown** and **Comparison** views, selecting an attribute sets the current **Group by** attribute. In the trace list view, select multiple attributes to add or remove table columns. The app saves favorites in your browser.
+
+## Share your investigation
+
+Select **Copy url** (link icon) in the tab bar to copy a URL that captures your current exploration state, including the data source, filters, selected metric, active tab, and time range.
+Share the URL so others can open the same view.
+
+## View service insights
+
+{{< admonition type="note" >}}
+Service insights require the Grafana Asserts app and are available on Grafana Cloud.
+{{< /admonition >}}
+
+When the Grafana Asserts app is available, Traces Drilldown adds context for the service you're investigating:
+
+- **Insights**: Turn on the **Insights** toggle on the RED metric time series to overlay annotations that mark notable events on the timeline.
+- **Entity assertions**: An assertions widget in the header summarizes active assertions for the selected service.
 
 ## Query result streaming
 


### PR DESCRIPTION
Updated docs to catch changes: 
- Sync investigation and UI reference docs with the v2.0.3 UI (primary signals, tab names, Create alert, Comparison controls, Share/Insights).
- Soften incorrect 24-hour time-range claims and refresh screenshots to the uploaded v2.0.3 media assets.

## Test plan
- [ ] Spot-check rendered docs pages for updated screenshots and callouts
- [ ] Confirm image URLs under /media/docs/explore-traces/2.0/ load