### PR TITLE
chore(ci): bump create-plugin-update to v2.0.3

### DIFF
--- a/.github/workflows/cp-update.yml
+++ b/.github/workflows/cp-update.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           github_app: grafana-plugins-platform-bot
 
-      - uses: grafana/plugin-actions/create-plugin-update@b82357e85d512c678416146ca4e9f8672bd108da # create-plugin-update/v2.0.2 (2026-03-09)
+      - uses: grafana/plugin-actions/create-plugin-update@143b102daefed8b8dff14becfdd7eabcdbfa0ec7 # create-plugin-update/v2.0.3 (2026-08-20)
         with:
           token: ${{ steps.get-github-token.outputs.token }}
           node-version: '22'


### PR DESCRIPTION
**What is this feature?**

Bumps `grafana/plugin-actions/create-plugin-update` from `v2.0.2` to `v2.0.3` in `.github/workflows/cp-update.yml`.

**Why do we need this feature?**

So the monthly `cp-update` workflow stops failing with `GH013: Commits must have verified signatures`. `v2.0.2` commits locally with `git commit` + `git push`, which produces unsigned commits our ruleset rejects. `v2.0.3` switches to the GitHub GraphQL `createCommitOnBranch` API, which GitHub signs automatically.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Pin-only change, no functional difference to our workflow inputs (`token`, `node-version`).
