### PR TITLE
fix: skip duration filter without latency

### DIFF
--- a/src/components/Explore/TracesByService/Tabs/Structure/StructureScene.test.ts
+++ b/src/components/Explore/TracesByService/Tabs/Structure/StructureScene.test.ts
@@ -1,4 +1,4 @@
-import { parseTraces } from './StructureScene';
+import { buildQuery, parseTraces } from './StructureScene';
 import { dumpTree, mergeTraces } from '../../../../../utils/trace-merge/merge';
 import { SearchResponse } from '../../../../../types';
 
@@ -30,5 +30,70 @@ describe('parseTraces', () => {
     const fromArray = mergeTraces(parseTraces(JSON.stringify(response.traces)));
 
     expect(dumpTree(fromArray, 0)).toEqual(dumpTree(fromResponse, 0));
+  });
+});
+
+describe('buildQuery', () => {
+  const baseFields = {
+    refId: 'A',
+    queryType: 'traceql',
+    tableType: 'raw',
+    limit: 200,
+    spss: 20,
+    filters: [],
+  };
+
+  it('should build a rate query filtering on server spans', () => {
+    const expected =
+      '({${primarySignal} && ${filters} } &>> { kind = server }) || ({${primarySignal} && ${filters} }) | select(status, resource.service.name, name, nestedSetParent, nestedSetLeft, nestedSetRight)';
+
+    const result = buildQuery('rate', '', '');
+
+    expect(result).toEqual({ ...baseFields, query: expected });
+  });
+
+  it('should build an errors query filtering on error status', () => {
+    const expected =
+      '({${primarySignal} && ${filters} && status = error} &>> { status = error }) || ({${primarySignal} && ${filters} && status = error}) | select(status, resource.service.name, name, nestedSetParent, nestedSetLeft, nestedSetRight)';
+
+    const result = buildQuery('errors', '', '');
+
+    expect(result).toEqual({ ...baseFields, query: expected });
+  });
+
+  it('should build a duration query with no thresholds set', () => {
+    const expected =
+      '({${primarySignal} && ${filters} } &>> { true }) || ({${primarySignal} && ${filters} }) | select(status, resource.service.name, name, nestedSetParent, nestedSetLeft, nestedSetRight)';
+
+    const result = buildQuery('duration', '', '');
+
+    expect(result).toEqual({ ...baseFields, query: expected });
+  });
+
+  it('should build a duration query using only the partial latency threshold', () => {
+    const expected =
+      '({${primarySignal} && ${filters} } &>> { duration > ${partialLatencyThreshold} }) || ({${primarySignal} && ${filters} }) | select(status, resource.service.name, name, nestedSetParent, nestedSetLeft, nestedSetRight)';
+
+    const result = buildQuery('duration', '100ms', '');
+
+    expect(result).toEqual({ ...baseFields, query: expected });
+  });
+
+  it('should build a duration query using only the latency threshold', () => {
+    const expected =
+      '({${primarySignal} && ${filters} && duration > ${latencyThreshold}} &>> { true }) || ({${primarySignal} && ${filters} && duration > ${latencyThreshold}}) | select(status, resource.service.name, name, nestedSetParent, nestedSetLeft, nestedSetRight)';
+
+    const result = buildQuery('duration', '', '200ms');
+
+    expect(result).toEqual({ ...baseFields, query: expected });
+  });
+
+  it('should build a duration query using both latency thresholds', () => {
+    const expected =
+      '({${primarySignal} && ${filters} && duration > ${latencyThreshold}} &>> { duration > ${partialLatencyThreshold} }) || ({${primarySignal} && ${filters} && duration > ${latencyThreshold}}) | select(status, resource.service.name, name, nestedSetParent, nestedSetLeft, nestedSetRight)';
+
+    const result = buildQuery('duration', '100ms', '200ms');
+
+    expect(result).toEqual({ ...baseFields, query: expected });
   });
 });

--- a/src/components/Explore/TracesByService/Tabs/Structure/StructureScene.tsx
+++ b/src/components/Explore/TracesByService/Tabs/Structure/StructureScene.tsx
@@ -30,7 +30,12 @@ import { t, Trans } from '@grafana/i18n';
 import Skeleton from 'react-loading-skeleton';
 import { EmptyState } from '../../../../states/EmptyState/EmptyState';
 import { css } from '@emotion/css';
-import { getOpenTrace, getTraceExplorationScene } from 'utils/utils';
+import {
+  getLatencyPartialThresholdVariable,
+  getLatencyThresholdVariable,
+  getOpenTrace,
+  getTraceExplorationScene,
+} from 'utils/utils';
 import { structureDisplayName } from '../TabsBarScene';
 import { testIds } from 'utils/testIds';
 
@@ -45,22 +50,27 @@ const ROOT_SPAN_ID = '0000000000000000';
 
 export class StructureTabScene extends SceneObjectBase<ServicesTabSceneState> {
   constructor(state: Partial<ServicesTabSceneState>) {
-    super({
-      $data: new SceneDataTransformer({
-        $data: new SceneQueryRunner({
-          datasource: explorationDS,
-          queries: [buildQuery(state.metric as MetricFunction)],
-        }),
-        transformations: filterStreamingProgressTransformations,
-      }),
-      loading: true,
-      ...state,
-    });
+    super({ ...state });
 
     this.addActivationHandler(this._onActivate.bind(this));
   }
 
   public _onActivate() {
+    const partialLatency = getLatencyPartialThresholdVariable(this).getValue()?.toString() ?? '';
+    const latency = getLatencyThresholdVariable(this).getValue()?.toString() ?? '';
+
+    this.setState({
+      $data: new SceneDataTransformer({
+        $data: new SceneQueryRunner({
+          datasource: explorationDS,
+          queries: [buildQuery(this.state.metric as MetricFunction, partialLatency, latency)],
+        }),
+        transformations: filterStreamingProgressTransformations,
+      }),
+      ...this.state,
+      loading: true,
+    });
+
     this._subs.add(
       this.state.$data?.subscribeToState((state) => {
         if (state.data?.state === LoadingState.Loading || state.data?.state === LoadingState.Streaming) {
@@ -381,7 +391,7 @@ export function parseTraces(frame: string): TraceSearchMetadata[] {
   return Array.isArray(parsed) ? parsed : (parsed?.traces ?? []);
 }
 
-function buildQuery(metric: MetricFunction) {
+export function buildQuery(metric: MetricFunction, partialLatency: string, latency: string) {
   let metricQuery;
   let selectionQuery = '';
   switch (metric) {
@@ -390,8 +400,8 @@ function buildQuery(metric: MetricFunction) {
       selectionQuery = 'status = error';
       break;
     case 'duration':
-      metricQuery = `duration > ${VAR_LATENCY_PARTIAL_THRESHOLD_EXPR}`;
-      selectionQuery = `duration > ${VAR_LATENCY_THRESHOLD_EXPR}`;
+      metricQuery = partialLatency ? `duration > ${VAR_LATENCY_PARTIAL_THRESHOLD_EXPR}` : 'true';
+      selectionQuery = latency ? `duration > ${VAR_LATENCY_THRESHOLD_EXPR}` : '';
       break;
     default:
       metricQuery = 'kind = server';

--- a/src/components/Explore/TracesByService/TracesByServiceScene.test.tsx
+++ b/src/components/Explore/TracesByService/TracesByServiceScene.test.tsx
@@ -45,7 +45,7 @@ describe('TracesByServiceScene', () => {
 
   describe('buildQuery', () => {
     it('should build basic query with no selection', () => {
-      const query = buildQuery('rate', '');
+      const query = buildQuery('rate', '', '');
       expect(query).toEqual({
         refId: 'A',
         query: '{${primarySignal} && ${filters}}',
@@ -58,12 +58,17 @@ describe('TracesByServiceScene', () => {
     });
 
     it('should add error status for error type', () => {
-      const query = buildQuery('errors', '');
+      const query = buildQuery('errors', '', '');
       expect(query.query).toBe('{${primarySignal} && ${filters} && status = error}');
     });
 
-    it('should add latency threshold for duration type with no selection', () => {
-      const query = buildQuery('duration', '');
+    it('should not add latency threshold for duration type without latency and with no selection', () => {
+      const query = buildQuery('duration', '', '');
+      expect(query.query).toBe('{${primarySignal} && ${filters}}');
+    });
+
+    it('should add latency threshold for duration type with latency and with no selection', () => {
+      const query = buildQuery('duration', '', '4ms');
       expect(query.query).toBe('{${primarySignal} && ${filters}&& duration > ${latencyThreshold}}');
     });
 
@@ -75,7 +80,7 @@ describe('TracesByServiceScene', () => {
           to: '500ms',
         },
       };
-      const query = buildQuery('duration', '', selection);
+      const query = buildQuery('duration', '', '', selection);
       expect(query.query).toBe('{${primarySignal} && ${filters}&& duration >= 100ms && duration <= 500ms}');
     });
 
@@ -87,7 +92,7 @@ describe('TracesByServiceScene', () => {
           to: '',
         },
       };
-      const query = buildQuery('duration', '', selection);
+      const query = buildQuery('duration', '', '', selection);
       expect(query.query).toBe('{${primarySignal} && ${filters}&& duration >= 100ms}');
     });
 
@@ -99,12 +104,12 @@ describe('TracesByServiceScene', () => {
           to: '500ms',
         },
       };
-      const query = buildQuery('duration', '', selection);
+      const query = buildQuery('duration', '', '', selection);
       expect(query.query).toBe('{${primarySignal} && ${filters}&& duration <= 500ms}');
     });
 
     it('should add select columns when provided', () => {
-      const query = buildQuery('rate', 'duration,service.name');
+      const query = buildQuery('rate', 'duration,service.name', '');
       expect(query.query).toBe('{${primarySignal} && ${filters}} | select(duration,service.name)');
     });
   });

--- a/src/components/Explore/TracesByService/TracesByServiceScene.tsx
+++ b/src/components/Explore/TracesByService/TracesByServiceScene.tsx
@@ -42,6 +42,7 @@ import { isEqual } from 'lodash';
 import {
   getDatasourceVariable,
   getGroupByVariable,
+  getLatencyThresholdVariable,
   getSpanListColumnsVariable,
   getTraceExplorationScene,
 } from 'utils/utils';
@@ -284,12 +285,13 @@ export class TracesByServiceScene extends SceneObjectBase<TraceSceneState> {
   private updateQueryRunner(metric: MetricFunction) {
     const selection = this.state.selection;
     const columns = getSpanListColumnsVariable(this).getValue()?.toString() ?? '';
+    const latency = getLatencyThresholdVariable(this).getValue()?.toString() ?? '';
 
     this.setState({
       $data: new SceneDataTransformer({
         $data: new SceneQueryRunner({
           datasource: explorationDS,
-          queries: [buildQuery(metric, columns, selection)],
+          queries: [buildQuery(metric, columns, latency, selection)],
           $timeRange: timeRangeFromSelection(selection),
         }),
         transformations: [...filterStreamingProgressTransformations, ...spanListTransformations],
@@ -426,7 +428,7 @@ function getStyles(theme: GrafanaTheme2) {
 const MAIN_PANEL_HEIGHT = 240;
 export const MINI_PANEL_HEIGHT = (MAIN_PANEL_HEIGHT - 8) / 2;
 
-export function buildQuery(type: MetricFunction, columns: string, selection?: ComparisonSelection) {
+export function buildQuery(type: MetricFunction, columns: string, latency: string, selection?: ComparisonSelection) {
   const selectQuery = columns !== '' ? ` | select(${columns})` : '';
   let typeQuery = '';
   switch (type) {
@@ -446,7 +448,7 @@ export function buildQuery(type: MetricFunction, columns: string, selection?: Co
           typeQuery += '&& ' + duration.join(' && ');
         }
       }
-      if (!typeQuery.length) {
+      if (!typeQuery.length && latency) {
         typeQuery = `&& duration > ${VAR_LATENCY_THRESHOLD_EXPR}`;
       }
       break;


### PR DESCRIPTION
**What is this feature?**

Fixes so the duration query no longer adds `&& duration > ${latencyThreshold}` when no latency threshold is set. `buildQuery` now takes the latency value explicitly and only adds that clause when it's truthy.

**Why do we need this feature?**

So the duration view returns results instead of an empty/invalid comparison when there's no latency filter.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #850

**Special notes for your reviewer:**

