### PR TITLE
fix: use locationUtil.assureBaseUrl for subpath URLs

### DIFF
--- a/src/components/Explore/TracesByService/Tabs/Spans/SpanListScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Spans/SpanListScene.tsx
@@ -10,8 +10,7 @@ import {
   SceneObjectBase,
   SceneObjectState,
 } from '@grafana/scenes';
-import { DataFrame, GrafanaTheme2, LoadingState, PanelData, toURLRange, urlUtil, toOption } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { DataFrame, GrafanaTheme2, LoadingState, PanelData, locationUtil, toURLRange, urlUtil, toOption } from '@grafana/data';
 import { LoadingStateScene } from 'components/states/LoadingState/LoadingStateScene';
 import { EmptyStateScene } from 'components/states/EmptyState/EmptyStateScene';
 import { css } from '@emotion/css';
@@ -146,8 +145,10 @@ export class SpanListScene extends SceneObjectBase<SpanListSceneState> {
         datasource,
       },
     });
-    const subUrl = config.appSubUrl ?? '';
-    return urlUtil.renderUrl(`${subUrl}/explore`, { panes: exploreState, schemaVersion: 1 });
+    return urlUtil.renderUrl(locationUtil.assureBaseUrl('/explore'), {
+      panes: exploreState,
+      schemaVersion: 1,
+    });
   };
 
   private updatePanel(data?: PanelData) {

--- a/src/components/Explore/panels/PanelMenu.tsx
+++ b/src/components/Explore/panels/PanelMenu.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
-import { PanelMenuItem, toURLRange, urlUtil } from '@grafana/data';
-import { config, usePluginComponent } from '@grafana/runtime';
+import { PanelMenuItem, locationUtil, toURLRange, urlUtil } from '@grafana/data';
+import { usePluginComponent } from '@grafana/runtime';
 import { t } from '@grafana/i18n';
 import {
   SceneObjectBase,
@@ -114,8 +114,10 @@ const getExploreHref = (model: SceneObject<PanelMenuState>) => {
       queries: [{ refId: 'A', datasource, query: model.state.query, step }],
     },
   });
-  const subUrl = config.appSubUrl ?? '';
-  const exploreUrl = urlUtil.renderUrl(`${subUrl}/explore`, { panes: exploreState, schemaVersion: 1 });
+  const exploreUrl = urlUtil.renderUrl(locationUtil.assureBaseUrl('/explore'), {
+    panes: exploreState,
+    schemaVersion: 1,
+  });
   return exploreUrl;
 };
 

--- a/src/featureFlags/openFeature.test.tsx
+++ b/src/featureFlags/openFeature.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, renderHook, screen, waitFor } from '@testing-library/react';
 import { OpenFeatureTestProvider } from '@openfeature/react-sdk';
 import { OpenFeature } from '@openfeature/web-sdk';
+import { GrafanaConfig, locationUtil } from '@grafana/data';
 import { logWarning } from '@grafana/runtime';
 
 import { TIME_SEEKER_FEATURE_FLAG_KEY, useFlagTracesDrilldownTimeSeeker } from './featureFlags';
@@ -26,13 +27,26 @@ jest.mock('@grafana/runtime', () => {
   };
 });
 
+let ofrepBaseUrl: string | undefined;
+
 /** Real OFREP constructs `OFREPApi` in the constructor (needs fetch); that runs before `setProviderAndWait` is invoked. */
 jest.mock('@openfeature/ofrep-web-provider', () => ({
   OFREPWebProvider: class MockOFREPWebProvider {
     metadata = { name: 'mock-ofrep' };
     runsOn = 'client';
+    constructor(options: { baseUrl?: string }) {
+      ofrepBaseUrl = options.baseUrl;
+    }
   },
 }));
+
+function initLocationUtil(appSubUrl: string) {
+  locationUtil.initialize({
+    config: { appSubUrl } as GrafanaConfig,
+    getTimeRangeForUrl: () => ({ from: 'now-1h', to: 'now' }),
+    getVariablesUrlParams: () => ({}),
+  });
+}
 
 describe('openFeature', () => {
   let setProviderAndWaitSpy: jest.SpiedFunction<(typeof OpenFeature)['setProviderAndWait']>;
@@ -40,6 +54,8 @@ describe('openFeature', () => {
   beforeEach(async () => {
     resetOpenFeaturePluginStateForTesting();
     jest.clearAllMocks();
+    ofrepBaseUrl = undefined;
+    initLocationUtil('');
     await OpenFeature.clearProviders();
     setProviderAndWaitSpy = jest.spyOn(OpenFeature, 'setProviderAndWait').mockResolvedValue(undefined);
   });
@@ -123,6 +139,20 @@ describe('openFeature', () => {
       expect(a).toBe(b);
       await a;
       expect(setProviderAndWaitSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('prefixes the OFREP path with appSubUrl and strips a trailing slash', async () => {
+      const expectedPath = `/grafana/apis/features.grafana.app/v0alpha1/namespaces/${encodeURIComponent('test-ns')}`;
+
+      initLocationUtil('/grafana');
+      await ensureOpenFeaturePluginInitialized();
+      expect(ofrepBaseUrl).toBe(new URL(expectedPath, window.location.origin).toString());
+
+      resetOpenFeaturePluginStateForTesting();
+      ofrepBaseUrl = undefined;
+      initLocationUtil('/grafana/');
+      await ensureOpenFeaturePluginInitialized();
+      expect(ofrepBaseUrl).toBe(new URL(expectedPath, window.location.origin).toString());
     });
   });
 });

--- a/src/featureFlags/openFeature.tsx
+++ b/src/featureFlags/openFeature.tsx
@@ -4,6 +4,7 @@ import { OFREPWebProvider } from '@openfeature/ofrep-web-provider';
 import { StandardResolutionReasons } from '@openfeature/core';
 import { OpenFeature, type Provider, type ResolutionDetails } from '@openfeature/web-sdk';
 
+import { locationUtil } from '@grafana/data';
 import { config, logWarning } from '@grafana/runtime';
 
 /** OpenFeature domain for this plugin’s evaluations (OFREP to Grafana’s feature API). */
@@ -14,9 +15,9 @@ function getFeaturesOfrepBaseUrl(): string | undefined {
   if (typeof window === 'undefined') {
     return undefined;
   }
-  const sub = (config.appSubUrl ?? '').replace(/\/$/, '');
-  const path = `${sub}/apis/features.grafana.app/v0alpha1/namespaces/${encodeURIComponent(config.namespace)}`;
-  const pathname = path.startsWith('/') ? path : `/${path}`;
+  const pathname = locationUtil.assureBaseUrl(
+    `/apis/features.grafana.app/v0alpha1/namespaces/${encodeURIComponent(config.namespace)}`
+  );
   return new URL(pathname, window.location.origin).toString();
 }
 

--- a/src/featureFlags/openFeature.tsx
+++ b/src/featureFlags/openFeature.tsx
@@ -15,9 +15,12 @@ function getFeaturesOfrepBaseUrl(): string | undefined {
   if (typeof window === 'undefined') {
     return undefined;
   }
-  const pathname = locationUtil.assureBaseUrl(
-    `/apis/features.grafana.app/v0alpha1/namespaces/${encodeURIComponent(config.namespace)}`
-  );
+  const pathname = locationUtil
+    .assureBaseUrl(
+      `/apis/features.grafana.app/v0alpha1/namespaces/${encodeURIComponent(config.namespace)}`
+    )
+    // Match the previous appSubUrl.replace(/\/$/, '') join so `/grafana/` does not become `//apis`.
+    .replace(/\/{2,}/g, '/');
   return new URL(pathname, window.location.origin).toString();
 }
 

--- a/src/pages/Explore/DataLinksCustomContext.test.tsx
+++ b/src/pages/Explore/DataLinksCustomContext.test.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { DataLinksCustomContext } from './DataLinksCustomContext';
-import { DataLinksContext, locationUtil, useDataLinksContext } from '@grafana/data';
+import { DataLinksContext, GrafanaConfig, locationUtil, useDataLinksContext } from '@grafana/data';
 import { getDataSourceSrv, usePluginFunctions } from '@grafana/runtime';
 
 // --- Mocks ---
@@ -19,7 +19,6 @@ jest.mock('@grafana/data', () => {
 });
 
 jest.mock('@grafana/runtime', () => ({
-  config: { appSubUrl: '/grafana' },
   getDataSourceSrv: jest.fn(),
   usePluginFunctions: jest.fn(),
 }));
@@ -85,7 +84,7 @@ beforeEach(() => {
   capturedContext = null;
   setupAllConditionsMet();
   locationUtil.initialize({
-    config: { appSubUrl: '/grafana' } as Parameters<typeof locationUtil.initialize>[0]['config'],
+    config: { appSubUrl: '/grafana' } as GrafanaConfig,
     getTimeRangeForUrl: () => ({ from: 'now-1h', to: 'now' }),
     getVariablesUrlParams: () => ({}),
   });

--- a/src/pages/Explore/DataLinksCustomContext.test.tsx
+++ b/src/pages/Explore/DataLinksCustomContext.test.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { DataLinksCustomContext } from './DataLinksCustomContext';
-import { DataLinksContext, useDataLinksContext } from '@grafana/data';
+import { DataLinksContext, locationUtil, useDataLinksContext } from '@grafana/data';
 import { getDataSourceSrv, usePluginFunctions } from '@grafana/runtime';
 
 // --- Mocks ---
@@ -84,6 +84,11 @@ beforeEach(() => {
   jest.clearAllMocks();
   capturedContext = null;
   setupAllConditionsMet();
+  locationUtil.initialize({
+    config: { appSubUrl: '/grafana' } as Parameters<typeof locationUtil.initialize>[0]['config'],
+    getTimeRangeForUrl: () => ({ from: 'now-1h', to: 'now' }),
+    getVariablesUrlParams: () => ({}),
+  });
 });
 
 // --- Tests ---

--- a/src/pages/Explore/DataLinksCustomContext.tsx
+++ b/src/pages/Explore/DataLinksCustomContext.tsx
@@ -1,11 +1,12 @@
 import {
   DataLinkPostProcessor,
   DataLinksContext,
+  locationUtil,
   PluginExtensionLink,
   TimeRange,
   useDataLinksContext,
 } from '@grafana/data';
-import { config, getDataSourceSrv, usePluginFunctions } from '@grafana/runtime';
+import { getDataSourceSrv, usePluginFunctions } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import React, { useCallback, useMemo, useRef } from 'react';
 
@@ -81,8 +82,7 @@ export function DataLinksCustomContext(props: Props) {
       });
 
       if (extensionLink?.path) {
-        const subUrl = config.appSubUrl ?? '';
-        linkModel.href = `${subUrl}${extensionLink.path}`;
+        linkModel.href = locationUtil.assureBaseUrl(extensionLink.path);
       }
     }
 


### PR DESCRIPTION
## Description
Fixes: #872

Explore links, Loki data links, and the OFREP base URL now use locationUtil.assureBaseUrl instead of concatenating config.appSubUrl.

[x] This pull request was substantially generated with AI assistance

## How to test
* Grafana behind a subpath
* Explore menu and span list links keep the subpath
* Loki drilldown data link keeps the subpath
* pnpm lint, typecheck, and the DataLinksCustomContext tests