### PR TITLE
chore(e2e): add primary signal option test ids

### DIFF
--- a/e2e/components.spec.ts
+++ b/e2e/components.spec.ts
@@ -1,4 +1,6 @@
+import { testIds } from '../src/utils/testIds';
 import { expect, test } from './index';
+import { gte } from 'semver';
 
 test.describe('components', () => {
   test('in header are visible', async ({ tracesExplorePage, selectors }) => {
@@ -66,5 +68,19 @@ test.describe('components', () => {
     ).toBeVisible({
       timeout: 20000,
     });
+  });
+
+  test('pathfinder test ids are available', async ({ tracesExplorePage, grafanaVersion, selectors }) => {
+    // https://github.com/grafana/grafana/pull/131243
+    if (!gte(grafanaVersion, '13.3.0-32698776838')) {
+      return;
+    }
+
+    // https://github.com/grafana/traces-drilldown/issues/844
+    await expect(tracesExplorePage.page.getByTestId(testIds.primarySignalOptionRootSpans)).toBeVisible();
+    await expect(tracesExplorePage.page.getByTestId(testIds.primarySignalOptionAllSpans)).toBeVisible();
+    await expect(tracesExplorePage.page.getByTestId(testIds.primarySignalOptionServerSpans)).not.toBeVisible();
+    await expect(tracesExplorePage.page.getByTestId(testIds.primarySignalOptionConsumerSpans)).not.toBeVisible();
+    await expect(tracesExplorePage.page.getByTestId(testIds.primarySignalOptionDatbaseCalls)).not.toBeVisible();
   });
 });

--- a/src/pages/Explore/primary-signals.ts
+++ b/src/pages/Explore/primary-signals.ts
@@ -1,4 +1,5 @@
 import { SelectableValue } from '@grafana/data';
+import { testIds } from 'utils/testIds';
 
 export const DATABASE_CALLS_KEY = 'span.db.system.name';
 
@@ -8,30 +9,35 @@ export const primarySignalOptions: Array<SelectableValue<string>> = [
     value: 'nestedSetParent<0',
     filter: { key: 'nestedSetParent', operator: '<', value: '0' },
     description: 'Focus your analysis on the root span of each trace',
+    dataTestId: testIds.primarySignalOptionRootSpans,
   },
   {
     label: 'All spans',
     value: 'true',
     filter: { key: '', operator: '', value: true },
     description: 'View and analyse raw span data. This option may result in long query times.',
+    dataTestId: testIds.primarySignalOptionAllSpans,
   },
   {
     label: 'Server spans',
     value: 'kind=server',
     filter: { key: 'kind', operator: '=', value: 'server' },
     description: 'Explore server-specific segments of traces',
+    dataTestId: testIds.primarySignalOptionServerSpans,
   },
   {
     label: 'Consumer spans',
     value: 'kind=consumer',
     filter: { key: 'kind', operator: '=', value: 'consumer' },
     description: 'Analyze interactions initiated by consumer services',
+    dataTestId: testIds.primarySignalOptionConsumerSpans,
   },
   {
     label: 'Database calls',
     value: `${DATABASE_CALLS_KEY}!=""`,
     filter: { key: DATABASE_CALLS_KEY, operator: '!=', value: '""' },
     description: 'Evaluate the performance issues in database interactions',
+    dataTestId: testIds.primarySignalOptionDatbaseCalls,
   },
 ];
 

--- a/src/utils/testIds.test.ts
+++ b/src/utils/testIds.test.ts
@@ -20,27 +20,27 @@ describe('getTestIdFromMetric', () => {
 
   it('should return correct testid for unknown metric', () => {
     const metric: VariableValue = 'log';
-    expect(getTestIdFromMetric(metric)).toEqual('data-testid unknown-panel');
+    expect(getTestIdFromMetric(metric)).toEqual('unknown-panel');
   });
 
   it('should return correct testid for no metric', () => {
-    expect(getTestIdFromMetric('')).toEqual('data-testid unknown-panel');
+    expect(getTestIdFromMetric('')).toEqual('unknown-panel');
   });
 });
 
 describe('getTestIdFromAttribute', () => {
   it('should return correct testid for attribute', () => {
     const attribute: AttributeItem = { label: 'name', scope: 'Span', value: 'name' };
-    expect(getTestIdFromAttribute(attribute)).toEqual('data-testid name-attribute-item');
+    expect(getTestIdFromAttribute(attribute)).toEqual('grafana-exploretraces-app name-attribute-item');
   });
 
   it('should return correct testid for attribute without value', () => {
     const attribute: AttributeItem = { label: 'name', scope: 'Span', value: '' };
-    expect(getTestIdFromAttribute(attribute)).toEqual('data-testid unknown-attribute-item');
+    expect(getTestIdFromAttribute(attribute)).toEqual('grafana-exploretraces-app unknown-attribute-item');
   });
 
   it('should return correct testid for undefined attribute', () => {
     const attribute = undefined as unknown as AttributeItem;
-    expect(getTestIdFromAttribute(attribute)).toEqual('data-testid unknown-attribute-item');
+    expect(getTestIdFromAttribute(attribute)).toEqual('grafana-exploretraces-app unknown-attribute-item');
   });
 });

--- a/src/utils/testIds.ts
+++ b/src/utils/testIds.ts
@@ -1,17 +1,24 @@
 import { VariableValue } from '@grafana/scenes';
 import { AttributeItem } from '../types';
+import pluginJson from '../plugin.json';
 
 export const testIds = {
-  emptyState: 'data-testid empty-state',
-  errorState: 'data-testid error-state',
-  loadingState: 'data-testid loading-state',
-  ratePanel: `data-testid rate-panel`,
-  errorsPanel: `data-testid errors-panel`,
-  durationPanel: `data-testid duration-panel`,
-  breakdownContainer: `data-testid breakdown container`,
-  serviceStructureContainer: `data-testid service structure container`,
-  comparisonContainer: `data-testid comparison container`,
-  tracesContainer: `data-testid traces container`,
+  emptyState: `${pluginJson.id} empty-state`,
+  errorState: `${pluginJson.id} error-state`,
+  loadingState: `${pluginJson.id} loading-state`,
+  ratePanel: `${pluginJson.id} rate-panel`,
+  errorsPanel: `${pluginJson.id} errors-panel`,
+  durationPanel: `${pluginJson.id} duration-panel`,
+  breakdownContainer: `${pluginJson.id} breakdown container`,
+  serviceStructureContainer: `${pluginJson.id} service structure container`,
+  comparisonContainer: `${pluginJson.id} comparison container`,
+  tracesContainer: `${pluginJson.id} traces container`,
+  primarySignalOptionRootSpans: `${pluginJson.id} primary signal option root spans`,
+  primarySignalOptionAllSpans: `${pluginJson.id} primary signal option all spans`,
+  primarySignalOptionServerSpans: `${pluginJson.id} primary signal option server spans`,
+  primarySignalOptionConsumerSpans: `${pluginJson.id} primary signal option consumer spans`,
+  primarySignalOptionDatbaseCalls: `${pluginJson.id} primary signal option database calls`,
+  primarySignalSelect: `${pluginJson.id} primary signal select`,
 };
 
 export function getTestIdFromMetric(metric: VariableValue | string): string {
@@ -25,12 +32,12 @@ export function getTestIdFromMetric(metric: VariableValue | string): string {
       return testIds.durationPanel;
   }
 
-  return 'data-testid unknown-panel';
+  return 'unknown-panel';
 }
 
 export function getTestIdFromAttribute(attribute: AttributeItem): string {
   if (!attribute?.value) {
-    return 'data-testid unknown-attribute-item';
+    return `${pluginJson.id} unknown-attribute-item`;
   }
-  return `data-testid ${attribute.value}-attribute-item`;
+  return `${pluginJson.id} ${attribute.value}-attribute-item`;
 }


### PR DESCRIPTION
**What is this feature?**

Adds test ids to the primary signal options and switches all test ids to be prefixed with the plugin id from `plugin.json`. Also adds an e2e test that verifies the primary signal test ids are available once the Pathfinder change lands in Grafana.

**Why do we need this feature?**

So we can reliably target the primary signal options in e2e tests and in pathfinder.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #844

**Special notes for your reviewer:**

The new e2e test is gated behind `13.3.0-32698776838` since it depends on grafana/grafana#131243.
