### PR TITLE
chore(colors): centralise metric colors and clean up overrides

### DIFF
--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -84,10 +84,10 @@ Use the **Comparison** tab to correlate attributes values with errors. The resul
 you see what's causing the errors immediately.
 The **Comparison** tab analyzes the difference between two sets of traces:
 
-- Green bars (Baseline): Normal/healthy trace behavior
+- Blue bars (Baseline): Normal/healthy trace behavior
 - Red bars (Selection): Current selection with status = error filter
 
-The view compares your selection (red) to the baseline (green) and ranks attributes by the largest difference.
+The view compares your selection (red) to the baseline (blue) and ranks attributes by the largest difference.
 This indicates a significant spike in `HTTP 500` (Internal Server Error) responses during your selected time range.
 The visualization highlights that:
 

--- a/docs/sources/investigate/analyze-tracing-data.md
+++ b/docs/sources/investigate/analyze-tracing-data.md
@@ -21,7 +21,7 @@ Each tab provides a brief explanation about the information provided.
 
 The **Breakdown** tab splits the selected metric by the values of a chosen resource or span attribute.
 When you're using **Duration** metrics, **Breakdown** shows the 90th percentile duration for every value of the selected attribute and orders values by average duration.
-When you select **Rate**, **Breakdown** orders the sequence of attributes by their rate of requests per second, with errors colored red.
+When you select **Rate**, **Breakdown** orders the sequence of attributes by their rate of requests per second.
 
 You can change the **Scope** to show **Resource** or **Span**.
 

--- a/src/components/Explore/TracesByService/MiniREDPanel.tsx
+++ b/src/components/Explore/TracesByService/MiniREDPanel.tsx
@@ -16,7 +16,6 @@ import { EmptyStateScene } from 'components/states/EmptyState/EmptyStateScene';
 import { LoadingStateScene } from 'components/states/LoadingState/LoadingStateScene';
 import { SkeletonComponent } from '../ByFrameRepeater';
 import { barsPanelConfig } from '../panels/barsPanel';
-import { getMetricColorName } from '../seeker/getMetricColor';
 import { getMetricsTempoQuery } from '../queries/generateMetricsQuery';
 import { StepQueryRunner } from '../queries/StepQueryRunner';
 import { RadioButtonList, useStyles2 } from '@grafana/ui';
@@ -122,10 +121,7 @@ export class MiniREDPanel extends SceneObjectBase<MiniREDPanelState> {
     if (metric === 'rate') {
       panel.setCustomFieldConfig('axisLabel', 'span/s');
     } else if (metric === 'errors') {
-      panel.setTitle('Errors rate').setCustomFieldConfig('axisLabel', 'error/s').setColor({
-        fixedColor: getMetricColorName('errors'),
-        mode: 'fixed',
-      });
+      panel.setTitle('Errors rate').setCustomFieldConfig('axisLabel', 'error/s');
     }
 
     return panel.build();

--- a/src/components/Explore/TracesByService/MiniREDPanel.tsx
+++ b/src/components/Explore/TracesByService/MiniREDPanel.tsx
@@ -16,6 +16,7 @@ import { EmptyStateScene } from 'components/states/EmptyState/EmptyStateScene';
 import { LoadingStateScene } from 'components/states/LoadingState/LoadingStateScene';
 import { SkeletonComponent } from '../ByFrameRepeater';
 import { barsPanelConfig } from '../panels/barsPanel';
+import { getMetricColorName } from '../seeker/getMetricColor';
 import { getMetricsTempoQuery } from '../queries/generateMetricsQuery';
 import { StepQueryRunner } from '../queries/StepQueryRunner';
 import { RadioButtonList, useStyles2 } from '@grafana/ui';
@@ -122,7 +123,7 @@ export class MiniREDPanel extends SceneObjectBase<MiniREDPanelState> {
       panel.setCustomFieldConfig('axisLabel', 'span/s');
     } else if (metric === 'errors') {
       panel.setTitle('Errors rate').setCustomFieldConfig('axisLabel', 'error/s').setColor({
-        fixedColor: 'semi-dark-red',
+        fixedColor: getMetricColorName('errors'),
         mode: 'fixed',
       });
     }

--- a/src/components/Explore/TracesByService/REDPanel.tsx
+++ b/src/components/Explore/TracesByService/REDPanel.tsx
@@ -17,7 +17,6 @@ import { EmptyStateScene } from 'components/states/EmptyState/EmptyStateScene';
 import { LoadingStateScene } from 'components/states/LoadingState/LoadingStateScene';
 import { SkeletonComponent } from '../ByFrameRepeater';
 import { barsPanelConfig } from '../panels/barsPanel';
-import { getMetricColorName } from '../seeker/getMetricColor';
 import { getMetricsTempoQuery } from '../queries/generateMetricsQuery';
 import { StepQueryRunner } from '../queries/StepQueryRunner';
 import { css } from '@emotion/css';
@@ -221,10 +220,7 @@ export class REDPanel extends SceneObjectBase<RateMetricsPanelState> {
     if (type === 'rate') {
       panel.setCustomFieldConfig('axisLabel', 'span/s');
     } else if (type === 'errors') {
-      panel.setCustomFieldConfig('axisLabel', 'error/s').setColor({
-        fixedColor: getMetricColorName('errors'),
-        mode: 'fixed',
-      });
+      panel.setCustomFieldConfig('axisLabel', 'error/s');
     }
     return new SceneFlexLayout({
       direction: 'row',

--- a/src/components/Explore/TracesByService/REDPanel.tsx
+++ b/src/components/Explore/TracesByService/REDPanel.tsx
@@ -17,6 +17,7 @@ import { EmptyStateScene } from 'components/states/EmptyState/EmptyStateScene';
 import { LoadingStateScene } from 'components/states/LoadingState/LoadingStateScene';
 import { SkeletonComponent } from '../ByFrameRepeater';
 import { barsPanelConfig } from '../panels/barsPanel';
+import { getMetricColorName } from '../seeker/getMetricColor';
 import { getMetricsTempoQuery } from '../queries/generateMetricsQuery';
 import { StepQueryRunner } from '../queries/StepQueryRunner';
 import { css } from '@emotion/css';
@@ -221,7 +222,7 @@ export class REDPanel extends SceneObjectBase<RateMetricsPanelState> {
       panel.setCustomFieldConfig('axisLabel', 'span/s');
     } else if (type === 'errors') {
       panel.setCustomFieldConfig('axisLabel', 'error/s').setColor({
-        fixedColor: 'semi-dark-red',
+        fixedColor: getMetricColorName('errors'),
         mode: 'fixed',
       });
     }

--- a/src/components/Explore/TracesByService/Tabs/Breakdown/AttributesBreakdownScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Breakdown/AttributesBreakdownScene.tsx
@@ -178,13 +178,19 @@ export class AttributesBreakdownScene extends SceneObjectBase<AttributesBreakdow
             tags={
               metric === 'duration'
                 ? []
-                : [
-                    { label: t('attributes-breakdown-scene.rate-label', 'Rate'), color: getMetricColor(theme, 'rate') },
-                    {
-                      label: t('attributes-breakdown-scene.error-label', 'Error'),
-                      color: getMetricColor(theme, 'errors'),
-                    },
-                  ]
+                : metric === 'errors'
+                  ? [
+                      {
+                        label: t('attributes-breakdown-scene.error-label', 'Error'),
+                        color: getMetricColor(theme, 'errors'),
+                      },
+                    ]
+                  : [
+                      {
+                        label: t('attributes-breakdown-scene.rate-label', 'Rate'),
+                        color: getMetricColor(theme, 'rate'),
+                      },
+                    ]
             }
           />
           {body instanceof LayoutSwitcher && (

--- a/src/components/Explore/TracesByService/Tabs/Breakdown/AttributesBreakdownScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Breakdown/AttributesBreakdownScene.tsx
@@ -12,7 +12,8 @@ import {
   VizPanel,
 } from '@grafana/scenes';
 import { t } from '@grafana/i18n';
-import { Stack, useStyles2 } from '@grafana/ui';
+import { Stack, useStyles2, useTheme2 } from '@grafana/ui';
+import { getMetricColor } from '../../../seeker/getMetricColor';
 
 import { MetricFunction, MIN_PANEL_HEIGHT } from '../../../../../utils/shared';
 
@@ -140,6 +141,7 @@ export class AttributesBreakdownScene extends SceneObjectBase<AttributesBreakdow
     const groupBy = groupByValue as string;
     const { body, createAlertPayload } = model.useState();
     const styles = useStyles2(getStyles);
+    const theme = useTheme2();
 
     const { attributes } = getTraceByServiceScene(model).useState();
     const { favoriteAttributes } = useFavoriteAttributes({ scene: model });
@@ -177,8 +179,11 @@ export class AttributesBreakdownScene extends SceneObjectBase<AttributesBreakdow
               metric === 'duration'
                 ? []
                 : [
-                    { label: t('attributes-breakdown-scene.rate-label', 'Rate'), color: 'blue' },
-                    { label: t('attributes-breakdown-scene.error-label', 'Error'), color: 'red' },
+                    { label: t('attributes-breakdown-scene.rate-label', 'Rate'), color: getMetricColor(theme, 'rate') },
+                    {
+                      label: t('attributes-breakdown-scene.error-label', 'Error'),
+                      color: getMetricColor(theme, 'errors'),
+                    },
                   ]
             }
           />

--- a/src/components/Explore/TracesByService/Tabs/Comparison/AttributesComparisonScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Comparison/AttributesComparisonScene.tsx
@@ -23,6 +23,7 @@ import { LayoutSwitcher } from '../../../LayoutSwitcher';
 import { AddToFiltersAction } from '../../../actions/AddToFiltersAction';
 import { map, Observable } from 'rxjs';
 import { BaselineColor, buildAllComparisonLayout, SelectionColor } from '../../../layouts/allComparison';
+import { getMetricColorName } from '../../../seeker/getMetricColor';
 // eslint-disable-next-line no-restricted-imports
 import { comparisonQuery } from '../../../queries/comparisonQuery';
 import { buildAttributeComparison } from '../../../layouts/attributeComparison';
@@ -235,7 +236,7 @@ export class AttributesComparisonScene extends SceneObjectBase<AttributesCompari
                 color:
                   traceExploration.getMetricFunction() === 'duration'
                     ? SelectionColor
-                    : getTheme().visualization.getColorByName('semi-dark-red'),
+                    : getTheme().visualization.getColorByName(getMetricColorName('errors')),
               },
             ]}
           />

--- a/src/components/Explore/layouts/allComparison.test.ts
+++ b/src/components/Explore/layouts/allComparison.test.ts
@@ -1,0 +1,43 @@
+import { BaselineColor, SelectionColor, getPanelConfig } from './allComparison';
+
+function colorOverrides(panel: { state: { fieldConfig?: { overrides?: unknown[] } } }) {
+  return panel.state.fieldConfig?.overrides ?? [];
+}
+
+function fixedColorForField(overrides: unknown[], fieldName: string) {
+  for (const override of overrides) {
+    const o = override as {
+      matcher?: { options?: string };
+      properties?: Array<{ id?: string; value?: { mode?: string; fixedColor?: string } }>;
+    };
+    if (o.matcher?.options !== fieldName) {
+      continue;
+    }
+    const colorProp = o.properties?.find((p) => p.id === 'color' && p.value?.mode === 'fixed');
+    if (colorProp?.value?.fixedColor) {
+      return colorProp.value.fixedColor;
+    }
+  }
+  return undefined;
+}
+
+describe('getPanelConfig comparison colors', () => {
+  it('uses BaselineColor for baseline on every metric (not green)', () => {
+    for (const metric of ['rate', 'errors', 'duration'] as const) {
+      const panel = getPanelConfig(metric).build();
+      const overrides = colorOverrides(panel);
+      expect(fixedColorForField(overrides, 'Baseline')).toBe(BaselineColor);
+      expect(fixedColorForField(overrides, 'Baseline')).not.toMatch(/green/);
+    }
+  });
+
+  it('uses SelectionColor for duration selection', () => {
+    const panel = getPanelConfig('duration').build();
+    expect(fixedColorForField(colorOverrides(panel), 'Selection')).toBe(SelectionColor);
+  });
+
+  it('uses semi-dark-red for rate/errors selection', () => {
+    expect(fixedColorForField(colorOverrides(getPanelConfig('rate').build()), 'Selection')).toBe('semi-dark-red');
+    expect(fixedColorForField(colorOverrides(getPanelConfig('errors').build()), 'Selection')).toBe('semi-dark-red');
+  });
+});

--- a/src/components/Explore/layouts/allComparison.ts
+++ b/src/components/Explore/layouts/allComparison.ts
@@ -5,6 +5,7 @@ import { AxisPlacement } from '@grafana/ui';
 import { TooltipDisplayMode } from '@grafana/schema';
 import { HighestDifferencePanel } from './HighestDifferencePanel';
 import { GRID_TEMPLATE_COLUMNS, MetricFunction } from '../../../utils/shared';
+import { getMetricColorName } from '../seeker/getMetricColor';
 
 export const BaselineColor = '#5794F299';
 export const SelectionColor = '#FF9930';
@@ -94,7 +95,7 @@ export function getPanelConfig(metric: MetricFunction) {
         .matchFieldsWithName('Selection')
         .overrideColor({
           mode: 'fixed',
-          fixedColor: metric === 'duration' ? SelectionColor : 'semi-dark-red',
+          fixedColor: metric === 'duration' ? SelectionColor : getMetricColorName('errors'),
         })
         .overrideUnit('percentunit');
     });

--- a/src/components/Explore/layouts/attributeBreakdown.ts
+++ b/src/components/Explore/layouts/attributeBreakdown.ts
@@ -71,11 +71,8 @@ export function buildNormalLayout(
         children: [
           new SceneFlexItem({
             minHeight: 300,
-            body: (() => {
-              const panel =
-                metric === 'duration' ? linesPanelConfig(metric).setUnit('s') : linesPanelConfig(metric);
-              return panel.build();
-            })(),
+            // No fixed metric color — default palette keeps multi-series distinguishable.
+            body: (metric === 'duration' ? linesPanelConfig().setUnit('s') : linesPanelConfig()).build(),
           }),
         ],
       }),

--- a/src/components/Explore/layouts/attributeBreakdown.ts
+++ b/src/components/Explore/layouts/attributeBreakdown.ts
@@ -25,6 +25,7 @@ import { syncYAxis } from '../behaviors/syncYaxis';
 import { exemplarsTransformations } from '../../../utils/exemplars';
 import type { AlertPanelTarget } from '../actions/createAlert/getPanelDataForAlert';
 import { PanelMenu, type PanelMenuCreateAlertHandler } from '../panels/PanelMenu';
+import { getMetricColorName } from '../seeker/getMetricColor';
 
 export function buildNormalLayout(
   scene: SceneObject,
@@ -71,10 +72,10 @@ export function buildNormalLayout(
         children: [
           new SceneFlexItem({
             minHeight: 300,
-            body: (metric === 'duration'
-              ? linesPanelConfig('semi-dark-blue').setUnit('s')
-              : linesPanelConfig(metric === 'errors' ? 'semi-dark-red' : 'blue')
-            ).build(),
+            body: (() => {
+              const color = getMetricColorName(metric);
+              return (metric === 'duration' ? linesPanelConfig(color).setUnit('s') : linesPanelConfig(color)).build();
+            })(),
           }),
         ],
       }),
@@ -148,9 +149,9 @@ export function getLayoutChild(
       },
     ];
 
-    // Duration uses semi-dark-blue to stay in the neutral (non-status) family while
-    // remaining distinguishable from the rate panels (blue).
-    const panel = (metric === 'duration' ? linesPanelConfig('semi-dark-blue').setUnit('s') : barsPanelConfig(metric))
+    const panel = (metric === 'duration'
+      ? linesPanelConfig(getMetricColorName(metric)).setUnit('s')
+      : barsPanelConfig(metric))
       .setTitle(getTitle(frame, variable.getValueText()))
       .setMenu(
         new PanelMenu({

--- a/src/components/Explore/layouts/attributeBreakdown.ts
+++ b/src/components/Explore/layouts/attributeBreakdown.ts
@@ -25,7 +25,6 @@ import { syncYAxis } from '../behaviors/syncYaxis';
 import { exemplarsTransformations } from '../../../utils/exemplars';
 import type { AlertPanelTarget } from '../actions/createAlert/getPanelDataForAlert';
 import { PanelMenu, type PanelMenuCreateAlertHandler } from '../panels/PanelMenu';
-import { getMetricColorName } from '../seeker/getMetricColor';
 
 export function buildNormalLayout(
   scene: SceneObject,
@@ -73,8 +72,9 @@ export function buildNormalLayout(
           new SceneFlexItem({
             minHeight: 300,
             body: (() => {
-              const color = getMetricColorName(metric);
-              return (metric === 'duration' ? linesPanelConfig(color).setUnit('s') : linesPanelConfig(color)).build();
+              const panel =
+                metric === 'duration' ? linesPanelConfig(metric).setUnit('s') : linesPanelConfig(metric);
+              return panel.build();
             })(),
           }),
         ],
@@ -149,9 +149,7 @@ export function getLayoutChild(
       },
     ];
 
-    const panel = (metric === 'duration'
-      ? linesPanelConfig(getMetricColorName(metric)).setUnit('s')
-      : barsPanelConfig(metric))
+    const panel = (metric === 'duration' ? linesPanelConfig(metric).setUnit('s') : barsPanelConfig(metric))
       .setTitle(getTitle(frame, variable.getValueText()))
       .setMenu(
         new PanelMenu({

--- a/src/components/Explore/panels/barsPanel.ts
+++ b/src/components/Explore/panels/barsPanel.ts
@@ -1,10 +1,9 @@
 import { PanelBuilders } from '@grafana/scenes';
 import { DrawStyle, StackingMode, TooltipDisplayMode } from '@grafana/ui';
 import { MetricFunction } from 'utils/shared';
+import { getMetricColorName } from '../seeker/getMetricColor';
 
 export const barsPanelConfig = (metric: MetricFunction, axisWidth?: number) => {
-  const isErrorsMetric = metric === 'errors' || false;
-  
   const builder = PanelBuilders.timeseries()
     .setOption('annotations', { multiLane: true })
     .setOption('legend', { showLegend: false })
@@ -17,9 +16,7 @@ export const barsPanelConfig = (metric: MetricFunction, axisWidth?: number) => {
     .setOverrides((overrides) => {
       overrides.matchFieldsWithNameByRegex('.*').overrideColor({
         mode: 'fixed',
-        // Rate is neutral throughput (all spans); use a neutral blue and reserve
-        // green for an explicit success signal.
-        fixedColor: isErrorsMetric ? 'semi-dark-red' : 'blue',
+        fixedColor: getMetricColorName(metric),
       });
     })
     .setOption('tooltip', { mode: TooltipDisplayMode.Multi });

--- a/src/components/Explore/panels/barsPanel.ts
+++ b/src/components/Explore/panels/barsPanel.ts
@@ -1,7 +1,7 @@
 import { PanelBuilders } from '@grafana/scenes';
 import { DrawStyle, StackingMode, TooltipDisplayMode } from '@grafana/ui';
 import { MetricFunction } from 'utils/shared';
-import { getMetricColorName } from '../seeker/getMetricColor';
+import { applyMetricSeriesColorOverrides } from '../seeker/getMetricColor';
 
 export const barsPanelConfig = (metric: MetricFunction, axisWidth?: number) => {
   const builder = PanelBuilders.timeseries()
@@ -14,10 +14,7 @@ export const barsPanelConfig = (metric: MetricFunction, axisWidth?: number) => {
     .setCustomFieldConfig('pointSize', 0)
     .setCustomFieldConfig('axisLabel', 'Rate')
     .setOverrides((overrides) => {
-      overrides.matchFieldsWithNameByRegex('.*').overrideColor({
-        mode: 'fixed',
-        fixedColor: getMetricColorName(metric),
-      });
+      applyMetricSeriesColorOverrides(overrides, metric);
     })
     .setOption('tooltip', { mode: TooltipDisplayMode.Multi });
 

--- a/src/components/Explore/panels/linesPanel.ts
+++ b/src/components/Explore/panels/linesPanel.ts
@@ -1,19 +1,18 @@
 import { PanelBuilders } from '@grafana/scenes';
 import { TooltipDisplayMode } from '@grafana/ui';
+import { MetricFunction } from 'utils/shared';
+import { applyMetricSeriesColorOverrides } from '../seeker/getMetricColor';
 
-export const linesPanelConfig = (fixedColor?: string) => {
+export const linesPanelConfig = (metric?: MetricFunction) => {
   const builder = PanelBuilders.timeseries()
     .setOption('annotations', { multiLane: true })
     .setOption('legend', { showLegend: false })
     .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
     .setCustomFieldConfig('fillOpacity', 15);
 
-  if (fixedColor) {
+  if (metric) {
     builder.setOverrides((overrides) => {
-      overrides.matchFieldsWithNameByRegex('.*').overrideColor({
-        mode: 'fixed',
-        fixedColor,
-      });
+      applyMetricSeriesColorOverrides(overrides, metric);
     });
   }
 

--- a/src/components/Explore/panels/metricPanelColors.test.ts
+++ b/src/components/Explore/panels/metricPanelColors.test.ts
@@ -1,0 +1,70 @@
+import { barsPanelConfig } from './barsPanel';
+import { linesPanelConfig } from './linesPanel';
+
+function colorOverrides(panel: { state: { fieldConfig?: { overrides?: unknown[] } } }) {
+  return panel.state.fieldConfig?.overrides ?? [];
+}
+
+function fixedColorsFromOverrides(overrides: unknown[]) {
+  return overrides.flatMap((override) => {
+    const o = override as {
+      matcher?: { id?: string; options?: string };
+      properties?: Array<{ id?: string; value?: { mode?: string; fixedColor?: string } }>;
+    };
+    return (o.properties ?? [])
+      .filter((p) => p.id === 'color' && p.value?.mode === 'fixed')
+      .map((p) => ({
+        matcher: o.matcher?.options,
+        fixedColor: p.value?.fixedColor,
+      }));
+  });
+}
+
+describe('barsPanelConfig', () => {
+  it('uses blue for rate (not green)', () => {
+    const panel = barsPanelConfig('rate').build();
+    expect(fixedColorsFromOverrides(colorOverrides(panel))).toEqual([
+      { matcher: '.*', fixedColor: 'blue' },
+    ]);
+  });
+
+  it('uses semi-dark-red for errors', () => {
+    const panel = barsPanelConfig('errors').build();
+    expect(fixedColorsFromOverrides(colorOverrides(panel))).toEqual([
+      { matcher: '.*', fixedColor: 'semi-dark-red' },
+    ]);
+  });
+
+  it('applies axisWidth when provided', () => {
+    const panel = barsPanelConfig('rate', 70).build();
+    expect(panel.state.fieldConfig?.defaults?.custom?.axisWidth).toBe(70);
+  });
+});
+
+describe('linesPanelConfig', () => {
+  it('does not apply a fixed color when metric is omitted (Single layout)', () => {
+    const panel = linesPanelConfig().build();
+    expect(fixedColorsFromOverrides(colorOverrides(panel))).toEqual([]);
+  });
+
+  it('uses semi-dark-blue for duration when metric is set', () => {
+    const panel = linesPanelConfig('duration').build();
+    expect(fixedColorsFromOverrides(colorOverrides(panel))).toEqual([
+      { matcher: '.*', fixedColor: 'semi-dark-blue' },
+    ]);
+  });
+
+  it('uses blue for rate when metric is set', () => {
+    const panel = linesPanelConfig('rate').build();
+    expect(fixedColorsFromOverrides(colorOverrides(panel))).toEqual([
+      { matcher: '.*', fixedColor: 'blue' },
+    ]);
+  });
+
+  it('uses semi-dark-red for errors when metric is set', () => {
+    const panel = linesPanelConfig('errors').build();
+    expect(fixedColorsFromOverrides(colorOverrides(panel))).toEqual([
+      { matcher: '.*', fixedColor: 'semi-dark-red' },
+    ]);
+  });
+});

--- a/src/components/Explore/seeker/TimeSeekerContext.test.tsx
+++ b/src/components/Explore/seeker/TimeSeekerContext.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import { TimeSeekerProvider, useTimeSeeker } from './TimeSeekerContext';
-import { getMetricColor } from './getMetricColor';
+import { getMetricColor, getMetricColorName } from './getMetricColor';
 import { dateTime, FieldType, LoadingState } from '@grafana/data';
 
 const createMockData = () => ({
@@ -126,6 +126,15 @@ describe('TimeSeekerContext', () => {
 
     it('returns blue for undefined metric', () => {
       expect(getMetricColor(mockTheme, undefined)).toBe('color-blue');
+    });
+  });
+
+  describe('getMetricColorName', () => {
+    it('returns palette names for each metric', () => {
+      expect(getMetricColorName('duration')).toBe('semi-dark-blue');
+      expect(getMetricColorName('errors')).toBe('semi-dark-red');
+      expect(getMetricColorName('rate')).toBe('blue');
+      expect(getMetricColorName(undefined)).toBe('blue');
     });
   });
 

--- a/src/components/Explore/seeker/TimeSeekerContext.test.tsx
+++ b/src/components/Explore/seeker/TimeSeekerContext.test.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import { TimeSeekerProvider, useTimeSeeker } from './TimeSeekerContext';
-import {
-  applyMetricSeriesColorOverrides,
-  getMetricColor,
-  getMetricColorName,
-} from './getMetricColor';
 import { dateTime, FieldType, LoadingState } from '@grafana/data';
 
 const createMockData = () => ({
@@ -106,71 +101,6 @@ describe('TimeSeekerContext', () => {
       expect(() => render(<TestConsumer />)).toThrow('useTimeSeeker must be used within a TimeSeekerProvider');
 
       consoleError.mockRestore();
-    });
-  });
-
-  describe('getMetricColor', () => {
-    const mockTheme = {
-      visualization: {
-        getColorByName: (name: string) => `color-${name}`,
-      },
-    } as any;
-
-    it('returns semi-dark-blue for duration metric', () => {
-      expect(getMetricColor(mockTheme, 'duration')).toBe('color-semi-dark-blue');
-    });
-
-    it('returns semi-dark-red for errors metric', () => {
-      expect(getMetricColor(mockTheme, 'errors')).toBe('color-semi-dark-red');
-    });
-
-    it('returns blue for rate metric', () => {
-      expect(getMetricColor(mockTheme, 'rate')).toBe('color-blue');
-    });
-
-    it('returns blue for undefined metric', () => {
-      expect(getMetricColor(mockTheme, undefined)).toBe('color-blue');
-    });
-  });
-
-  describe('getMetricColorName', () => {
-    it('returns palette names for each metric', () => {
-      expect(getMetricColorName('duration')).toBe('semi-dark-blue');
-      expect(getMetricColorName('errors')).toBe('semi-dark-red');
-      expect(getMetricColorName('rate')).toBe('blue');
-      expect(getMetricColorName(undefined)).toBe('blue');
-    });
-  });
-
-  describe('applyMetricSeriesColorOverrides', () => {
-    it('applies the metric color for rate', () => {
-      const calls: Array<{ regex: string; color: string }> = [];
-      const overrides = {
-        matchFieldsWithNameByRegex: (regex: string) => ({
-          overrideColor: ({ fixedColor }: { fixedColor: string }) => {
-            calls.push({ regex, color: fixedColor });
-          },
-        }),
-      };
-
-      applyMetricSeriesColorOverrides(overrides, 'rate');
-
-      expect(calls).toEqual([{ regex: '.*', color: 'blue' }]);
-    });
-
-    it('applies the metric color for errors', () => {
-      const calls: Array<{ regex: string; color: string }> = [];
-      const overrides = {
-        matchFieldsWithNameByRegex: (regex: string) => ({
-          overrideColor: ({ fixedColor }: { fixedColor: string }) => {
-            calls.push({ regex, color: fixedColor });
-          },
-        }),
-      };
-
-      applyMetricSeriesColorOverrides(overrides, 'errors');
-
-      expect(calls).toEqual([{ regex: '.*', color: 'semi-dark-red' }]);
     });
   });
 

--- a/src/components/Explore/seeker/TimeSeekerContext.test.tsx
+++ b/src/components/Explore/seeker/TimeSeekerContext.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import { TimeSeekerProvider, useTimeSeeker } from './TimeSeekerContext';
-import { getMetricColor, getMetricColorName } from './getMetricColor';
+import {
+  applyMetricSeriesColorOverrides,
+  getMetricColor,
+  getMetricColorName,
+} from './getMetricColor';
 import { dateTime, FieldType, LoadingState } from '@grafana/data';
 
 const createMockData = () => ({
@@ -135,6 +139,38 @@ describe('TimeSeekerContext', () => {
       expect(getMetricColorName('errors')).toBe('semi-dark-red');
       expect(getMetricColorName('rate')).toBe('blue');
       expect(getMetricColorName(undefined)).toBe('blue');
+    });
+  });
+
+  describe('applyMetricSeriesColorOverrides', () => {
+    it('applies the metric color for rate', () => {
+      const calls: Array<{ regex: string; color: string }> = [];
+      const overrides = {
+        matchFieldsWithNameByRegex: (regex: string) => ({
+          overrideColor: ({ fixedColor }: { fixedColor: string }) => {
+            calls.push({ regex, color: fixedColor });
+          },
+        }),
+      };
+
+      applyMetricSeriesColorOverrides(overrides, 'rate');
+
+      expect(calls).toEqual([{ regex: '.*', color: 'blue' }]);
+    });
+
+    it('applies the metric color for errors', () => {
+      const calls: Array<{ regex: string; color: string }> = [];
+      const overrides = {
+        matchFieldsWithNameByRegex: (regex: string) => ({
+          overrideColor: ({ fixedColor }: { fixedColor: string }) => {
+            calls.push({ regex, color: fixedColor });
+          },
+        }),
+      };
+
+      applyMetricSeriesColorOverrides(overrides, 'errors');
+
+      expect(calls).toEqual([{ regex: '.*', color: 'semi-dark-red' }]);
     });
   });
 

--- a/src/components/Explore/seeker/getMetricColor.test.ts
+++ b/src/components/Explore/seeker/getMetricColor.test.ts
@@ -1,0 +1,60 @@
+import { GrafanaTheme2 } from '@grafana/data';
+
+import {
+  applyMetricSeriesColorOverrides,
+  getMetricColor,
+  getMetricColorName,
+} from './getMetricColor';
+
+describe('getMetricColorName', () => {
+  it('maps metrics to palette names (rate is blue, not green)', () => {
+    expect(getMetricColorName('duration')).toBe('semi-dark-blue');
+    expect(getMetricColorName('errors')).toBe('semi-dark-red');
+    expect(getMetricColorName('rate')).toBe('blue');
+    expect(getMetricColorName(undefined)).toBe('blue');
+  });
+
+  it('never returns green for rate or duration', () => {
+    expect(getMetricColorName('rate')).not.toMatch(/green/);
+    expect(getMetricColorName('duration')).not.toMatch(/green/);
+    expect(getMetricColorName('errors')).not.toMatch(/green/);
+  });
+});
+
+describe('getMetricColor', () => {
+  const mockTheme = {
+    visualization: {
+      getColorByName: (name: string) => `color-${name}`,
+    },
+  } as GrafanaTheme2;
+
+  it('resolves palette names through the theme', () => {
+    expect(getMetricColor(mockTheme, 'duration')).toBe('color-semi-dark-blue');
+    expect(getMetricColor(mockTheme, 'errors')).toBe('color-semi-dark-red');
+    expect(getMetricColor(mockTheme, 'rate')).toBe('color-blue');
+    expect(getMetricColor(mockTheme, undefined)).toBe('color-blue');
+  });
+});
+
+describe('applyMetricSeriesColorOverrides', () => {
+  function collectOverrides(metric: Parameters<typeof applyMetricSeriesColorOverrides>[1]) {
+    const calls: Array<{ regex: string; color: string; mode: string }> = [];
+    const overrides = {
+      matchFieldsWithNameByRegex: (regex: string) => ({
+        overrideColor: ({ mode, fixedColor }: { mode: string; fixedColor: string }) => {
+          calls.push({ regex, color: fixedColor, mode });
+        },
+      }),
+    };
+    applyMetricSeriesColorOverrides(overrides, metric);
+    return calls;
+  }
+
+  it.each([
+    ['rate', 'blue'],
+    ['errors', 'semi-dark-red'],
+    ['duration', 'semi-dark-blue'],
+  ] as const)('applies a single fixed %s color to all fields', (metric, color) => {
+    expect(collectOverrides(metric)).toEqual([{ regex: '.*', color, mode: 'fixed' }]);
+  });
+});

--- a/src/components/Explore/seeker/getMetricColor.ts
+++ b/src/components/Explore/seeker/getMetricColor.ts
@@ -1,14 +1,22 @@
 import { GrafanaTheme2 } from '@grafana/data';
 import { MetricFunction } from 'utils/shared';
 
-export function getMetricColor(theme: GrafanaTheme2, metric?: MetricFunction): string {
+/**
+ * Grafana visualization palette name for a metric series.
+ * Rate is neutral throughput (all spans), so use blue — green is reserved for an
+ * explicit success signal. Duration stays in the neutral family as semi-dark-blue
+ * so it remains distinguishable from rate.
+ */
+export function getMetricColorName(metric?: MetricFunction): string {
   if (metric === 'duration') {
-    // Semi-dark-blue keeps duration in the neutral family but visually distinct from rate (blue).
-    return theme.visualization.getColorByName('semi-dark-blue');
-  } else if (metric === 'errors') {
-    return theme.visualization.getColorByName('semi-dark-red');
+    return 'semi-dark-blue';
   }
-  // Rate is neutral throughput (all spans, regardless of status), so use a neutral
-  // color. Green is reserved for an explicit success signal.
-  return theme.visualization.getColorByName('blue');
+  if (metric === 'errors') {
+    return 'semi-dark-red';
+  }
+  return 'blue';
+}
+
+export function getMetricColor(theme: GrafanaTheme2, metric?: MetricFunction): string {
+  return theme.visualization.getColorByName(getMetricColorName(metric));
 }

--- a/src/components/Explore/seeker/getMetricColor.ts
+++ b/src/components/Explore/seeker/getMetricColor.ts
@@ -3,9 +3,9 @@ import { MetricFunction } from 'utils/shared';
 
 /**
  * Grafana visualization palette name for a metric series.
- * Rate is neutral throughput (all spans), so use blue — green is reserved for an
- * explicit success signal. Duration stays in the neutral family as semi-dark-blue
- * so it remains distinguishable from rate.
+ * Rate is neutral throughput (all statuses) → blue. Duration → semi-dark-blue.
+ * Errors → semi-dark-red. Green is reserved for an explicit success signal — do not
+ * use it for rate/throughput.
  */
 export function getMetricColorName(metric?: MetricFunction): string {
   if (metric === 'duration') {
@@ -19,4 +19,18 @@ export function getMetricColorName(metric?: MetricFunction): string {
 
 export function getMetricColor(theme: GrafanaTheme2, metric?: MetricFunction): string {
   return theme.visualization.getColorByName(getMetricColorName(metric));
+}
+
+type ColorOverrides = {
+  matchFieldsWithNameByRegex: (regex: string) => {
+    overrideColor: (color: { mode: 'fixed'; fixedColor: string }) => unknown;
+  };
+};
+
+/** Fixed color for the selected metric. */
+export function applyMetricSeriesColorOverrides(overrides: ColorOverrides, metric: MetricFunction) {
+  overrides.matchFieldsWithNameByRegex('.*').overrideColor({
+    mode: 'fixed',
+    fixedColor: getMetricColorName(metric),
+  });
 }


### PR DESCRIPTION
### ✨ Description

Follow up to https://github.com/grafana/traces-drilldown/pull/814

- Centralise rate / errors / duration colors in getMetricColor
- Skip fixed colors in Breakdown Single layout (multi-series palette)
- Drop redundant error .setColor on RED / MiniRED
- Update docs for blue baseline and Rate breakdown
- Add unit tests for color helpers and panel overrides