### PR TITLE
feat: Add TraceView resource attribute links

### DIFF
--- a/src/module.tsx
+++ b/src/module.tsx
@@ -6,6 +6,7 @@ import { lt } from 'semver';
 import { EmbeddedTraceExplorationState, OpenInExploreTracesButtonProps } from 'exposedComponents/types';
 import { SuspendedEmbeddedTraceExploration, SuspendedOpenInExploreTracesButton } from 'exposedComponents';
 import { linkConfigs } from 'utils/links';
+import { makeTraceResourceAttributeLink, TRACE_RESOURCE_ATTRIBUTE_LINKS } from 'utils/resourceAttributes';
 import { JsonData } from './components/AppConfig/AppConfig';
 import pluginJson from './plugin.json';
 
@@ -46,4 +47,8 @@ export const plugin = new AppPlugin<JsonData>()
 
 for (const linkConfig of linkConfigs) {
   plugin.addLink(linkConfig);
+}
+
+for (const config of TRACE_RESOURCE_ATTRIBUTE_LINKS) {
+  plugin.addLink(makeTraceResourceAttributeLink(config));
 }

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -106,6 +106,11 @@
         "targets": ["grafana-assistant-app/navigateToDrilldown/v1"],
         "title": "Grafana assistant link",
         "description": "Create a link to the Traces Drilldown app"
+      },
+      {
+        "targets": ["grafana/traceview/resource-attributes"],
+        "title": "Traces Drilldown",
+        "description": "Traces Drilldown"
       }
     ],
     "extensionPoints": [

--- a/src/utils/resourceAttributes.test.ts
+++ b/src/utils/resourceAttributes.test.ts
@@ -1,0 +1,137 @@
+import { type AbsoluteTimeRange, type PluginExtensionResourceAttributesContext } from '@grafana/data';
+
+import pluginJson from '../plugin.json';
+import {
+  makeTraceResourceAttributeLink,
+  RESOURCE_ATTRIBUTE_LINK_ICON,
+  RESOURCE_ATTRIBUTE_LINK_LABEL,
+  TRACE_RESOURCE_ATTRIBUTE_LINKS,
+} from './resourceAttributes';
+
+const timeRange: AbsoluteTimeRange = { from: 1000, to: 2000 };
+
+const context: PluginExtensionResourceAttributesContext = {
+  datasource: { uid: 'tempo', type: 'tempo' },
+  attributes: {
+    'service.name': ['cart'],
+    'service.version': ['1.2.3'],
+    'k8s.container.name': ['cart'],
+    'k8s.deployment.name': ['cart-deploy'],
+  },
+  timeRange,
+};
+
+function linkFor(attributeName: string) {
+  const config = TRACE_RESOURCE_ATTRIBUTE_LINKS.find((c) => c.attributeName === attributeName);
+  if (!config) {
+    throw new Error(`Missing TRACE_RESOURCE_ATTRIBUTE_LINKS entry for ${attributeName}`);
+  }
+  return makeTraceResourceAttributeLink(config);
+}
+
+function configure(attributeName: string, overrides?: Partial<PluginExtensionResourceAttributesContext>) {
+  return linkFor(attributeName).configure?.({ ...context, ...overrides });
+}
+
+function drilldownUrl(path: string) {
+  return new URL(path, 'https://example.com');
+}
+
+describe('TRACE_RESOURCE_ATTRIBUTE_LINKS', () => {
+  it('registers a unique TraceView category per attribute', () => {
+    const categories = TRACE_RESOURCE_ATTRIBUTE_LINKS.map((c) => c.attributeName);
+    expect(new Set(categories).size).toBe(categories.length);
+  });
+
+  it('declares matching title and description in plugin.json', () => {
+    expect(pluginJson.extensions?.addedLinks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          targets: ['grafana/traceview/resource-attributes'],
+          title: RESOURCE_ATTRIBUTE_LINK_LABEL,
+          description: RESOURCE_ATTRIBUTE_LINK_LABEL,
+        }),
+      ])
+    );
+  });
+});
+
+describe('makeTraceResourceAttributeLink', () => {
+  it('registers TraceView metadata', () => {
+    const link = linkFor('service.name');
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- TraceView matches rows via category
+    expect(link.category).toBe('service.name');
+    expect(link.targets).toEqual(['grafana/traceview/resource-attributes']);
+    expect(link.title).toBe(RESOURCE_ATTRIBUTE_LINK_LABEL);
+    expect(link.description).toBe(RESOURCE_ATTRIBUTE_LINK_LABEL);
+    expect(link.icon).toBe(RESOURCE_ATTRIBUTE_LINK_ICON);
+  });
+
+  it('filters to the row attribute by default', () => {
+    const result = configure('service.name');
+    const url = drilldownUrl(result!.path!);
+
+    expect(result).toMatchObject({
+      title: RESOURCE_ATTRIBUTE_LINK_LABEL,
+      description: RESOURCE_ATTRIBUTE_LINK_LABEL,
+      icon: RESOURCE_ATTRIBUTE_LINK_ICON,
+    });
+    expect(url.pathname).toBe('/a/grafana-exploretraces-app/explore');
+    expect(url.searchParams.get('var-ds')).toBe('tempo');
+    expect(url.searchParams.get('var-primarySignal')).toBe('true');
+    expect(url.searchParams.getAll('var-filters')).toEqual(['resource.service.name|=|cart']);
+    expect(url.searchParams.get('from')).toBe('1000');
+    expect(url.searchParams.get('to')).toBe('2000');
+  });
+
+  it('filters to the service and the row attribute', () => {
+    const url = drilldownUrl(configure('service.version')!.path!);
+
+    expect(url.searchParams.getAll('var-filters')).toEqual([
+      'resource.service.name|=|cart',
+      'resource.service.version|=|1.2.3',
+    ]);
+  });
+
+  it('filters to the parent entity, not the row attribute', () => {
+    const url = drilldownUrl(configure('k8s.container.name')!.path!);
+
+    expect(url.searchParams.getAll('var-filters')).toEqual(['resource.k8s.deployment.name|=|cart-deploy']);
+  });
+
+  it('omits the time range when context has none', () => {
+    const url = drilldownUrl(configure('service.name', { timeRange: undefined })!.path!);
+
+    expect(url.searchParams.has('from')).toBe(false);
+    expect(url.searchParams.has('to')).toBe(false);
+  });
+
+  it('hides when a required attribute is missing', () => {
+    expect(configure('service.name', { attributes: {} })).toBeUndefined();
+  });
+
+  it('hides when a required attribute is blank', () => {
+    expect(configure('service.name', { attributes: { 'service.name': ['  '] } })).toBeUndefined();
+  });
+
+  it('hides when an extra filter attribute is missing', () => {
+    expect(configure('service.version', { attributes: { 'service.version': ['1.2.3'] } })).toBeUndefined();
+  });
+
+  it('hides when the parent entity is missing', () => {
+    expect(configure('k8s.container.name', { attributes: { 'k8s.container.name': ['cart'] } })).toBeUndefined();
+  });
+
+  it('hides when the datasource is not Tempo', () => {
+    expect(configure('service.name', { datasource: { uid: 'loki', type: 'loki' } })).toBeUndefined();
+  });
+
+  it('hides when the datasource uid is missing', () => {
+    expect(configure('service.name', { datasource: { uid: '', type: 'tempo' } })).toBeUndefined();
+  });
+
+  it('hides when context is missing', () => {
+    expect(linkFor('service.name').configure?.(undefined)).toBeUndefined();
+  });
+});

--- a/src/utils/resourceAttributes.test.ts
+++ b/src/utils/resourceAttributes.test.ts
@@ -43,9 +43,10 @@ function drilldownUrl(path: string) {
 
 describe('TRACE_RESOURCE_ATTRIBUTE_LINKS', () => {
   it.each(TRACE_RESOURCE_ATTRIBUTE_LINKS)(
-    'registers a unique TraceView category for $attributeName',
+    'registers a unique group for $attributeName',
     ({ attributeName }) => {
       expect(TRACE_RESOURCE_ATTRIBUTE_LINKS.filter((c) => c.attributeName === attributeName)).toHaveLength(1);
+      expect(linkFor(attributeName).group).toEqual({ name: attributeName });
     }
   );
 
@@ -66,8 +67,7 @@ describe('makeTraceResourceAttributeLink', () => {
   it('registers TraceView metadata', () => {
     const link = linkFor('service.name');
 
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- TraceView matches rows via category
-    expect(link.category).toBe('service.name');
+    expect(link.group).toEqual({ name: 'service.name' });
     expect(link.targets).toEqual(['grafana/traceview/resource-attributes']);
     expect(link.title).toBe(RESOURCE_ATTRIBUTE_LINK_LABEL);
     expect(link.description).toBe(RESOURCE_ATTRIBUTE_LINK_LABEL);

--- a/src/utils/resourceAttributes.test.ts
+++ b/src/utils/resourceAttributes.test.ts
@@ -6,6 +6,7 @@ import {
   RESOURCE_ATTRIBUTE_LINK_ICON,
   RESOURCE_ATTRIBUTE_LINK_LABEL,
   TRACE_RESOURCE_ATTRIBUTE_LINKS,
+  type TraceResourceAttributeName,
 } from './resourceAttributes';
 
 const timeRange: AbsoluteTimeRange = { from: 1000, to: 2000 };
@@ -21,7 +22,7 @@ const context: PluginExtensionResourceAttributesContext = {
   timeRange,
 };
 
-function linkFor(attributeName: string) {
+function linkFor(attributeName: TraceResourceAttributeName) {
   const config = TRACE_RESOURCE_ATTRIBUTE_LINKS.find((c) => c.attributeName === attributeName);
   if (!config) {
     throw new Error(`Missing TRACE_RESOURCE_ATTRIBUTE_LINKS entry for ${attributeName}`);
@@ -29,7 +30,10 @@ function linkFor(attributeName: string) {
   return makeTraceResourceAttributeLink(config);
 }
 
-function configure(attributeName: string, overrides?: Partial<PluginExtensionResourceAttributesContext>) {
+function configure(
+  attributeName: TraceResourceAttributeName,
+  overrides?: Partial<PluginExtensionResourceAttributesContext>
+) {
   return linkFor(attributeName).configure?.({ ...context, ...overrides });
 }
 

--- a/src/utils/resourceAttributes.test.ts
+++ b/src/utils/resourceAttributes.test.ts
@@ -42,10 +42,12 @@ function drilldownUrl(path: string) {
 }
 
 describe('TRACE_RESOURCE_ATTRIBUTE_LINKS', () => {
-  it('registers a unique TraceView category per attribute', () => {
-    const categories = TRACE_RESOURCE_ATTRIBUTE_LINKS.map((c) => c.attributeName);
-    expect(new Set(categories).size).toBe(categories.length);
-  });
+  it.each(TRACE_RESOURCE_ATTRIBUTE_LINKS)(
+    'registers a unique TraceView category for $attributeName',
+    ({ attributeName }) => {
+      expect(TRACE_RESOURCE_ATTRIBUTE_LINKS.filter((c) => c.attributeName === attributeName)).toHaveLength(1);
+    }
+  );
 
   it('declares matching title and description in plugin.json', () => {
     expect(pluginJson.extensions?.addedLinks).toEqual(

--- a/src/utils/resourceAttributes.ts
+++ b/src/utils/resourceAttributes.ts
@@ -1,0 +1,147 @@
+import {
+  type IconName,
+  type PluginExtensionAddedLinkConfig,
+  PluginExtensionPoints,
+  type PluginExtensionResourceAttributesContext,
+} from '@grafana/data';
+
+import { EXPLORATIONS_ROUTE, RESOURCE_ATTR, VAR_DATASOURCE, VAR_FILTERS, VAR_PRIMARY_SIGNAL } from './shared';
+
+export type TraceResourceAttributeLinkConfig = {
+  /** TraceView row key (`link.category === attribute.key`). Always required. */
+  attributeName: string;
+  /**
+   * Resource attributes applied as TraceQL filters.
+   * Defaults to `[attributeName]`. Omit the row key when a secondary attribute
+   * should open a parent entity (e.g. container.name → k8s.deployment.name).
+   */
+  filters?: string[];
+};
+
+const HOST_OS_PROCESS_TELEMETRY_ATTRIBUTES = [
+  'host.arch',
+  'os.type',
+  'os.description',
+  'os.name',
+  'os.version',
+  'os.build_id',
+  'process.pid',
+  'process.parent_pid',
+  'process.executable.name',
+  'process.executable.path',
+  'process.command',
+  'process.command_line',
+  'process.command_args',
+  'process.owner',
+  'process.runtime.name',
+  'process.runtime.version',
+  'process.runtime.description',
+  'process.working_directory',
+  'telemetry.sdk.name',
+  'telemetry.sdk.language',
+  'telemetry.sdk.version',
+  'telemetry.distro.name',
+  'telemetry.distro.version',
+] as const;
+
+/** withService — filter service.name plus this attribute */
+const withService = (attributeName: string): TraceResourceAttributeLinkConfig => ({
+  attributeName,
+  filters: ['service.name', attributeName],
+});
+
+/** asEntity — show the link on this row, filter the parent entity */
+const asEntity = (attributeName: string, entity: string): TraceResourceAttributeLinkConfig => ({
+  attributeName,
+  filters: [entity],
+});
+
+/** TRACE_RESOURCE_ATTRIBUTE_LINKS — rows with no helper filter only that attribute */
+export const TRACE_RESOURCE_ATTRIBUTE_LINKS: TraceResourceAttributeLinkConfig[] = [
+  { attributeName: 'service.name' },
+  { attributeName: 'service.namespace' },
+  withService('service.version'),
+  withService('service.instance.id'),
+  withService('deployment.environment'),
+  withService('deployment.environment.name'),
+  withService('k8s.namespace.name'),
+  { attributeName: 'k8s.pod.name' },
+  { attributeName: 'k8s.deployment.name' },
+  { attributeName: 'k8s.node.name' },
+  asEntity('k8s.container.name', 'k8s.deployment.name'),
+  asEntity('container.name', 'k8s.deployment.name'),
+  asEntity('container.id', 'k8s.pod.name'),
+  asEntity('k8s.pod.uid', 'k8s.pod.name'),
+  asEntity('k8s.pod.ip', 'k8s.pod.name'),
+  asEntity('k8s.pod.start_time', 'k8s.pod.name'),
+  ...HOST_OS_PROCESS_TELEMETRY_ATTRIBUTES.map((attributeName) => ({ attributeName })),
+];
+
+/** Visible label in TraceView (menu uses description, then title). */
+export const RESOURCE_ATTRIBUTE_LINK_LABEL = 'Traces Drilldown';
+export const RESOURCE_ATTRIBUTE_LINK_ICON: IconName = 'gf-traces';
+
+const linkCopy = {
+  title: RESOURCE_ATTRIBUTE_LINK_LABEL,
+  description: RESOURCE_ATTRIBUTE_LINK_LABEL,
+  icon: RESOURCE_ATTRIBUTE_LINK_ICON,
+};
+
+function attrValue(attributes: Record<string, string[]> | undefined, name: string): string | undefined {
+  return attributes?.[name]?.[0]?.trim() || undefined;
+}
+
+/** filterNames — TraceQL filter keys; defaults to the row attribute */
+function filterNames(config: TraceResourceAttributeLinkConfig): string[] {
+  return config.filters ?? [config.attributeName];
+}
+
+/** makeTraceResourceAttributeLink — TraceView link (`category === attribute.key`) that opens Traces Drilldown */
+export function makeTraceResourceAttributeLink(
+  config: TraceResourceAttributeLinkConfig
+): PluginExtensionAddedLinkConfig<PluginExtensionResourceAttributesContext> {
+  const filters = filterNames(config);
+  const required = [...new Set([config.attributeName, ...filters])];
+
+  return {
+    targets: [PluginExtensionPoints.TraceViewResourceAttributes],
+    ...linkCopy,
+    // TraceView matches the link to an attribute row via category === attribute.key
+    category: config.attributeName,
+    path: EXPLORATIONS_ROUTE,
+    configure: (context) => {
+      const values: Record<string, string> = {};
+
+      for (const name of required) {
+        const value = attrValue(context?.attributes, name);
+        if (!value) {
+          return undefined;
+        }
+        values[name] = value;
+      }
+
+      const datasourceUid = context?.datasource?.uid;
+      if (!datasourceUid || context?.datasource?.type !== 'tempo') {
+        return undefined;
+      }
+
+      const params = new URLSearchParams();
+      params.set(`var-${VAR_DATASOURCE}`, datasourceUid);
+      params.set(`var-${VAR_PRIMARY_SIGNAL}`, 'true');
+
+      for (const name of filters) {
+        params.append(`var-${VAR_FILTERS}`, `${RESOURCE_ATTR}${name}|=|${values[name]}`);
+      }
+
+      if (context.timeRange) {
+        params.set('from', String(context.timeRange.from));
+        params.set('to', String(context.timeRange.to));
+      }
+
+      return {
+        ...linkCopy,
+        path: `${EXPLORATIONS_ROUTE}?${params.toString()}`,
+      };
+    },
+  };
+}

--- a/src/utils/resourceAttributes.ts
+++ b/src/utils/resourceAttributes.ts
@@ -7,17 +7,6 @@ import {
 
 import { EXPLORATIONS_ROUTE, RESOURCE_ATTR, VAR_DATASOURCE, VAR_FILTERS, VAR_PRIMARY_SIGNAL } from './shared';
 
-export type TraceResourceAttributeLinkConfig = {
-  /** TraceView row key (`link.category === attribute.key`). Always required. */
-  attributeName: string;
-  /**
-   * Resource attributes applied as TraceQL filters.
-   * Defaults to `[attributeName]`. Omit the row key when a secondary attribute
-   * should open a parent entity (e.g. container.name → k8s.deployment.name).
-   */
-  filters?: string[];
-};
-
 const HOST_OS_PROCESS_TELEMETRY_ATTRIBUTES = [
   'host.arch',
   'os.type',
@@ -45,19 +34,19 @@ const HOST_OS_PROCESS_TELEMETRY_ATTRIBUTES = [
 ] as const;
 
 /** withService — filter service.name plus this attribute */
-const withService = (attributeName: string): TraceResourceAttributeLinkConfig => ({
+const withService = <T extends string>(attributeName: T) => ({
   attributeName,
-  filters: ['service.name', attributeName],
+  filters: ['service.name', attributeName] as const,
 });
 
 /** asEntity — show the link on this row, filter the parent entity */
-const asEntity = (attributeName: string, entity: string): TraceResourceAttributeLinkConfig => ({
+const asEntity = <T extends string, E extends string>(attributeName: T, entity: E) => ({
   attributeName,
-  filters: [entity],
+  filters: [entity] as const,
 });
 
 /** TRACE_RESOURCE_ATTRIBUTE_LINKS — rows with no helper filter only that attribute */
-export const TRACE_RESOURCE_ATTRIBUTE_LINKS: TraceResourceAttributeLinkConfig[] = [
+export const TRACE_RESOURCE_ATTRIBUTE_LINKS = [
   { attributeName: 'service.name' },
   { attributeName: 'service.namespace' },
   withService('service.version'),
@@ -75,7 +64,11 @@ export const TRACE_RESOURCE_ATTRIBUTE_LINKS: TraceResourceAttributeLinkConfig[] 
   asEntity('k8s.pod.ip', 'k8s.pod.name'),
   asEntity('k8s.pod.start_time', 'k8s.pod.name'),
   ...HOST_OS_PROCESS_TELEMETRY_ATTRIBUTES.map((attributeName) => ({ attributeName })),
-];
+] as const;
+
+/** Closed set of OTel resource attribute keys we register as TraceView rows. */
+export type TraceResourceAttributeName = (typeof TRACE_RESOURCE_ATTRIBUTE_LINKS)[number]['attributeName'];
+export type TraceResourceAttributeLinkConfig = (typeof TRACE_RESOURCE_ATTRIBUTE_LINKS)[number];
 
 /** Visible label in TraceView (menu uses description, then title). */
 export const RESOURCE_ATTRIBUTE_LINK_LABEL = 'Traces Drilldown';
@@ -87,13 +80,16 @@ const linkCopy = {
   icon: RESOURCE_ATTRIBUTE_LINK_ICON,
 };
 
-function attrValue(attributes: Record<string, string[]> | undefined, name: string): string | undefined {
+function attrValue(
+  attributes: Record<string, string[]> | undefined,
+  name: TraceResourceAttributeName
+): string | undefined {
   return attributes?.[name]?.[0]?.trim() || undefined;
 }
 
 /** filterNames — TraceQL filter keys; defaults to the row attribute */
-function filterNames(config: TraceResourceAttributeLinkConfig): string[] {
-  return config.filters ?? [config.attributeName];
+function filterNames(config: TraceResourceAttributeLinkConfig): TraceResourceAttributeName[] {
+  return [...('filters' in config ? config.filters : [config.attributeName])];
 }
 
 /** makeTraceResourceAttributeLink — TraceView link (`category === attribute.key`) that opens Traces Drilldown */

--- a/src/utils/resourceAttributes.ts
+++ b/src/utils/resourceAttributes.ts
@@ -87,9 +87,12 @@ function attrValue(
   return attributes?.[name]?.[0]?.trim() || undefined;
 }
 
-/** filterNames — TraceQL filter keys; defaults to the row attribute */
+/** filterNames — TraceQL filter keys; defaults to the row attribute when omitted or empty */
 function filterNames(config: TraceResourceAttributeLinkConfig): TraceResourceAttributeName[] {
-  return [...('filters' in config ? config.filters : [config.attributeName])];
+  if ('filters' in config && config.filters.length > 0) {
+    return [...config.filters];
+  }
+  return [config.attributeName];
 }
 
 /** makeTraceResourceAttributeLink — TraceView link (`category === attribute.key`) that opens Traces Drilldown */
@@ -102,8 +105,9 @@ export function makeTraceResourceAttributeLink(
   return {
     targets: [PluginExtensionPoints.TraceViewResourceAttributes],
     ...linkCopy,
-    // TraceView matches the link to an attribute row via category === attribute.key
+    // TraceView matches a row via category === key today or group.name
     category: config.attributeName,
+    group: { name: config.attributeName },
     path: EXPLORATIONS_ROUTE,
     configure: (context) => {
       const values: Record<string, string> = {};


### PR DESCRIPTION
### ✨ Description

Part of https://github.com/grafana/grafana/issues/129072

Similar to https://github.com/grafana/asserts-app-plugin/pull/3682

Adds TraceView links on resource attributes (grafana/traceview/resource-attributes) that open Traces Drilldown with matching filters. 