### PR TITLE
fix: preserve tab browser history

### DIFF
--- a/e2e/models/TracesExplore.ts
+++ b/e2e/models/TracesExplore.ts
@@ -1,10 +1,12 @@
-import { Page, expect } from '@playwright/test';
+import { Locator, Page, expect } from '@playwright/test';
 import { GrafanaPage, NavigateOptions, PluginTestCtx } from '@grafana/plugin-e2e';
 
 import pluginJson from '../../src/plugin.json';
 import { getTestIdFromMetric, testIds } from '../../src/utils/testIds';
 import { MetricFunction } from '../../src/utils/shared';
 import { AttributeItem } from '../../src/types';
+
+export type RateTabs = 'Service structure' | 'Comparison' | 'Traces' | 'Breakdown';
 
 export class TracesExplorePage extends GrafanaPage {
   constructor(readonly ctx: PluginTestCtx) {
@@ -94,5 +96,19 @@ export class TracesExplorePage extends GrafanaPage {
     await expect(this.page.getByTestId(selectedId)).toHaveAttribute('data-selected', 'true');
     await expect(this.page.getByTestId(notSelectedId)).toBeVisible();
     await expect(this.page.getByTestId(notSelectedId)).toHaveAttribute('data-selected', 'false');
+  }
+
+  getTab(tab: RateTabs): Locator {
+    return this.getByGrafanaSelector(this.ctx.selectors.components.Tab.title(tab));
+  }
+
+  async assertTabSelected(tab: RateTabs) {
+    await expect(this.getTab(tab)).toBeVisible();
+    await expect(this.getTab(tab)).toHaveAttribute('aria-selected', 'true');
+  }
+
+  async assertTabNotSelected(tab: RateTabs) {
+    await expect(this.getTab(tab)).toBeVisible();
+    await expect(this.getTab(tab)).toHaveAttribute('aria-selected', 'false');
   }
 }

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,8 +1,8 @@
 import { AttributeItem } from '../src/types';
 import { MetricFunction } from '../src/utils/shared';
-import { getTestIdFromAttribute } from '../src/utils/testIds';
+import { getTestIdFromAttribute, testIds } from '../src/utils/testIds';
 import { expect, test } from './index';
-import { TracesExplorePage } from './models/TracesExplore';
+import { RateTabs, TracesExplorePage } from './models/TracesExplore';
 
 test.describe('navigating app', () => {
   test('explore page should render successfully', async ({ tracesExplorePage }) => {
@@ -33,6 +33,24 @@ test.describe('ensure back button works for main actions', () => {
     tracesExplorePage,
   }) => {
     await assertBackAndForwardNavigationWorksForFilters(tracesExplorePage, 'exclude');
+  });
+
+  test('clicking on the "Service structure" tab, browser back and browser forward should work as expected', async ({
+    tracesExplorePage,
+  }) => {
+    await assertBackAndForwardNavigationWorksForTabs(tracesExplorePage, 'Service structure');
+  });
+
+  test('clicking on the "Comparison" tab, browser back and browser forward should work as expected', async ({
+    tracesExplorePage,
+  }) => {
+    await assertBackAndForwardNavigationWorksForTabs(tracesExplorePage, 'Comparison');
+  });
+
+  test('clicking on the "Traces" tab, browser back and browser forward should work as expected', async ({
+    tracesExplorePage,
+  }) => {
+    await assertBackAndForwardNavigationWorksForTabs(tracesExplorePage, 'Traces');
   });
 });
 
@@ -114,4 +132,59 @@ async function assertBackAndForwardNavigationWorksForFilters(
   await tracesExplorePage.assertAdHocFilterPopulated(serviceNameAttribute);
   await tracesExplorePage.assertSelectedLabel('name');
   await tracesExplorePage.assertSelectedAttributes(spanNameTestId, serviceNameTestId);
+}
+
+async function assertBackAndForwardNavigationWorksForTabs(tracesExplorePage: TracesExplorePage, tabToClick: RateTabs) {
+  await tracesExplorePage.assertNotLoading();
+
+  await assertBackAndForwardNavigationWorksForTabsInitialState(tracesExplorePage);
+
+  await tracesExplorePage.getTab(tabToClick).click();
+  await tracesExplorePage.assertNotLoading();
+
+  await assertBackAndForwardNavigationWorksForTabsClickedState(tracesExplorePage, tabToClick);
+
+  await tracesExplorePage.page.goBack();
+  await tracesExplorePage.assertNotLoading();
+
+  await assertBackAndForwardNavigationWorksForTabsInitialState(tracesExplorePage);
+
+  await tracesExplorePage.page.goForward();
+  await tracesExplorePage.assertNotLoading();
+
+  await assertBackAndForwardNavigationWorksForTabsClickedState(tracesExplorePage, tabToClick);
+}
+
+async function assertBackAndForwardNavigationWorksForTabsInitialState(tracesExplorePage: TracesExplorePage) {
+  await tracesExplorePage.assertTabSelected('Breakdown');
+  await tracesExplorePage.assertTabNotSelected('Service structure');
+  await tracesExplorePage.assertTabNotSelected('Comparison');
+  await tracesExplorePage.assertTabNotSelected('Traces');
+
+  await expect(tracesExplorePage.page.getByTestId(testIds.breakdownContainer)).toBeVisible();
+  await expect(tracesExplorePage.page.getByTestId(testIds.serviceStructureContainer)).not.toBeVisible();
+  await expect(tracesExplorePage.page.getByTestId(testIds.comparisonContainer)).not.toBeVisible();
+  await expect(tracesExplorePage.page.getByTestId(testIds.tracesContainer)).not.toBeVisible();
+}
+
+async function assertBackAndForwardNavigationWorksForTabsClickedState(
+  tracesExplorePage: TracesExplorePage,
+  tabToClick: RateTabs
+) {
+  await tracesExplorePage.assertTabSelected(tabToClick);
+  await tracesExplorePage.assertTabNotSelected('Breakdown');
+
+  await expect(tracesExplorePage.page.getByTestId(testIds.breakdownContainer)).not.toBeVisible();
+
+  if (tabToClick === 'Service structure') {
+    await expect(tracesExplorePage.page.getByTestId(testIds.serviceStructureContainer)).toBeVisible();
+  }
+
+  if (tabToClick === 'Comparison') {
+    await expect(tracesExplorePage.page.getByTestId(testIds.comparisonContainer)).toBeVisible();
+  }
+
+  if (tabToClick === 'Traces') {
+    await expect(tracesExplorePage.page.getByTestId(testIds.tracesContainer)).toBeVisible();
+  }
 }

--- a/src/components/Explore/LayoutSwitcher.tsx
+++ b/src/components/Explore/LayoutSwitcher.tsx
@@ -22,7 +22,9 @@ export class LayoutSwitcher extends SceneObjectBase<LayoutSwitcherState> {
 
     return (
       <Stack>
-        <Label className={styles.label}><Trans i18nKey="layout-switcher.view-label">View</Trans></Label>
+        <Label className={styles.label}>
+          <Trans i18nKey="layout-switcher.view-label">View</Trans>
+        </Label>
         <RadioButtonGroup options={options} value={active} onChange={model.onLayoutChange} />
       </Stack>
     );

--- a/src/components/Explore/TracesByService/Tabs/Breakdown/AttributesBreakdownScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Breakdown/AttributesBreakdownScene.tsx
@@ -38,6 +38,7 @@ import { AttributesDescription } from './AttributesDescription';
 import { PercentilesSelect } from './PercentilesSelect';
 import { AttributesSidebar } from 'components/Explore/AttributesSidebar';
 import { useFavoriteAttributes } from 'hooks/useFavoriteAttributes';
+import { testIds } from 'utils/testIds';
 
 const CREATE_ALERT_FROM_PANEL_PLUGIN_ID = 'grafana/alerting/create-alert-from-panel/v1';
 
@@ -174,7 +175,7 @@ export class AttributesBreakdownScene extends SceneObjectBase<AttributesBreakdow
     }, [groupBy]);
 
     return (
-      <div className={styles.container}>
+      <div className={styles.container} data-testid={testIds.breakdownContainer}>
         <BreakdownCreateAlertModalBridge payload={createAlertPayload} scene={model} />
         <div className={styles.controls}>
           <AttributesDescription

--- a/src/components/Explore/TracesByService/Tabs/Comparison/AttributesComparisonScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Comparison/AttributesComparisonScene.tsx
@@ -48,6 +48,7 @@ import { formatUnixRangeDurationSeconds } from '../../../../../utils/dates';
 import { AttributesDescription } from '../Breakdown/AttributesDescription';
 import { isEqual } from 'lodash';
 import { AttributesSidebar } from 'components/Explore/AttributesSidebar';
+import { testIds } from 'utils/testIds';
 
 const HIDE_BASELINE_ONLY_LS_KEY = 'grafana.drilldown.traces.hideBaselineOnly';
 
@@ -228,7 +229,7 @@ export class AttributesComparisonScene extends SceneObjectBase<AttributesCompari
     const styles = useStyles2(getStyles);
 
     return (
-      <div className={styles.container}>
+      <div className={styles.container} data-testid={testIds.comparisonContainer}>
         <div className={styles.controls}>
           <AttributesDescription
             description={t(

--- a/src/components/Explore/TracesByService/Tabs/Spans/SpanListScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Spans/SpanListScene.tsx
@@ -33,6 +33,7 @@ import {
 } from '../../../../../utils/shared';
 import { reportAppInteraction, USER_EVENTS_PAGES, USER_EVENTS_ACTIONS } from 'utils/analytics';
 import { AttributesSidebar } from 'components/Explore/AttributesSidebar';
+import { testIds } from 'utils/testIds';
 
 export interface SpanListSceneState extends SceneObjectState {
   panel?: SceneFlexLayout;
@@ -242,7 +243,7 @@ export class SpanListScene extends SceneObjectBase<SpanListSceneState> {
     }
 
     return (
-      <div className={styles.container}>
+      <div className={styles.container} data-testid={testIds.tracesContainer}>
         <div className={styles.header}>
           <div className={styles.description}>
             <Trans i18nKey="span-list-scene.description">View a list of spans for the current set of filters.</Trans>

--- a/src/components/Explore/TracesByService/Tabs/Structure/StructureScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Structure/StructureScene.tsx
@@ -32,6 +32,7 @@ import { EmptyState } from '../../../../states/EmptyState/EmptyState';
 import { css } from '@emotion/css';
 import { getOpenTrace, getTraceExplorationScene } from 'utils/utils';
 import { structureDisplayName } from '../TabsBarScene';
+import { testIds } from 'utils/testIds';
 
 export interface ServicesTabSceneState extends SceneObjectState {
   panel?: SceneFlexLayout;
@@ -255,8 +256,16 @@ export class StructureTabScene extends SceneObjectBase<ServicesTabSceneState> {
       case 'rate':
         description = (
           <>
-            <div><Trans i18nKey="structure-scene.rate-description">Analyse the service structure of the traces that match the current filters.</Trans></div>
-            <div><Trans i18nKey="structure-scene.rate-panel-info">Each panel represents an aggregate view compiled using spans from multiple traces.</Trans></div>
+            <div>
+              <Trans i18nKey="structure-scene.rate-description">
+                Analyse the service structure of the traces that match the current filters.
+              </Trans>
+            </div>
+            <div>
+              <Trans i18nKey="structure-scene.rate-panel-info">
+                Each panel represents an aggregate view compiled using spans from multiple traces.
+              </Trans>
+            </div>
           </>
         );
         emptyMsg = 'server';
@@ -264,8 +273,16 @@ export class StructureTabScene extends SceneObjectBase<ServicesTabSceneState> {
       case 'errors':
         description = (
           <>
-            <div><Trans i18nKey="structure-scene.errors-description">Analyse the errors structure of the traces that match the current filters.</Trans></div>
-            <div><Trans i18nKey="structure-scene.errors-panel-info">Each panel represents an aggregate view compiled using spans from multiple traces.</Trans></div>
+            <div>
+              <Trans i18nKey="structure-scene.errors-description">
+                Analyse the errors structure of the traces that match the current filters.
+              </Trans>
+            </div>
+            <div>
+              <Trans i18nKey="structure-scene.errors-panel-info">
+                Each panel represents an aggregate view compiled using spans from multiple traces.
+              </Trans>
+            </div>
           </>
         );
         emptyMsg = 'error';
@@ -273,8 +290,16 @@ export class StructureTabScene extends SceneObjectBase<ServicesTabSceneState> {
       case 'duration':
         description = (
           <>
-            <div><Trans i18nKey="structure-scene.duration-description">Analyse the structure of slow spans from the traces that match the current filters.</Trans></div>
-            <div><Trans i18nKey="structure-scene.duration-panel-info">Each panel represents an aggregate view compiled using spans from multiple traces.</Trans></div>
+            <div>
+              <Trans i18nKey="structure-scene.duration-description">
+                Analyse the structure of slow spans from the traces that match the current filters.
+              </Trans>
+            </div>
+            <div>
+              <Trans i18nKey="structure-scene.duration-panel-info">
+                Each panel represents an aggregate view compiled using spans from multiple traces.
+              </Trans>
+            </div>
           </>
         );
         emptyMsg = 'slow';
@@ -290,7 +315,10 @@ export class StructureTabScene extends SceneObjectBase<ServicesTabSceneState> {
         </Text>
         <Text textAlignment={'center'} variant="body">
           <div className={styles.longText}>
-            <Trans i18nKey="structure-scene.no-data-message">The structure tab shows {{ emptyMsg }} spans beneath what you are currently investigating. Currently, there are no descendant {{ emptyMsg }} spans beneath the spans you are investigating.</Trans>
+            <Trans i18nKey="structure-scene.no-data-message">
+              The structure tab shows {{ emptyMsg }} spans beneath what you are currently investigating. Currently,
+              there are no descendant {{ emptyMsg }} spans beneath the spans you are investigating.
+            </Trans>
           </div>
         </Text>
         <Stack gap={0.5} alignItems={'center'}>
@@ -320,7 +348,7 @@ export class StructureTabScene extends SceneObjectBase<ServicesTabSceneState> {
     );
 
     return (
-      <Stack direction={'column'} gap={1}>
+      <Stack direction={'column'} gap={1} data-testid={testIds.serviceStructureContainer}>
         <div className={styles.description}>{description}</div>
         {isLoading && (
           <Stack direction={'column'} gap={2}>
@@ -370,9 +398,7 @@ function buildQuery(metric: MetricFunction) {
       break;
   }
 
-  const rootSelectors = `${VAR_FILTERS_EXPR} ${
-    selectionQuery.length ? `&& ${selectionQuery}` : ''
-  }`;
+  const rootSelectors = `${VAR_FILTERS_EXPR} ${selectionQuery.length ? `&& ${selectionQuery}` : ''}`;
 
   // ({${rootSelectors}} &>> { ${metricQuery} }) # finds trees of spans in error or with high duration
   //    || ({${rootSelectors}})                  # finds single spans in error or with high duration

--- a/src/components/Explore/TracesByService/Tabs/TabsBarScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/TabsBarScene.tsx
@@ -155,7 +155,7 @@ export class TabsBarScene extends SceneObjectBase<TabsBarSceneState> {
                 key={index}
                 label={tab.displayName(metric as MetricFunction)}
                 active={actionView === tab.value}
-                onChangeTab={() => metricScene.setActionView(tab.value)}
+                onChangeTab={() => metricScene.onUserSetActionView(tab.value)}
                 counter={
                   tab.value === 'traceList' ? tracesCount : tab.value === 'exceptions' ? exceptionsCount : undefined
                 }

--- a/src/components/Explore/TracesByService/TracesByServiceScene.tsx
+++ b/src/components/Explore/TracesByService/TracesByServiceScene.tsx
@@ -161,14 +161,14 @@ export class TracesByServiceScene extends SceneObjectBase<TraceSceneState> {
     }
   }
 
-    private updateExceptionsScene(metric: MetricFunction) {
+  private updateExceptionsScene(metric: MetricFunction) {
     if (metric === 'errors') {
       if (!this.state.exceptionsScene) {
         const exceptionsScene = new ExceptionsScene({});
         this.setState({
-          exceptionsScene
+          exceptionsScene,
         });
-        
+
         // Activate the scene after it's been set in state to ensure it starts fetching data
         setTimeout(() => {
           exceptionsScene.activate();
@@ -178,7 +178,7 @@ export class TracesByServiceScene extends SceneObjectBase<TraceSceneState> {
       // Remove exceptions scene if metric is not errors
       if (this.state.exceptionsScene) {
         this.setState({
-          exceptionsScene: undefined
+          exceptionsScene: undefined,
         });
       }
     }
@@ -194,7 +194,7 @@ export class TracesByServiceScene extends SceneObjectBase<TraceSceneState> {
     const timeRange = sceneGraph.getTimeRange(this);
     const options = {
       timeRange: timeRange.state.value,
-      filters: []
+      filters: [],
     };
 
     ds.getTagKeys?.(options).then((tagKeys: GetTagResponse | MetricFindValue[]) => {
@@ -244,6 +244,12 @@ export class TracesByServiceScene extends SceneObjectBase<TraceSceneState> {
     });
   }
 
+  public onUserSetActionView(actionView: ActionViewType) {
+    this._urlSync.performBrowserHistoryAction(() => {
+      this.setActionView(actionView);
+    });
+  }
+
   public setActionView(actionView?: ActionViewType) {
     const { body } = this.state;
     const actionViewDef = actionViewsDefinitions.find((v) => v.value === actionView);
@@ -251,28 +257,28 @@ export class TracesByServiceScene extends SceneObjectBase<TraceSceneState> {
     const metric = traceExploration.getMetricVariable().getValue();
     const prefixLen = getActionViewPrefixLen(traceExploration.state.hideRedPanels);
 
-    if (body.state.children.length > prefixLen - 1) {
-      if (actionViewDef) {
-        let scene: SceneObject;
-        if (actionView === 'exceptions' && this.state.exceptionsScene) {
-          // Use the persistent exceptions scene to maintain data subscription
-          scene = new SceneFlexItem({
-            body: this.state.exceptionsScene,
-          });
-        } else {
-          scene = actionViewDef.getScene(metric as MetricFunction);
-        }
-        
-        body.setState({
-          children: [...body.state.children.slice(0, prefixLen), scene],
-        });
-        reportAppInteraction(USER_EVENTS_PAGES.analyse_traces, USER_EVENTS_ACTIONS.analyse_traces.action_view_changed, {
-          oldAction: this.state.actionView,
-          newAction: actionView,
-        });
-        this.setState({ actionView: actionViewDef.value });
-      }
+    if (body.state.children.length <= prefixLen - 1 || !actionViewDef) {
+      return;
     }
+
+    let scene: SceneObject;
+    if (actionView === 'exceptions' && this.state.exceptionsScene) {
+      // Use the persistent exceptions scene to maintain data subscription
+      scene = new SceneFlexItem({
+        body: this.state.exceptionsScene,
+      });
+    } else {
+      scene = actionViewDef.getScene(metric as MetricFunction);
+    }
+
+    body.setState({
+      children: [...body.state.children.slice(0, prefixLen), scene],
+    });
+    reportAppInteraction(USER_EVENTS_PAGES.analyse_traces, USER_EVENTS_ACTIONS.analyse_traces.action_view_changed, {
+      oldAction: this.state.actionView,
+      newAction: actionView,
+    });
+    this.setState({ actionView: actionViewDef.value });
   }
 
   private updateQueryRunner(metric: MetricFunction) {
@@ -320,19 +326,38 @@ const MetricTypeTooltip = () => {
 
   return (
     <Stack direction={'column'} gap={1}>
-      <div className={styles.tooltip.title}><Trans i18nKey="traces-by-service.tooltip.title">RED metrics for traces</Trans></div>
+      <div className={styles.tooltip.title}>
+        <Trans i18nKey="traces-by-service.tooltip.title">RED metrics for traces</Trans>
+      </div>
       <span className={styles.tooltip.subtitle}>
-        <Trans i18nKey="traces-by-service.tooltip.subtitle">Explore rate, errors, and duration (RED) metrics generated from traces by Tempo.</Trans>
+        <Trans i18nKey="traces-by-service.tooltip.subtitle">
+          Explore rate, errors, and duration (RED) metrics generated from traces by Tempo.
+        </Trans>
       </span>
       <div className={styles.tooltip.text}>
         <div>
-          <span className={styles.tooltip.emphasize}><Trans i18nKey="traces-by-service.tooltip.rate-label">Rate</Trans></span> <Trans i18nKey="traces-by-service.tooltip.rate-description">- Spans per second that match your filter, useful to find unusual spikes in activity</Trans>
+          <span className={styles.tooltip.emphasize}>
+            <Trans i18nKey="traces-by-service.tooltip.rate-label">Rate</Trans>
+          </span>{' '}
+          <Trans i18nKey="traces-by-service.tooltip.rate-description">
+            - Spans per second that match your filter, useful to find unusual spikes in activity
+          </Trans>
         </div>
         <div>
-          <span className={styles.tooltip.emphasize}><Trans i18nKey="traces-by-service.tooltip.errors-label">Errors</Trans></span> <Trans i18nKey="traces-by-service.tooltip.errors-description">-Spans that are failing, overall issues in tracing ecosystem</Trans>
+          <span className={styles.tooltip.emphasize}>
+            <Trans i18nKey="traces-by-service.tooltip.errors-label">Errors</Trans>
+          </span>{' '}
+          <Trans i18nKey="traces-by-service.tooltip.errors-description">
+            -Spans that are failing, overall issues in tracing ecosystem
+          </Trans>
         </div>
         <div>
-          <span className={styles.tooltip.emphasize}><Trans i18nKey="traces-by-service.tooltip.duration-label">Duration</Trans></span> <Trans i18nKey="traces-by-service.tooltip.duration-description">- Amount of time those spans take, represented as a heat map (responds time, latency)</Trans>
+          <span className={styles.tooltip.emphasize}>
+            <Trans i18nKey="traces-by-service.tooltip.duration-label">Duration</Trans>
+          </span>{' '}
+          <Trans i18nKey="traces-by-service.tooltip.duration-description">
+            - Amount of time those spans take, represented as a heat map (responds time, latency)
+          </Trans>
         </div>
       </div>
 

--- a/src/utils/testIds.ts
+++ b/src/utils/testIds.ts
@@ -8,6 +8,10 @@ export const testIds = {
   ratePanel: `data-testid rate-panel`,
   errorsPanel: `data-testid errors-panel`,
   durationPanel: `data-testid duration-panel`,
+  breakdownContainer: `data-testid breakdown container`,
+  serviceStructureContainer: `data-testid service structure container`,
+  comparisonContainer: `data-testid comparison container`,
+  tracesContainer: `data-testid traces container`,
 };
 
 export function getTestIdFromMetric(metric: VariableValue | string): string {


### PR DESCRIPTION
**What is this feature?**

Preserves browser history when switching Traces Drilldown tabs and adds Playwright coverage for back and forward navigation.

**Why do we need this feature?**

So switching between `Breakdown`, `Service structure`, `Comparison`, and `Traces` can be navigated with the browser back and forward buttons.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/traces-drilldown/issues/800

**Special notes for your reviewer:**
