### PR TITLE
chore: updates keywords and navigation name

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -7,7 +7,7 @@
   "autoEnabled": true,
   "languages": ["en-US"],
   "info": {
-    "keywords": ["app", "tempo", "traces", "explore"],
+    "keywords": ["app", "tempo", "traces", "explore", "drilldown", "drill", "down", "drill-down"],
     "description": "Use Rate, Errors, and Duration (RED) metrics derived from traces to investigate errors within complex distributed systems.",
     "author": {
       "name": "Grafana"
@@ -46,7 +46,7 @@
   "includes": [
     {
       "type": "page",
-      "name": "Explore",
+      "name": "Grafana Traces Drilldown",
       "path": "/a/%PLUGIN_ID%/",
       "action": "datasources:explore",
       "addToNav": true,


### PR DESCRIPTION
**What is this feature?**

Updates `plugin.json`: adds `drilldown`, `drill`, `down`, `drill-down` to `keywords` so the plugin surfaces in catalog search, and renames the nav page from `Explore` to `Grafana Traces Drilldown`.

**Why do we need this feature?**

So the plugin is easier to find and the nav label matches the product name

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For #841

**Special notes for your reviewer:**

