### PR TITLE
fix(deps): resolve pnpm audit vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ overrides:
   brace-expansion@^5: '>=5.0.9'
   fast-uri: '>=4.1.2'
   postcss: ^8.5.23
-  nanoid@^3: '>=3.3.17 <4'
+  nanoid@^3: '>=3.3.18 <4'
 
 importers:
 
@@ -4206,8 +4206,8 @@ packages:
       react: '*'
       react-dom: '*'
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -10417,7 +10417,7 @@ snapshots:
       stacktrace-js: 2.0.2
       stylis: 4.4.0
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -10698,7 +10698,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,4 +46,4 @@ overrides:
   brace-expansion@^5: '>=5.0.9'
   fast-uri: '>=4.1.2'
   postcss: ^8.5.23
-  nanoid@^3: '>=3.3.17 <4'
+  nanoid@^3: '>=3.3.18 <4'


### PR DESCRIPTION
## Summary
Updates pnpm overrides in `pnpm-workspace.yaml` to resolve `pnpm audit` findings.

- **nanoid** `>=3.3.17 <4` → `>=3.3.18 <4` — resolves [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (custom generators can loop indefinitely when size is zero). Verified installable; nanoid resolves to `3.3.18` in the tree (transitive via `postcss`).

## Test plan
- [x] `pnpm install --no-frozen-lockfile` succeeds under existing supply-chain policies (no protections disabled)
- [x] `pnpm audit` — nanoid advisory resolved; only known-remaining react-router advisories persist (see below)

## Known remaining
The following advisories have **no installable patch** for this repo's current major line and are intentionally left unchanged (no audit suppressions added):

- **react-router** — [GHSA-wrjc-x8rr-h8h6](https://github.com/advisories/GHSA-wrjc-x8rr-h8h6) & [GHSA-337j-9hxr-rhxg](https://github.com/advisories/GHSA-337j-9hxr-rhxg). Only patch is `>=7.18.0`, a major version bump. This repo is on react-router-dom **v6** (`^6.30.2`), and react-router 7.x is incompatible with the v6 API used by `@grafana/*` dependents.
- **react-router-dom** — [GHSA-jjmj-jmhj-qwj2](https://github.com/advisories/GHSA-jjmj-jmhj-qwj2). Patch claims `>=6.30.5`, but **6.30.5 was never published** — the 6.x line dead-ends at 6.30.4. No installable 6.x fix exists.

Resolving these requires a coordinated migration to react-router 7.x across the `@grafana/*` stack and is out of scope for this CVE remediation.