### PR TITLE
chore(ci): pass correct node version to Create Plugin Update

### DIFF
--- a/.github/workflows/cp-update.yml
+++ b/.github/workflows/cp-update.yml
@@ -22,3 +22,4 @@ jobs:
       - uses: grafana/plugin-actions/create-plugin-update@b82357e85d512c678416146ca4e9f8672bd108da # create-plugin-update/v2.0.2 (2026-03-09)
         with:
           token: ${{ steps.get-github-token.outputs.token }}
+          node-version: '22'


### PR DESCRIPTION
**What is this feature?**

Passes `node-version: '22'` to the `create-plugin-update` action in the `cp-update` workflow.

**Why do we need this feature?**

So the Create Plugin Update workflow runs with the correct Node version

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
