### PR TITLE
fix(deps): resolve pnpm audit vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ overrides:
   react-router: ^6.30.2
   serialize-javascript: ^7.0.5
   immutable: ^5.1.8
-  dompurify: ^3.4.12
+  dompurify: ^3.4.13
   yaml: ^2.8.3
   minimatch@^3: ~3.1.4
   minimatch@^9: ~10.2.0
@@ -22,13 +22,14 @@ overrides:
   uuid: ^14.0.0
   js-cookie: ^3.0.7
   ws: 8.21.0
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
   '@opentelemetry/core': 2.8.0
   qs: ^6.15.2
   brace-expansion@^1: 1.1.18
   brace-expansion@^5: '>=5.0.9'
   fast-uri: '>=4.1.2'
   postcss: ^8.5.23
+  nanoid@^3: '>=3.3.17 <4'
 
 importers:
 
@@ -2946,8 +2947,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   downshift@9.3.6:
     resolution: {integrity: sha512-xEKP1vbt/k7Siu481TKibmj8EyL6iyBwaRJgb6gCsFyLeiyZ1KEJnApS9R1U71hTdK5ym0R99AOYRROcTz1PeQ==}
@@ -3960,8 +3961,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdoc-type-pratt-parser@7.1.1:
@@ -4205,8 +4206,8 @@ packages:
       react: '*'
       react-dom: '*'
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6240,7 +6241,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -6332,7 +6333,7 @@ snapshots:
       d3-interpolate: 3.0.1
       d3-scale-chromatic: 3.1.0
       date-fns: 4.1.0
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       eventemitter3: 5.0.1
       history: 4.10.1
       lodash: 4.18.1
@@ -6761,7 +6762,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -8650,7 +8651,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.8.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -8803,7 +8804,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       csstype: 3.2.3
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -10184,7 +10185,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -10416,7 +10417,7 @@ snapshots:
       stacktrace-js: 2.0.2
       stylis: 4.4.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -10697,7 +10698,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,7 +31,7 @@ overrides:
   react-router: ^6.30.2
   serialize-javascript: ^7.0.5
   immutable: ^5.1.8
-  dompurify: ^3.4.12
+  dompurify: ^3.4.13
   yaml: ^2.8.3
   minimatch@^3: ~3.1.4
   minimatch@^9: ~10.2.0
@@ -39,10 +39,11 @@ overrides:
   uuid: ^14.0.0
   js-cookie: ^3.0.7
   ws: 8.21.0
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
   '@opentelemetry/core': 2.8.0
   qs: ^6.15.2
   brace-expansion@^1: 1.1.18
   brace-expansion@^5: '>=5.0.9'
   fast-uri: '>=4.1.2'
   postcss: ^8.5.23
+  nanoid@^3: '>=3.3.17 <4'


### PR DESCRIPTION
## Summary

Bumps transitive dependency overrides in `pnpm-workspace.yaml` to clear `pnpm audit` findings.

`pnpm audit`: **6 findings (4 moderate, 2 high) → 3 findings (3 moderate, 0 high)**. Both high-severity findings are resolved.

### Fixed

| Package | Before | After | Advisory | Severity |
| --- | --- | --- | --- | --- |
| `dompurify` | `^3.4.12` | `^3.4.13` | GHSA-55q2-fjhq-7xh7 | moderate |
| `js-yaml` | `4.3.0` | `4.3.1` | GHSA-5p4m-2wfm-xmqj | high |
| `nanoid@^3` | (none) | `>=3.3.17 <4` | GHSA-2v37-7h3g-55p8 | high |

### Note on the `nanoid` override scope

The `nanoid` override is deliberately scoped to the 3.x line rather than left unbounded.
`postcss` declares `nanoid: ^3.3.16` and loads it via `require('nanoid/non-secure')`, but
`nanoid` 6.x is ESM-only (`"type": "module"`, no CJS entry). An unbounded `>=3.3.17`
resolves to `nanoid@6.0.1` and breaks that `require`. The bounded selector keeps the
patched `3.3.17` (which ships `non-secure/index.cjs`) in place.

## Known remaining

These have **no installable patch** and are intentionally left as-is. No audit
suppressions were added.

- **`react-router`** — GHSA-wrjc-x8rr-h8h6, GHSA-337j-9hxr-rhxg (moderate). Patched
  at `>=7.18.0`, but this repo is deliberately held on the 6.x line. `@grafana/ui`
  depends on `react-router-dom-v5-compat`, which imports `UNSAFE_useRoutesImpl`,
  `UNSAFE_useRouteId` and `UNSAFE_logV6DeprecationWarnings` from `react-router`.
  None of the three are exported by `react-router` 7.18.2 (verified against the
  published tarball), so forcing the override to 7 would break `@grafana/ui` at
  runtime. Requires an upstream `@grafana/ui` migration off `v5-compat`.
- **`react-router-dom`** — GHSA-jjmj-jmhj-qwj2 (moderate). Advisory lists the fix as
  `>=6.30.5`, but that version was never published: the 6.x line ends at `6.30.4`,
  which is itself flagged. There is no 6.x patch to move to.

## Related PRs

- Supersedes #837 (stale draft from a previous run; it conflicts with `main` and would revert `fast-uri` to an older range).
- Overlaps #845, which fixes GHSA-5p4m-2wfm-xmqj by bumping `js-yaml` directly. Either path closes that advisory.
- #822 and #823 (`react-router` v8 / `react-router-dom` v7) should not be merged while `@grafana/ui` depends on `react-router-dom-v5-compat` — see "Known remaining" above.

## Test plan

- [x] `pnpm install` succeeds with no supply-chain policy changes
- [x] `pnpm audit` — 0 high, 0 critical; 3 moderate remaining, all documented above
- [x] `pnpm run typecheck` passes
- [x] `pnpm run build` passes
- [x] Verified `postcss` resolves `nanoid` to `3.3.17` and `require('nanoid/non-secure')` works
