### PR TITLE
chore: add cp-update workflow, bump action pins

### DIFF
--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
   actions: read
 
@@ -21,8 +21,8 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 (2026-01-09)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 (2026-07-17)
         with:
           persist-credentials: false
 
-      - uses: grafana/plugin-actions/bundle-size@a66a1c96cdbb176f9cccf10cf23593e250db7cce # bundle-size/v1.1.0 (2025-11-13)
+      - uses: grafana/plugin-actions/bundle-size@31f6f292a4ccc6530594b8939af571898b09cda8 # bundle-size/v1.1.1 (2026-08-11)

--- a/.github/workflows/cp-update.yml
+++ b/.github/workflows/cp-update.yml
@@ -1,0 +1,26 @@
+name: Create Plugin Update
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *' # run once a month on the 1st day
+
+# To use the default github token with the following elevated permissions make sure to check:
+# **Allow GitHub Actions to create and approve pull requests** in https://github.com/ORG_NAME/REPO_NAME/settings/actions.
+# Alternatively create a fine-grained personal access token for your repository with
+# `contents: read and write` and `pull requests: read and write` and pass it to the action.
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: grafana/plugin-actions/create-plugin-update@b82357e85d512c678416146ca4e9f8672bd108da # create-plugin-update/v2.0.2 (2026-03-09)
+        # Uncomment to use a fine-grained personal access token instead of default github token
+        # (For more info on how to generate the token see https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+        # with:
+        # Make sure to save the token in your repository secrets
+        # token: $

--- a/.github/workflows/cp-update.yml
+++ b/.github/workflows/cp-update.yml
@@ -5,22 +5,20 @@ on:
   schedule:
     - cron: '0 0 1 * *' # run once a month on the 1st day
 
-# To use the default github token with the following elevated permissions make sure to check:
-# **Allow GitHub Actions to create and approve pull requests** in https://github.com/ORG_NAME/REPO_NAME/settings/actions.
-# Alternatively create a fine-grained personal access token for your repository with
-# `contents: read and write` and `pull requests: read and write` and pass it to the action.
-
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # required for create-github-app-token OIDC auth
     steps:
+      - id: get-github-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1 (2026-06-01)
+        with:
+          github_app: grafana-plugins-platform-bot
+
       - uses: grafana/plugin-actions/create-plugin-update@b82357e85d512c678416146ca4e9f8672bd108da # create-plugin-update/v2.0.2 (2026-03-09)
-        # Uncomment to use a fine-grained personal access token instead of default github token
-        # (For more info on how to generate the token see https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
-        # with:
-        # Make sure to save the token in your repository secrets
-        # token: $
+        with:
+          token: ${{ steps.get-github-token.outputs.token }}


### PR DESCRIPTION
**What is this feature?**

Adds a `create-plugin-update` workflow and bumps the pins in the existing `bundle-size` workflow. `actions/checkout` goes to `v7.0.1`, `bundle-size` to `v1.1.1`, and `create-plugin-update` lands on `v2.0.2`. Every action is pinned to the immutable release SHA with a `# version (date)` comment so Dependabot stays happy.

**Why do we need this feature?**

So we get automated bundle-size diffs on PRs and monthly create-plugin scaffolding updates.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #319

**Special notes for your reviewer:**

Also dropped `contents: write` to `contents: read` in `bundle-stats.yml` since the bundle-size action only needs read. 

How often should we run this? Monthly seems fine to me
