### PR TITLE
chore(ci): bump create-plugin-update to v2.0.4

### DIFF
--- a/.github/workflows/cp-update.yml
+++ b/.github/workflows/cp-update.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           github_app: grafana-plugins-platform-bot
 
-      - uses: grafana/plugin-actions/create-plugin-update@143b102daefed8b8dff14becfdd7eabcdbfa0ec7 # create-plugin-update/v2.0.3 (2026-08-20)
+      - uses: grafana/plugin-actions/create-plugin-update@18c6da61002740639bf0322e1a756366d98f5b81 # create-plugin-update/v2.0.4 (2026-08-25)
         with:
           token: ${{ steps.get-github-token.outputs.token }}
           node-version: '22'


### PR DESCRIPTION
**What is this feature?**

Bumps `create-plugin-update` from v2.0.3 to v2.0.4.

**Why do we need this feature?**

So the plugin update workflow uses the latest action version.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

see https://github.com/grafana/traces-drilldown/actions/runs/32719570946/job/97407907797

```bash
Error: Multiple versions of pnpm specified:
      - version 11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26 in the GitHub Action config with the key "version"
      - version pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26 in the package.json with the key "packageManager"
    Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
        at jDe (/home/runner/work/_actions/pnpm/action-setup/0977fd99725f1db4007ccb2928dbb4e90d06cc86/dist/index.js:263:77090)
        at zDe (/home/runner/work/_actions/pnpm/action-setup/0977fd99725f1db4007ccb2928dbb4e90d06cc86/dist/index.js:263:76407)
        at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
        at async YDe (/home/runner/work/_actions/pnpm/action-setup/0977fd99725f1db4007ccb2928dbb4e90d06cc86/dist/index.js:273:730)
        at async KDe (/home/runner/work/_actions/pnpm/action-setup/0977fd99725f1db4007ccb2928dbb4e90d06cc86/dist/index.js:273:2048)
        at async $De (/home/runner/work/_actions/pnpm/action-setup/0977fd99725f1db4007ccb2928dbb4e90d06cc86/dist/index.js:273:1934)
    Error: Error: Multiple versions of pnpm specified:
      - version 11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26 in the GitHub Action config with the key "version"
      - version pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26 in the package.json with the key "packageManager"
    Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
```

**Special notes for your reviewer:**
