### PR TITLE
fix: always show panel menus and use secondary Include/Exclude buttons

### DIFF
--- a/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionsTable.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionsTable.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Icon, useStyles2, Tooltip } from '@grafana/ui';
+import { Button, Icon, Stack, useStyles2, Tooltip } from '@grafana/ui';
 import { t, Trans } from '@grafana/i18n';
 import { css } from '@emotion/css';
 import { SparklineCell } from './SparklineCell';
@@ -264,22 +264,24 @@ export const ExceptionsTable = ({ rows, theme, onFilterClick, scene }: Exception
                             )}
                           </div>
                         </div>
-                        <div className={styles.filterButtonsContainer}>
-                          <button
-                            className={styles.filterButton}
+                        <Stack gap={0.5}>
+                          <Button
+                            size="sm"
+                            variant="secondary"
                             onClick={(e) => handleMessageFilterClick(row.message, 'include', e)}
                             aria-label={t('exceptions-table.include-aria-label', 'Include exception message')}
                           >
                             <Trans i18nKey="exceptions-table.include">Include</Trans>
-                          </button>
-                          <button
-                            className={styles.filterButton}
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="secondary"
                             onClick={(e) => handleMessageFilterClick(row.message, 'exclude', e)}
                             aria-label={t('exceptions-table.exclude-aria-label', 'Exclude exception message')}
                           >
                             <Trans i18nKey="exceptions-table.exclude">Exclude</Trans>
-                          </button>
-                        </div>
+                          </Button>
+                        </Stack>
                       </div>
                     </div>
                   </td>
@@ -400,34 +402,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       flexDirection: 'column',
       flex: 1,
       minWidth: 0, // Allows flex item to shrink below content size
-    }),
-    filterButtonsContainer: css({
-      display: 'flex',
-      border: `1px solid ${theme.colors.border.medium}`,
-      borderRadius: '4px',
-      overflow: 'hidden',
-    }),
-    filterButton: css({
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      padding: `${theme.spacing(0.25)} ${theme.spacing(1)}`,
-      background: 'transparent',
-      border: 'none',
-      cursor: 'pointer',
-      color: theme.colors.text.primary,
-      fontSize: theme.typography.bodySmall.fontSize,
-      transition: 'background 0.2s ease-in-out, color 0.2s ease-in-out',
-      whiteSpace: 'nowrap',
-      '&:hover': {
-        background: theme.colors.background.primary,
-      },
-      '&:active': {
-        transform: 'scale(0.95)',
-      },
-      '&:not(:last-child)': {
-        borderRight: `1px solid ${theme.colors.border.medium}`,
-      },
     }),
     exceptionType: css({
       fontWeight: theme.typography.fontWeightMedium,

--- a/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionsTable.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Exceptions/ExceptionsTable.tsx
@@ -1,11 +1,12 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, Icon, Stack, useStyles2, Tooltip } from '@grafana/ui';
+import { Icon, useStyles2, Tooltip } from '@grafana/ui';
 import { t, Trans } from '@grafana/i18n';
 import { css } from '@emotion/css';
 import { SparklineCell } from './SparklineCell';
 import { ExceptionAccordionContent } from './accordion/ExceptionAccordion';
 import { SceneObject } from '@grafana/scenes';
+import { IncludeExcludeButtons } from 'components/Explore/actions/IncludeExcludeButtons';
 
 import { ExceptionMessageFilterOperator, getExceptionMessageFilter } from './ExceptionUtils';
 
@@ -264,24 +265,12 @@ export const ExceptionsTable = ({ rows, theme, onFilterClick, scene }: Exception
                             )}
                           </div>
                         </div>
-                        <Stack gap={0.5}>
-                          <Button
-                            size="sm"
-                            variant="secondary"
-                            onClick={(e) => handleMessageFilterClick(row.message, 'include', e)}
-                            aria-label={t('exceptions-table.include-aria-label', 'Include exception message')}
-                          >
-                            <Trans i18nKey="exceptions-table.include">Include</Trans>
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="secondary"
-                            onClick={(e) => handleMessageFilterClick(row.message, 'exclude', e)}
-                            aria-label={t('exceptions-table.exclude-aria-label', 'Exclude exception message')}
-                          >
-                            <Trans i18nKey="exceptions-table.exclude">Exclude</Trans>
-                          </Button>
-                        </Stack>
+                        <IncludeExcludeButtons
+                          onInclude={(e) => handleMessageFilterClick(row.message, 'include', e)}
+                          onExclude={(e) => handleMessageFilterClick(row.message, 'exclude', e)}
+                          includeAriaLabel={t('exceptions-table.include-aria-label', 'Include exception message')}
+                          excludeAriaLabel={t('exceptions-table.exclude-aria-label', 'Exclude exception message')}
+                        />
                       </div>
                     </div>
                   </td>

--- a/src/components/Explore/actions/AddToFiltersAction.tsx
+++ b/src/components/Explore/actions/AddToFiltersAction.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 
-import { DataFrame, GrafanaTheme2 } from '@grafana/data';
+import { DataFrame } from '@grafana/data';
 import { SceneObjectState, SceneObjectBase, SceneComponentProps, AdHocFiltersVariable } from '@grafana/scenes';
-import { t, Trans } from '@grafana/i18n';
-import { useStyles2 } from '@grafana/ui';
-import { css } from '@emotion/css';
+import { Trans } from '@grafana/i18n';
+import { Button, Stack } from '@grafana/ui';
 import { getFiltersVariable, getLabelValue } from '../../../utils/utils';
 import { DATABASE_CALLS_KEY } from 'pages/Explore/primary-signals';
 
@@ -46,53 +45,16 @@ export class AddToFiltersAction extends SceneObjectBase<AddToFiltersActionState>
   };
 
   public static Component = ({ model }: SceneComponentProps<AddToFiltersAction>) => {
-    const styles = useStyles2(getStyles);
-
     return (
-      <div className={styles.group} role="group" aria-label={t('add-to-filters-action.aria-label', 'Add to filters')}>
-        <button type="button" className={styles.segment} onClick={model.onIncludeClick}>
+      <Stack gap={0.5}>
+        <Button size="sm" variant="secondary" onClick={model.onIncludeClick}>
           <Trans i18nKey="add-to-filters-action.include">Include</Trans>
-        </button>
-        <button type="button" className={styles.segment} onClick={model.onExcludeClick}>
+        </Button>
+        <Button size="sm" variant="secondary" onClick={model.onExcludeClick}>
           <Trans i18nKey="add-to-filters-action.exclude">Exclude</Trans>
-        </button>
-      </div>
+        </Button>
+      </Stack>
     );
-  };
-}
-
-function getStyles(theme: GrafanaTheme2) {
-  return {
-    group: css({
-      display: 'inline-flex',
-      alignItems: 'stretch',
-      border: `1px solid ${theme.colors.border.medium}`,
-      borderRadius: theme.shape.radius.default,
-      padding: 0,
-      gap: theme.spacing(1.5),
-      overflow: 'hidden',
-    }),
-    segment: css({
-      ...theme.typography.bodySmall,
-      fontWeight: theme.typography.fontWeightBold,
-      lineHeight: 1.2,
-      color: theme.colors.text.primary,
-      background: 'transparent',
-      border: 'none',
-      margin: 0,
-      cursor: 'pointer',
-      display: 'inline-flex',
-      alignItems: 'center',
-      alignSelf: 'stretch',
-      padding: theme.spacing(0.5, 1),
-      '&:hover': {
-        backgroundColor: theme.colors.background.secondary,
-      },
-      '&:focus-visible': {
-        outline: 'none',
-        boxShadow: `inset 0 0 0 2px ${theme.colors.primary.border}`,
-      },
-    }),
   };
 }
 

--- a/src/components/Explore/actions/AddToFiltersAction.tsx
+++ b/src/components/Explore/actions/AddToFiltersAction.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 
 import { DataFrame } from '@grafana/data';
 import { SceneObjectState, SceneObjectBase, SceneComponentProps, AdHocFiltersVariable } from '@grafana/scenes';
-import { Trans } from '@grafana/i18n';
-import { Button, Stack } from '@grafana/ui';
 import { getFiltersVariable, getLabelValue } from '../../../utils/utils';
 import { DATABASE_CALLS_KEY } from 'pages/Explore/primary-signals';
+import { IncludeExcludeButtons } from './IncludeExcludeButtons';
 
 interface AddToFiltersActionState extends SceneObjectState {
   frame: DataFrame;
@@ -45,16 +44,7 @@ export class AddToFiltersAction extends SceneObjectBase<AddToFiltersActionState>
   };
 
   public static Component = ({ model }: SceneComponentProps<AddToFiltersAction>) => {
-    return (
-      <Stack gap={0.5}>
-        <Button size="sm" variant="secondary" onClick={model.onIncludeClick}>
-          <Trans i18nKey="add-to-filters-action.include">Include</Trans>
-        </Button>
-        <Button size="sm" variant="secondary" onClick={model.onExcludeClick}>
-          <Trans i18nKey="add-to-filters-action.exclude">Exclude</Trans>
-        </Button>
-      </Stack>
-    );
+    return <IncludeExcludeButtons onInclude={model.onIncludeClick} onExclude={model.onExcludeClick} />;
   };
 }
 

--- a/src/components/Explore/actions/IncludeExcludeButtons.test.tsx
+++ b/src/components/Explore/actions/IncludeExcludeButtons.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+
+import { IncludeExcludeButtons } from './IncludeExcludeButtons';
+
+describe('IncludeExcludeButtons', () => {
+  it('should render both buttons and call the matching handler', () => {
+    const onInclude = jest.fn();
+    const onExclude = jest.fn();
+
+    render(<IncludeExcludeButtons onInclude={onInclude} onExclude={onExclude} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Include' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Exclude' }));
+
+    expect(onInclude).toHaveBeenCalledTimes(1);
+    expect(onExclude).toHaveBeenCalledTimes(1);
+  });
+
+  it('should hide buttons when requested', () => {
+    render(
+      <IncludeExcludeButtons
+        onInclude={jest.fn()}
+        onExclude={jest.fn()}
+        showInclude={false}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Include' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Exclude' })).toBeInTheDocument();
+  });
+
+  it('should render nothing when both buttons are hidden', () => {
+    const { container } = render(
+      <IncludeExcludeButtons onInclude={jest.fn()} onExclude={jest.fn()} showInclude={false} showExclude={false} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/Explore/actions/IncludeExcludeButtons.tsx
+++ b/src/components/Explore/actions/IncludeExcludeButtons.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import { t, Trans } from '@grafana/i18n';
+import { Button, Stack } from '@grafana/ui';
+
+export interface IncludeExcludeButtonsProps {
+  onInclude: (event: React.MouseEvent) => void;
+  onExclude: (event: React.MouseEvent) => void;
+  showInclude?: boolean;
+  showExclude?: boolean;
+  includeAriaLabel?: string;
+  excludeAriaLabel?: string;
+}
+
+export function IncludeExcludeButtons({
+  onInclude,
+  onExclude,
+  showInclude = true,
+  showExclude = true,
+  includeAriaLabel = t('add-to-filters-action.include', 'Include'),
+  excludeAriaLabel = t('add-to-filters-action.exclude', 'Exclude'),
+}: IncludeExcludeButtonsProps) {
+  if (!showInclude && !showExclude) {
+    return null;
+  }
+
+  return (
+    <Stack gap={0.5}>
+      {showInclude && (
+        <Button size="sm" variant="secondary" onClick={onInclude} aria-label={includeAriaLabel}>
+          <Trans i18nKey="add-to-filters-action.include">Include</Trans>
+        </Button>
+      )}
+      {showExclude && (
+        <Button size="sm" variant="secondary" onClick={onExclude} aria-label={excludeAriaLabel}>
+          <Trans i18nKey="add-to-filters-action.exclude">Exclude</Trans>
+        </Button>
+      )}
+    </Stack>
+  );
+}

--- a/src/components/Explore/layouts/HighestDifferencePanel.tsx
+++ b/src/components/Explore/layouts/HighestDifferencePanel.tsx
@@ -1,11 +1,12 @@
 import { SceneComponentProps, SceneObjectBase, SceneObjectState, VizPanel } from '@grafana/scenes';
 import { DataFrame, GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { Button, Stack, useStyles2 } from '@grafana/ui';
+import { Stack, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import React from 'react';
 import { getFiltersVariable } from '../../../utils/utils';
 import { addToFilters } from '../actions/AddToFiltersAction';
+import { IncludeExcludeButtons } from '../actions/IncludeExcludeButtons';
 import { computeHighestDifference } from '../../../utils/comparison';
 
 interface HighestDifferencePanelState extends SceneObjectState {
@@ -96,18 +97,12 @@ export class HighestDifferencePanel extends SceneObjectBase<HighestDifferencePan
             <>
               <Stack gap={1} justifyContent={'space-between'} alignItems={'center'}>
                 <div className={styles.title}><Trans i18nKey="highest-difference-panel.title">Highest difference</Trans></div>
-                <Stack gap={0.5}>
-                  {!includeFilterExists && (
-                    <Button size="sm" variant="secondary" onClick={() => model.onIncludeClick()}>
-                      <Trans i18nKey="highest-difference-panel.include">Include</Trans>
-                    </Button>
-                  )}
-                  {!excludeFilterExists && (
-                    <Button size="sm" variant="secondary" onClick={() => model.onExcludeClick()}>
-                      <Trans i18nKey="highest-difference-panel.exclude">Exclude</Trans>
-                    </Button>
-                  )}
-                </Stack>
+                <IncludeExcludeButtons
+                  onInclude={() => model.onIncludeClick()}
+                  onExclude={() => model.onExcludeClick()}
+                  showInclude={!includeFilterExists}
+                  showExclude={!excludeFilterExists}
+                />
               </Stack>
               <div className={styles.differenceValue}>
                 {(Math.abs(maxDifference) * 100).toFixed(maxDifference === 0 ? 0 : 2)}%

--- a/src/components/Explore/layouts/HighestDifferencePanel.tsx
+++ b/src/components/Explore/layouts/HighestDifferencePanel.tsx
@@ -98,12 +98,12 @@ export class HighestDifferencePanel extends SceneObjectBase<HighestDifferencePan
                 <div className={styles.title}><Trans i18nKey="highest-difference-panel.title">Highest difference</Trans></div>
                 <Stack gap={0.5}>
                   {!includeFilterExists && (
-                    <Button size="sm" variant="primary" fill="text" onClick={() => model.onIncludeClick()}>
+                    <Button size="sm" variant="secondary" onClick={() => model.onIncludeClick()}>
                       <Trans i18nKey="highest-difference-panel.include">Include</Trans>
                     </Button>
                   )}
                   {!excludeFilterExists && (
-                    <Button size="sm" variant="primary" fill="text" onClick={() => model.onExcludeClick()}>
+                    <Button size="sm" variant="secondary" onClick={() => model.onExcludeClick()}>
                       <Trans i18nKey="highest-difference-panel.exclude">Exclude</Trans>
                     </Button>
                   )}

--- a/src/components/Explore/layouts/attributeBreakdown.ts
+++ b/src/components/Explore/layouts/attributeBreakdown.ts
@@ -155,6 +155,7 @@ export function getLayoutChild(
           onBreakdownCreateAlert,
         })
       )
+      .setShowMenuAlways(true)
       .setData(dataNode);
 
     const actions = actionsFn(frame);

--- a/src/locales/en-US/grafana-exploretraces-app.json
+++ b/src/locales/en-US/grafana-exploretraces-app.json
@@ -81,7 +81,6 @@
     "description": "View exception details from errored traces for the current set of filters."
   },
   "exceptions-table": {
-    "exclude": "Exclude",
     "exclude-aria-label": "Exclude exception message",
     "grouped-messages-aria-label": "Show grouped exception messages",
     "grouped-messages-common-prefix": "Common",
@@ -94,7 +93,6 @@
       "occurrences": "Occurrences",
       "occurrences-tooltip": "Total number of times this exception has occurred"
     },
-    "include": "Include",
     "include-aria-label": "Include exception message"
   },
   "exemplars": {
@@ -110,8 +108,6 @@
     }
   },
   "highest-difference-panel": {
-    "exclude": "Exclude",
-    "include": "Include",
     "title": "Highest difference"
   },
   "inspect-attribute-action": {

--- a/src/locales/en-US/grafana-exploretraces-app.json
+++ b/src/locales/en-US/grafana-exploretraces-app.json
@@ -3,7 +3,6 @@
     "loading": "Loading Adaptive Traces..."
   },
   "add-to-filters-action": {
-    "aria-label": "Add to filters",
     "exclude": "Exclude",
     "include": "Include"
   },


### PR DESCRIPTION
### ✨ Description

- Always show the breakdown panel kebab (`showMenuAlways`) so header actions do not leave empty hover-only menu space.
- Replace the Include/Exclude segmented control with two small secondary buttons (breakdown tiles, comparison highest-difference, exceptions table).

### 🧪 How to test?

<img width="574" height="178" alt="Screenshot 2026-08-24 at 08 41 56" src="https://github.com/user-attachments/assets/a144d7fe-0758-4cfa-b60b-06c5af6500d7" />
