### PR TITLE
chore: Remove unused dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,11 +20,8 @@ overrides:
   minimatch@^9: ~10.2.0
   minimatch@^10: ^10.2.3
   uuid: ^14.0.0
-  '@tootallnate/once': '>=3.0.1'
   js-cookie: ^3.0.7
-  protobufjs: 7.6.3
   ws: 8.21.0
-  esbuild: 0.28.1
   js-yaml: 4.3.0
   '@opentelemetry/core': 2.8.0
   qs: ^6.15.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,8 +16,6 @@ blockExoticSubdeps: true
 strictDepBuilds: true
 
 allowBuilds:
-  esbuild: true
-  rolldown: true
   unrs-resolver: true
 
 overrides:
@@ -36,11 +34,8 @@ overrides:
   minimatch@^9: ~10.2.0
   minimatch@^10: ^10.2.3
   uuid: ^14.0.0
-  '@tootallnate/once': '>=3.0.1'
   js-cookie: ^3.0.7
-  protobufjs: 7.6.3
   ws: 8.21.0
-  esbuild: 0.28.1
   js-yaml: 4.3.0
   '@opentelemetry/core': 2.8.0
   qs: ^6.15.2


### PR DESCRIPTION
### ✨ Description

chore: Remove unused dependencies

Also drop stale allowBuilds / override entries for packages no longer in the dependency tree (esbuild, rolldown, protobufjs, @tootallnate/once).