### PR TITLE
fix(create-github-app-token): version bump to 0.3.1

### DIFF
--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -18,7 +18,7 @@ jobs:
           persist-credentials: false
       - name: Get GitHub App token
         id: get-github-app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3 (2026-05-05)
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1 (2026-08-19)
         with:
           github_app: grafana-pr-automation
       - name: 'Get vault secrets'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for i18n Crowdin downloads to use a newer version of the `create-github-app-token` action. This change ensures the workflow benefits from the latest features and fixes provided in version `v0.3.1`.

Workflow dependency update:

* [`.github/workflows/i18n-crowdin-download.yml`](diffhunk://#diff-f8820ea7fc9b9bf225a13dad6b8c5f70a56b159657571468310b0b416843c867L21-R21): Updated the `create-github-app-token` action from version `v0.2.3` to `v0.3.1` for improved reliability and potential new features.
