### PR TITLE
fix(deps): resolve pnpm audit vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,9 +27,10 @@ overrides:
   js-yaml: 4.3.0
   '@opentelemetry/core': 2.8.0
   qs: ^6.15.2
-  brace-expansion@^5: '>=5.0.8'
+  brace-expansion@^1: '>=1.1.18 <2'
+  brace-expansion@^5: '>=5.0.9'
   fast-uri: '>=4.1.1'
-  postcss: ^8.5.18
+  postcss: '>=8.5.23'
 
 importers:
 
@@ -2589,11 +2590,11 @@ packages:
   body@5.1.0:
     resolution: {integrity: sha512-chUsBxGRtuElD6fmw1gHLpvnKdVLK302peeFa9ZqAEk8TyzZ3fygLyUEDDPTJvL9+Bor0dIwn6ePOsRM2y0zQQ==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -3530,7 +3531,7 @@ packages:
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: ^8.5.18
+      postcss: '>=8.5.23'
 
   identity-obj-proxy@3.0.0:
     resolution: {integrity: sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==}
@@ -4450,25 +4451,25 @@ packages:
     resolution: {integrity: sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: ^8.5.18
+      postcss: '>=8.5.23'
 
   postcss-modules-local-by-default@4.2.0:
     resolution: {integrity: sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: ^8.5.18
+      postcss: '>=8.5.23'
 
   postcss-modules-scope@3.2.1:
     resolution: {integrity: sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: ^8.5.18
+      postcss: '>=8.5.23'
 
   postcss-modules-values@4.0.0:
     resolution: {integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: ^8.5.18
+      postcss: '>=8.5.23'
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -4477,8 +4478,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.22:
-    resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prefix-style@2.0.1:
@@ -8479,12 +8480,12 @@ snapshots:
       raw-body: 1.1.7
       safe-json-parse: 1.0.1
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8677,12 +8678,12 @@ snapshots:
 
   css-loader@7.1.4(webpack@5.104.1):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.22)
-      postcss: 8.5.22
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.22)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.22)
-      postcss-modules-scope: 3.2.1(postcss@8.5.22)
-      postcss-modules-values: 4.0.0(postcss@8.5.22)
+      icss-utils: 5.1.0(postcss@8.5.25)
+      postcss: 8.5.25
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.25)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.25)
+      postcss-modules-scope: 3.2.1(postcss@8.5.25)
+      postcss-modules-values: 4.0.0(postcss@8.5.25)
       postcss-value-parser: 4.2.0
       semver: 7.8.2
     optionalDependencies:
@@ -9561,9 +9562,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  icss-utils@5.1.0(postcss@8.5.22):
+  icss-utils@5.1.0(postcss@8.5.25):
     dependencies:
-      postcss: 8.5.22
+      postcss: 8.5.25
 
   identity-obj-proxy@3.0.0:
     dependencies:
@@ -10382,11 +10383,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 
@@ -10668,26 +10669,26 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.5.22):
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.25):
     dependencies:
-      postcss: 8.5.22
+      postcss: 8.5.25
 
-  postcss-modules-local-by-default@4.2.0(postcss@8.5.22):
+  postcss-modules-local-by-default@4.2.0(postcss@8.5.25):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.22)
-      postcss: 8.5.22
+      icss-utils: 5.1.0(postcss@8.5.25)
+      postcss: 8.5.25
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.1(postcss@8.5.22):
+  postcss-modules-scope@3.2.1(postcss@8.5.25):
     dependencies:
-      postcss: 8.5.22
+      postcss: 8.5.25
       postcss-selector-parser: 7.1.1
 
-  postcss-modules-values@4.0.0(postcss@8.5.22):
+  postcss-modules-values@4.0.0(postcss@8.5.25):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.22)
-      postcss: 8.5.22
+      icss-utils: 5.1.0(postcss@8.5.25)
+      postcss: 8.5.25
 
   postcss-selector-parser@7.1.1:
     dependencies:
@@ -10696,7 +10697,7 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.22:
+  postcss@8.5.25:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,6 +43,7 @@ overrides:
   js-yaml: 4.3.0
   '@opentelemetry/core': 2.8.0
   qs: ^6.15.2
-  brace-expansion@^5: '>=5.0.8'
+  brace-expansion@^1: '>=1.1.18 <2'
+  brace-expansion@^5: '>=5.0.9'
   fast-uri: '>=4.1.1'
-  postcss: ^8.5.18
+  postcss: '>=8.5.23'


### PR DESCRIPTION
## Summary

Bumps `pnpm-workspace.yaml` overrides to remediate `pnpm audit` findings. Audit went from **8 findings (4 high / 4 moderate)** to **4 findings (1 high / 3 moderate)**; every remaining item has no installable patch (details below).

| Package | Before | After | Advisory |
| --- | --- | --- | --- |
| `brace-expansion@^5` | `>=5.0.8` | `>=5.0.9` | GHSA-rgw5-rvv9-x895 |
| `brace-expansion@^1` | *(absent)* | `>=1.1.18 <2` | GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895 |
| `postcss` | `^8.5.18` | `>=8.5.23` | GHSA-fxqj-rqcc-2cmp |

Notes on the two non-obvious choices:

- **`brace-expansion@^1` needs the `<2` upper bound.** A 1.x copy really is in the tree: `minimatch@3.1.5` declares `brace-expansion: ^1.1.7`. Because pnpm matches the `@^1` selector against that *declared* range, an unbounded `>=1.1.18` happily resolved to **5.0.8** and left the advisory unfixed. The `<2` bound pins it to the 1.x line. Per-major keys are kept separate deliberately — v5 changed the CJS export shape, so collapsing majors would break `minimatch` 3 vs 10.
- **`postcss` was edited in place, not added.** An existing `postcss: ^8.5.18` override was already present, so adding a second `postcss:` key would have created a duplicate YAML key where the last one silently wins.

`fast-uri` keeps a single bare key (no version-scoped split): only a 4.x line exists in this tree, so there is no 3.x branch needing its own key.

## Known remaining

All 4 remaining findings are unfixable today; no override was forced to reach zero.

- **`fast-uri` (high, GHSA-7p8r-x3mc-p8w7)** — the patch `4.1.2` is the newest 4.x and the only version outside the vulnerable range (`>=4.0.0 <4.1.2`), but it was published 2026-07-31 and is rejected by this repo's `minimumReleaseAge: 7200` (5 days): `ERR_PNPM_NO_MATURE_MATCHING_VERSION`. Left at `>=4.1.1` rather than disabling the supply-chain policy or inventing a `minimumReleaseAgeExclude` entry (no such precedent exists in this file). **Re-runnable from ~2026-08-05**, when 4.1.2 ages past the cutoff.
- **`react-router` (moderate x2, GHSA-wrjc-x8rr-h8h6 / GHSA-337j-9hxr-rhxg)** and **`react-router-dom` (moderate, GHSA-jjmj-jmhj-qwj2)** — left at 6.30.4.
  - `react-router-dom-v5-compat@6.30.4` is in the tree (via `@grafana/ui@13.1.0`) and its `dist/index.js` imports `UNSAFE_useRoutesImpl` and `UNSAFE_useRouteId` directly from `react-router`, calling them at lines 605 and 1056. Loading `react-router@7.18.0` shows both are `undefined` (as is `UNSAFE_logV6DeprecationWarnings`), so bumping to the patched `>=7.18.0` breaks v5-compat at runtime.
  - Worth noting the usual "React 18 blocks v7" reasoning does *not* apply here: `react-router@7.18.0` peers are `react: >=18`, which this repo (React 18.3.1) satisfies. The blocker is purely the removed `UNSAFE_*` exports. (`react-router@8.x` peers `react: >=19.2.7` and is separately unusable.)
  - `react-router-dom`'s patch `6.30.5` was **never published** — 6.x dead-ends at the flagged 6.30.4.

Two advisories mentioned in the original remediation plan (`GHSA-v2hh-gcrm-f6hx` for fast-uri, `GHSA-r28c-9q8g-f849` for postcss) do not fire in this tree.

## Test plan

- [x] `pnpm install --no-frozen-lockfile` succeeds with all supply-chain policies (`minimumReleaseAge`, `trustPolicy: no-downgrade`, `blockExoticSubdeps`, `strictDepBuilds`) left enabled
- [x] `pnpm audit` — 8 findings (4 high / 4 moderate) to 4 (1 high / 3 moderate)
- [x] `pnpm run typecheck` (`tsc --noEmit`) passes
- [x] `pnpm run build` (production webpack) passes; only a pre-existing asset-size warning
- [x] Verified overrides are not inert by listing `node_modules/.pnpm/` and re-checking the lockfile: `brace-expansion` resolves to exactly `1.1.18` + `5.0.9` (no 5.0.8 references remain), `postcss` to a single `8.5.25`
- [x] Verified the major split preserves export shapes: `minimatch@3.1.5` still loads as a callable function, `minimatch@10.2.5` as a namespace, both matching correctly

Only `pnpm-workspace.yaml` and `pnpm-lock.yaml` are touched; no audit suppressions were added.

### Note for reviewers: `postcss` major bound

Main's override was `postcss: ^8.5.18`, bounded to 8.x; this PR uses `postcss: '>=8.5.23'`, which is unbounded upward. That matches the advisory's patched range and resolves cleanly today (single `8.5.25`; no mature 9.x on npm). Flagging it because an unbounded `>=` selector is structurally the same footgun that made the `brace-expansion@^1` key resolve to 5.0.8 — it can drift across majors once a new major publishes. Happy to switch to `'>=8.5.23 <9'` to preserve main's 8.x ceiling if preferred.
