### PR TITLE
fix: ignore attribute changes that are not human

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,7 +1,9 @@
 import { expect, test } from '@grafana/plugin-e2e';
 import { ExplorePage } from './fixtures/explore';
-import { getTestIdFromMetric, testIds } from '../src/utils/testIds';
+import { getTestIdFromAttribute, getTestIdFromMetric, testIds } from '../src/utils/testIds';
 import type { Page } from '@playwright/test';
+import { Components } from '@grafana/e2e-selectors';
+import { AttributeItem } from '../src/types';
 
 test.describe('navigating app', () => {
   let explorePage: ExplorePage;
@@ -36,17 +38,29 @@ test.describe('ensure back button works for main actions', () => {
   });
 
   test('clicking on errors panel, browser back and browser forward should work as expected', async ({ page }) => {
-    await assertBackAndForwardNavigationWorks(page, 'rate', 'errors');
+    await assertBackAndForwardNavigationWorksForMetrics(page, 'rate', 'errors');
   });
 
   test('clicking on duration panel, browser back and browser forward should work as expected', async ({ page }) => {
-    await assertBackAndForwardNavigationWorks(page, 'rate', 'duration');
+    await assertBackAndForwardNavigationWorksForMetrics(page, 'rate', 'duration');
+  });
+
+  test('clicking on an include button, browser back and browser forward should work as expected', async ({ page }) => {
+    await assertBackAndForwardNavigationWorksForFilters(page, 'include');
+  });
+
+  test('clicking on an exclude button, browser back and browser forward should work as expected', async ({ page }) => {
+    await assertBackAndForwardNavigationWorksForFilters(page, 'exclude');
   });
 });
 
 type MetricType = 'rate' | 'errors' | 'duration';
 
-async function assertBackAndForwardNavigationWorks(page: Page, startMetric: MetricType, switchToMetric: MetricType) {
+async function assertBackAndForwardNavigationWorksForMetrics(
+  page: Page,
+  startMetric: MetricType,
+  switchToMetric: MetricType
+) {
   const explorePage = new ExplorePage(page);
   await explorePage.assertNotLoading();
 
@@ -98,4 +112,90 @@ async function assertUnCheckedForREDPanelRadio(page: Page, metric: MetricType) {
 
 async function clickOnREDPanelRadio(page: Page, metric: MetricType) {
   await page.getByTestId(getTestIdFromMetric(metric)).getByRole('radio').first().click();
+}
+
+async function assertBackAndForwardNavigationWorksForFilters(page: Page, toBeClicked: 'include' | 'exclude') {
+  const explorePage = new ExplorePage(page);
+  const serviceNameAttribute: AttributeItem = {
+    label: 'service.name',
+    scope: 'Resource',
+    value: 'resource.service.name',
+  };
+  const spanNameAttribute: AttributeItem = { label: 'name', scope: 'Span', value: 'name' };
+  const serviceNameTestId = getTestIdFromAttribute(serviceNameAttribute);
+  const spanNameTestId = getTestIdFromAttribute(spanNameAttribute);
+
+  await expect(page.getByRole('button', { name: toBeClicked }).first()).toBeVisible();
+
+  await assertAdHocFilterEmpty(page, serviceNameAttribute);
+  await assertSelectedLabel(page, 'resource.service.name');
+  await assertSelectedAttributes(page, serviceNameTestId, spanNameTestId);
+  await explorePage.assertNotLoading();
+  const initialPanelTexts = await getPanelTexts(page);
+  expect(initialPanelTexts.length).toBeGreaterThan(0);
+
+  await page.getByRole('button', { name: toBeClicked }).first().click();
+  await explorePage.assertNotLoading();
+
+  await assertAdHocFilterPopulated(page, serviceNameAttribute);
+  await assertSelectedLabel(page, 'name');
+  await assertSelectedAttributes(page, spanNameTestId, serviceNameTestId);
+  const afterClickPanelTexts = await getPanelTexts(page);
+  expect(afterClickPanelTexts.length).toBeGreaterThan(0);
+
+  await page.goBack();
+  await explorePage.assertNotLoading();
+
+  await assertAdHocFilterEmpty(page, serviceNameAttribute);
+  await assertSelectedLabel(page, 'resource.service.name');
+  await assertSelectedAttributes(page, serviceNameTestId, spanNameTestId);
+  await assertPanelTexts(page, initialPanelTexts);
+
+  await page.goForward();
+  await explorePage.assertNotLoading();
+
+  await assertAdHocFilterPopulated(page, serviceNameAttribute);
+  await assertSelectedLabel(page, 'name');
+  await assertSelectedAttributes(page, spanNameTestId, serviceNameTestId);
+  await assertPanelTexts(page, afterClickPanelTexts);
+}
+
+function getFilterNameFromAttribute(attribute: AttributeItem): string {
+  return `Edit filter with key ${attribute.value}`;
+}
+
+async function assertAdHocFilterEmpty(page: Page, attribute: AttributeItem) {
+  const name = getFilterNameFromAttribute(attribute);
+
+  await expect(page.getByRole('button', { name })).not.toBeVisible();
+  await expect(page.getByRole('button', { name })).toHaveCount(0);
+}
+
+async function assertAdHocFilterPopulated(page: Page, attribute: AttributeItem) {
+  const name = getFilterNameFromAttribute(attribute);
+
+  await expect(page.getByRole('button', { name })).toBeVisible();
+  await expect(page.getByRole('button', { name })).toHaveCount(1);
+}
+
+async function assertSelectedLabel(page: Page, label: string) {
+  await expect(page.getByText(`Selected: ${label}`)).toBeVisible();
+}
+
+async function assertSelectedAttributes(page: Page, selectedId: string, notSelectedId: string) {
+  await expect(page.getByTestId(selectedId)).toBeVisible();
+  await expect(page.getByTestId(selectedId)).toHaveAttribute('data-selected', 'true');
+  await expect(page.getByTestId(notSelectedId)).toBeVisible();
+  await expect(page.getByTestId(notSelectedId)).toHaveAttribute('data-selected', 'false');
+}
+
+async function getPanelTexts(page: Page): Promise<string[]> {
+  const panels = page.getByTestId(Components.Panels.Panel.headerContainer);
+  // make sure at least one panel is visible
+  await expect(panels.first()).toBeVisible();
+  return panels.allTextContents();
+}
+
+async function assertPanelTexts(page: Page, expectedPanelTexts: string[]) {
+  await expect.poll(() => getPanelTexts(page)).toEqual(expectedPanelTexts);
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "webpack -w -c ./webpack.config.ts --env development",
     "e2e": "playwright test -x --trace on --ui",
     "e2e:fast": "playwright test --retries=2 --workers=3 -x --trace on",
+    "e2e:fast:10x": "playwright test --retries=2 --workers=3 -x --trace on --repeat-each=10",
     "e2e:debug": "playwright test --debug -x --trace on /e2e",
     "e2e:codegen": "playwright codegen",
     "knip": "knip",

--- a/src/components/Explore/AttributesSidebar.test.tsx
+++ b/src/components/Explore/AttributesSidebar.test.tsx
@@ -225,6 +225,21 @@ describe('AttributesSidebar', () => {
 
       expect(mockOnAttributeChange).toHaveBeenCalledWith(undefined);
     });
+
+    it('should auto-advance to next attribute with ignore=true when selected attribute becomes filtered', () => {
+      mockFiltersVariable.useState = createMockUseState([{ key: 'resource.cluster', operator: '=', value: 'foo' }]);
+
+      render(
+        <AttributesSidebar
+          options={sampleOptions}
+          selected="resource.cluster"
+          onAttributeChange={mockOnAttributeChange}
+          model={mockModel}
+        />
+      );
+
+      expect(mockOnAttributeChange).toHaveBeenCalledWith('span.db.system', true);
+    });
   });
 
   describe('Multi Selection Mode', () => {

--- a/src/components/Explore/AttributesSidebar.tsx
+++ b/src/components/Explore/AttributesSidebar.tsx
@@ -8,8 +8,8 @@ import { MIN_PANEL_HEIGHT, RESOURCE_ATTR, SPAN_ATTR, ignoredAttributes } from 'u
 import { getFiltersVariable } from 'utils/utils';
 import { SceneObject } from '@grafana/scenes';
 import { useFavoriteAttributes } from 'hooks';
-
-type ScopeType = 'All' | 'Resource' | 'Span' | 'Favorites';
+import { AttributeItem, ScopeType } from '../../types';
+import { getTestIdFromAttribute } from 'utils/testIds';
 
 interface BaseAttributesSidebarProps {
   /** Array of available attribute options */
@@ -27,7 +27,7 @@ interface SingleAttributesSidebarProps extends BaseAttributesSidebarProps {
   /** Currently selected attribute value(s) - string for single mode, string[] for multi mode */
   selected?: string;
   /** Callback when attribute selection changes - receives string | undefined for single mode, string[] for multi mode */
-  onAttributeChange: (attribute: string | undefined) => void;
+  onAttributeChange: (attribute: string | undefined, ignore?: boolean) => void;
 
   isMulti?: false;
 }
@@ -36,15 +36,9 @@ interface MultiAttributesSidebarProps extends BaseAttributesSidebarProps {
   /** Currently selected attribute value(s) - string for single mode, string[] for multi mode */
   selected?: string[];
   /** Callback when attribute selection changes - receives string | undefined for single mode, string[] for multi mode */
-  onAttributeChange: (attribute: string[] | undefined) => void;
+  onAttributeChange: (attribute: string[] | undefined, ignore?: boolean) => void;
 
   isMulti: true;
-}
-
-interface AttributeItem {
-  label: string;
-  value: string;
-  scope: ScopeType;
 }
 
 export function AttributesSidebar({
@@ -182,7 +176,7 @@ export function AttributesSidebar({
       const nextIndex = currentIndex + 1;
 
       if (nextIndex < filteredAttributes.length) {
-        onAttributeChange(filteredAttributes[nextIndex].value);
+        onAttributeChange(filteredAttributes[nextIndex].value, true);
         return;
       }
     }
@@ -428,6 +422,8 @@ export function AttributesSidebar({
                   onDragOver={(e) => handleDragOver(e, index)}
                   onDragLeave={handleItemDragLeave}
                   onDrop={() => handleDrop(index)}
+                  data-testid={getTestIdFromAttribute(attribute)}
+                  data-selected={isSelected}
                 >
                   {isMulti && (
                     <Checkbox

--- a/src/components/Explore/TracesByService/Tabs/Breakdown/AttributesBreakdownScene.test.ts
+++ b/src/components/Explore/TracesByService/Tabs/Breakdown/AttributesBreakdownScene.test.ts
@@ -1,0 +1,53 @@
+import { CustomVariable } from '@grafana/scenes';
+import { AttributesBreakdownScene } from './AttributesBreakdownScene';
+import { getGroupByVariable } from 'utils/utils';
+import { reportAppInteraction } from 'utils/analytics';
+
+jest.mock('utils/utils', () => ({
+  getGroupByVariable: jest.fn(),
+  getAttributesAsOptions: jest.fn(),
+  getPercentilesVariable: jest.fn(),
+  getPrimarySignalVariable: jest.fn(),
+  getTraceByServiceScene: jest.fn(),
+  getTraceExplorationScene: jest.fn(),
+}));
+
+jest.mock('utils/analytics', () => ({
+  ...jest.requireActual('utils/analytics'),
+  reportAppInteraction: jest.fn(),
+}));
+
+describe('AttributesBreakdownScene', () => {
+  let mockVariable: { getValueText: jest.Mock; changeValueTo: jest.Mock };
+  let scene: AttributesBreakdownScene;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockVariable = {
+      getValueText: jest.fn(() => ''),
+      changeValueTo: jest.fn(),
+    };
+    jest.mocked(getGroupByVariable).mockReturnValue(mockVariable as unknown as CustomVariable);
+
+    scene = new AttributesBreakdownScene({});
+  });
+
+  describe('onChange', () => {
+    it('should replace state and skip analytics when ignore is true', () => {
+      scene.onChange('span.http.method', true);
+
+      expect(mockVariable.changeValueTo).toHaveBeenCalledWith('span.http.method', undefined, false);
+      expect(reportAppInteraction).not.toHaveBeenCalled();
+    });
+
+    it('should push state and report analytics when ignore is omitted', () => {
+      scene.onChange('span.http.method');
+
+      expect(mockVariable.changeValueTo).toHaveBeenCalledWith('span.http.method', undefined, true);
+      expect(reportAppInteraction).toHaveBeenCalledWith('analyse_traces', 'breakdown_group_by_changed', {
+        groupBy: 'span.http.method',
+      });
+    });
+  });
+});

--- a/src/components/Explore/TracesByService/Tabs/Breakdown/AttributesBreakdownScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Breakdown/AttributesBreakdownScene.tsx
@@ -213,7 +213,7 @@ export class AttributesBreakdownScene extends SceneObjectBase<AttributesBreakdow
             <AttributesSidebar
               options={getAttributesAsOptions(attributes ?? [])}
               selected={groupBy}
-              onAttributeChange={(attribute) => model.onChange(attribute ?? '')}
+              onAttributeChange={(attribute, ignore) => model.onChange(attribute ?? '', ignore)}
               model={model}
               showFavorites={true}
             />

--- a/src/components/Explore/TracesByService/Tabs/Comparison/AttributesComparisonScene.test.ts
+++ b/src/components/Explore/TracesByService/Tabs/Comparison/AttributesComparisonScene.test.ts
@@ -1,4 +1,5 @@
 import { DataFrame, FieldType } from '@grafana/data';
+import { CustomVariable } from '@grafana/scenes';
 
 import {
   AttributesComparisonScene,
@@ -6,6 +7,21 @@ import {
   normalizeTraceQlLabelString,
   sumNumberFieldValues,
 } from './AttributesComparisonScene';
+import { getGroupByVariable } from 'utils/utils';
+import { reportAppInteraction } from 'utils/analytics';
+
+jest.mock('utils/utils', () => ({
+  getGroupByVariable: jest.fn(),
+  getAttributesAsOptions: jest.fn(),
+  getPrimarySignalVariable: jest.fn(),
+  getTraceByServiceScene: jest.fn(),
+  getTraceExplorationScene: jest.fn(),
+}));
+
+jest.mock('utils/analytics', () => ({
+  ...jest.requireActual('utils/analytics'),
+  reportAppInteraction: jest.fn(),
+}));
 
 describe('hasSelectionValues', () => {
   it('returns true when Selection field has at least one value > 0', () => {
@@ -170,6 +186,39 @@ describe('AttributesComparisonScene', () => {
       (Storage.prototype.getItem as jest.Mock).mockReturnValue('true');
       new AttributesComparisonScene({});
       expect(Storage.prototype.getItem).toHaveBeenCalledWith('grafana.drilldown.traces.hideBaselineOnly');
+    });
+  });
+
+  describe('onChange', () => {
+    let mockVariable: { getValueText: jest.Mock; changeValueTo: jest.Mock };
+    let scene: AttributesComparisonScene;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      mockVariable = {
+        getValueText: jest.fn(() => ''),
+        changeValueTo: jest.fn(),
+      };
+      jest.mocked(getGroupByVariable).mockReturnValue(mockVariable as unknown as CustomVariable);
+
+      scene = new AttributesComparisonScene({});
+    });
+
+    it('should replace state and skip analytics when ignore is true', () => {
+      scene.onChange('span.http.method', true);
+
+      expect(mockVariable.changeValueTo).toHaveBeenCalledWith('span.http.method', undefined, false);
+      expect(reportAppInteraction).not.toHaveBeenCalled();
+    });
+
+    it('should push state and report analytics when ignore is omitted', () => {
+      scene.onChange('span.http.method');
+
+      expect(mockVariable.changeValueTo).toHaveBeenCalledWith('span.http.method', undefined, true);
+      expect(reportAppInteraction).toHaveBeenCalledWith('analyse_traces', 'select_attribute_in_comparison_clicked', {
+        value: 'span.http.method',
+      });
     });
   });
 });

--- a/src/components/Explore/TracesByService/Tabs/Comparison/AttributesComparisonScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Comparison/AttributesComparisonScene.tsx
@@ -17,14 +17,21 @@ import {
 import { t } from '@grafana/i18n';
 import { Checkbox, getTheme, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 
-import { VAR_FILTERS, VAR_PRIMARY_SIGNAL, explorationDS, VAR_FILTERS_EXPR, ALL, MIN_PANEL_HEIGHT } from '../../../../../utils/shared';
+import {
+  VAR_FILTERS,
+  VAR_PRIMARY_SIGNAL,
+  explorationDS,
+  VAR_FILTERS_EXPR,
+  ALL,
+  MIN_PANEL_HEIGHT,
+} from '../../../../../utils/shared';
 
 import { LayoutSwitcher } from '../../../LayoutSwitcher';
 import { AddToFiltersAction } from '../../../actions/AddToFiltersAction';
 import { map, Observable } from 'rxjs';
 import { BaselineColor, buildAllComparisonLayout, SelectionColor } from '../../../layouts/allComparison';
 import { getMetricColorName } from '../../../seeker/getMetricColor';
-// eslint-disable-next-line no-restricted-imports
+
 import { comparisonQuery } from '../../../queries/comparisonQuery';
 import { buildAttributeComparison } from '../../../layouts/attributeComparison';
 import {
@@ -204,11 +211,13 @@ export class AttributesComparisonScene extends SceneObjectBase<AttributesCompari
     const variable = getGroupByVariable(this);
     variable.changeValueTo(value, undefined, !ignore);
 
-    reportAppInteraction(
-      USER_EVENTS_PAGES.analyse_traces,
-      USER_EVENTS_ACTIONS.analyse_traces.select_attribute_in_comparison_clicked,
-      { value }
-    );
+    if (!ignore) {
+      reportAppInteraction(
+        USER_EVENTS_PAGES.analyse_traces,
+        USER_EVENTS_ACTIONS.analyse_traces.select_attribute_in_comparison_clicked,
+        { value }
+      );
+    }
   };
 
   public static Component = ({ model }: SceneComponentProps<AttributesComparisonScene>) => {
@@ -264,7 +273,7 @@ export class AttributesComparisonScene extends SceneObjectBase<AttributesCompari
             <AttributesSidebar
               options={getAttributesAsOptions(attributes ?? [])}
               selected={variable.getValueText()}
-              onAttributeChange={(attribute) => model.onChange(attribute ?? '')}
+              onAttributeChange={(attribute, ignore) => model.onChange(attribute ?? '', ignore)}
               model={model}
               showFavorites={true}
               allowAllOption={true}

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,10 +67,19 @@ export type SearchResponse = {
   traces: TraceSearchMetadata[];
   metrics: SearchMetrics;
 };
+
 export interface TempoDatasource {
   traceQuery?: {
     timeShiftEnabled?: boolean;
     spanStartTimeShift?: string;
     spanEndTimeShift?: string;
   };
+}
+
+export type ScopeType = 'All' | 'Resource' | 'Span' | 'Favorites';
+
+export interface AttributeItem {
+  label: string;
+  value: string;
+  scope: ScopeType;
 }

--- a/src/utils/testIds.test.ts
+++ b/src/utils/testIds.test.ts
@@ -1,0 +1,46 @@
+import { VariableValue } from '@grafana/scenes';
+import { getTestIdFromAttribute, getTestIdFromMetric, testIds } from './testIds';
+import { AttributeItem } from '../types';
+
+describe('getTestIdFromMetric', () => {
+  it('should return correct testid for rate metric', () => {
+    const metric: VariableValue = 'rate';
+    expect(getTestIdFromMetric(metric)).toEqual(testIds.ratePanel);
+  });
+
+  it('should return correct testid for errors metric', () => {
+    const metric: VariableValue = 'errors';
+    expect(getTestIdFromMetric(metric)).toEqual(testIds.errorsPanel);
+  });
+
+  it('should return correct testid for duration metric', () => {
+    const metric: VariableValue = 'duration';
+    expect(getTestIdFromMetric(metric)).toEqual(testIds.durationPanel);
+  });
+
+  it('should return correct testid for unknown metric', () => {
+    const metric: VariableValue = 'log';
+    expect(getTestIdFromMetric(metric)).toEqual('data-testid unknown-panel');
+  });
+
+  it('should return correct testid for no metric', () => {
+    expect(getTestIdFromMetric('')).toEqual('data-testid unknown-panel');
+  });
+});
+
+describe('getTestIdFromAttribute', () => {
+  it('should return correct testid for attribute', () => {
+    const attribute: AttributeItem = { label: 'name', scope: 'Span', value: 'name' };
+    expect(getTestIdFromAttribute(attribute)).toEqual('data-testid name-attribute-item');
+  });
+
+  it('should return correct testid for attribute without value', () => {
+    const attribute: AttributeItem = { label: 'name', scope: 'Span', value: '' };
+    expect(getTestIdFromAttribute(attribute)).toEqual('data-testid unknown-attribute-item');
+  });
+
+  it('should return correct testid for undefined attribute', () => {
+    const attribute = undefined as unknown as AttributeItem;
+    expect(getTestIdFromAttribute(attribute)).toEqual('data-testid unknown-attribute-item');
+  });
+});

--- a/src/utils/testIds.ts
+++ b/src/utils/testIds.ts
@@ -1,4 +1,5 @@
 import { VariableValue } from '@grafana/scenes';
+import { AttributeItem } from '../types';
 
 export const testIds = {
   emptyState: 'data-testid empty-state',
@@ -21,4 +22,11 @@ export function getTestIdFromMetric(metric: VariableValue | string): string {
   }
 
   return 'data-testid unknown-panel';
+}
+
+export function getTestIdFromAttribute(attribute: AttributeItem): string {
+  if (!attribute?.value) {
+    return 'data-testid unknown-attribute-item';
+  }
+  return `data-testid ${attribute.value}-attribute-item`;
 }


### PR DESCRIPTION
**What is this feature?**

Fixes so clicking include/exclude no longer pollutes the browser history. When that attribute gets added to the filters, `AttributesSidebar` auto-advances the selection to the next attribute in a `useEffect`. That auto-advance went through the same `onAttributeChange` path as a real user click, so it pushed its own history entry on top of the filter-click entry, breaking back/forward for include and exclude. This affects both the Breakdown and Comparison tabs, since both render `AttributesSidebar`.

The auto-advance now passes `ignore`, same pattern as #849:

```ts
if (nextIndex < filteredAttributes.length) {
  onAttributeChange(filteredAttributes[nextIndex].value, true);
  return;
}
```

`onChange` uses `ignore` to skip the `reportAppInteraction` call and use `replaceState` instead of `pushState`, so only the actual filter click lands in history.

Also adds `data-testid`/`data-selected` to sidebar attribute items (via a new `getTestIdFromAttribute` helper), unit tests pinning the `ignore` mechanism on both scenes, include/exclude back-button e2e tests in `e2e/navigation.spec.ts`, and an `e2e:fast:10x` command so you can run the new e2e tests 10 times to check for flakiness.

**Why do we need this feature?**

So the back button behaves correctly when a user includes or excludes an attribute in the filter.

**Which issue(s) does this PR fix?**:

For https://github.com/grafana/traces-drilldown/issues/800

**Special notes for your reviewer:**

This is another step on #800 (following #849), so it intentionally does not close the issue. Tab switching and time range still need their own fixes.
