### PR TITLE
fix: initialize i18n before embedded Trace Exploration mounts

### DIFF
--- a/src/exposedComponents/index.test.tsx
+++ b/src/exposedComponents/index.test.tsx
@@ -1,0 +1,78 @@
+import { dateTime } from '@grafana/data';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { SuspendedEmbeddedTraceExploration, SuspendedOpenInExploreTracesButton } from './index';
+
+const initPluginI18n = jest.fn();
+
+jest.mock('i18n/initPluginI18n', () => ({
+  initPluginI18n: (...args: unknown[]) => initPluginI18n(...args),
+}));
+
+jest.mock('featureFlags/openFeature', () => ({
+  OpenFeaturePluginScope: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const embeddedRender = jest.fn(() => <div>embedded-exploration</div>);
+jest.mock('exposedComponents/EmbeddedTraceExploration/EmbeddedTraceExploration', () => ({
+  __esModule: true,
+  default: () => embeddedRender(),
+}));
+
+const buttonRender = jest.fn(() => <div>open-in-explore-button</div>);
+jest.mock('exposedComponents/OpenInExploreTracesButton/OpenInExploreTracesButton', () => ({
+  __esModule: true,
+  default: () => buttonRender(),
+}));
+
+const initialTimeRange = {
+  from: dateTime(1000),
+  to: dateTime(3000),
+  raw: { from: dateTime(1000), to: dateTime(3000) },
+};
+
+describe('exposed component i18n init', () => {
+  let resolveInit: () => void;
+
+  beforeEach(() => {
+    embeddedRender.mockClear();
+    buttonRender.mockClear();
+    initPluginI18n.mockReset();
+    initPluginI18n.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveInit = resolve;
+        })
+    );
+  });
+
+  it('does not mount EmbeddedTraceExploration until i18n init finishes', async () => {
+    render(<SuspendedEmbeddedTraceExploration initialTimeRange={initialTimeRange} />);
+
+    expect(initPluginI18n).toHaveBeenCalled();
+    expect(embeddedRender).not.toHaveBeenCalled();
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+
+    resolveInit();
+
+    await waitFor(() => {
+      expect(screen.getByText('embedded-exploration')).toBeInTheDocument();
+    });
+    expect(embeddedRender).toHaveBeenCalled();
+  });
+
+  it('does not mount OpenInExploreTracesButton until i18n init finishes', async () => {
+    render(<SuspendedOpenInExploreTracesButton matchers={[]} />);
+
+    expect(initPluginI18n).toHaveBeenCalled();
+    expect(buttonRender).not.toHaveBeenCalled();
+
+    resolveInit();
+
+    await waitFor(() => {
+      expect(screen.getByText('open-in-explore-button')).toBeInTheDocument();
+    });
+    expect(buttonRender).toHaveBeenCalled();
+  });
+});

--- a/src/exposedComponents/index.tsx
+++ b/src/exposedComponents/index.tsx
@@ -2,13 +2,17 @@ import { Trans } from '@grafana/i18n';
 import { LinkButton } from '@grafana/ui';
 import { OpenFeaturePluginScope } from 'featureFlags/openFeature';
 import { OpenInExploreTracesButtonProps, EmbeddedTraceExplorationState } from 'exposedComponents/types';
+import { initPluginI18n } from 'i18n/initPluginI18n';
 import React, { lazy, Suspense } from 'react';
-const OpenInExploreTracesButton = lazy(
-  () => import('exposedComponents/OpenInExploreTracesButton/OpenInExploreTracesButton')
-);
-const EmbeddedTraceExploration = lazy(
-  () => import('exposedComponents/EmbeddedTraceExploration/EmbeddedTraceExploration')
-);
+
+const OpenInExploreTracesButton = lazy(async () => {
+  await initPluginI18n();
+  return import('exposedComponents/OpenInExploreTracesButton/OpenInExploreTracesButton');
+});
+const EmbeddedTraceExploration = lazy(async () => {
+  await initPluginI18n();
+  return import('exposedComponents/EmbeddedTraceExploration/EmbeddedTraceExploration');
+});
 
 export function SuspendedOpenInExploreTracesButton(props: OpenInExploreTracesButtonProps) {
   return (

--- a/src/i18n/__tests__/initPluginI18n.test.ts
+++ b/src/i18n/__tests__/initPluginI18n.test.ts
@@ -1,0 +1,46 @@
+const initPluginTranslations = jest.fn().mockResolvedValue(undefined);
+const scenesLoadResources = jest.fn();
+const pluginLoadResources = jest.fn();
+
+jest.mock('@grafana/i18n', () => ({
+  initPluginTranslations: (...args: unknown[]) => initPluginTranslations(...args),
+}));
+
+jest.mock('@grafana/scenes', () => ({
+  loadResources: scenesLoadResources,
+}));
+
+jest.mock('../loadResources', () => ({
+  loadResources: pluginLoadResources,
+}));
+
+describe('initPluginI18n', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    initPluginTranslations.mockClear();
+  });
+
+  it('initializes scenes and plugin translations once', async () => {
+    jest.doMock('@grafana/runtime', () => ({
+      config: { buildInfo: { version: '12.2.0' } },
+    }));
+
+    const { initPluginI18n } = await import('../initPluginI18n');
+    await Promise.all([initPluginI18n(), initPluginI18n()]);
+
+    expect(initPluginTranslations).toHaveBeenCalledTimes(2);
+    expect(initPluginTranslations).toHaveBeenNthCalledWith(1, 'grafana-scenes', [scenesLoadResources]);
+    expect(initPluginTranslations).toHaveBeenNthCalledWith(2, 'grafana-exploretraces-app', []);
+  });
+
+  it('loads plugin resources on Grafana versions before 12.1.0', async () => {
+    jest.doMock('@grafana/runtime', () => ({
+      config: { buildInfo: { version: '12.0.0' } },
+    }));
+
+    const { initPluginI18n } = await import('../initPluginI18n');
+    await initPluginI18n();
+
+    expect(initPluginTranslations).toHaveBeenNthCalledWith(2, 'grafana-exploretraces-app', [pluginLoadResources]);
+  });
+});

--- a/src/i18n/initPluginI18n.ts
+++ b/src/i18n/initPluginI18n.ts
@@ -1,0 +1,25 @@
+import { config } from '@grafana/runtime';
+import { lt } from 'semver';
+
+import pluginJson from '../plugin.json';
+
+let initPromise: Promise<void> | undefined;
+
+export function initPluginI18n(): Promise<void> {
+  if (!initPromise) {
+    initPromise = doInit();
+  }
+  return initPromise;
+}
+
+async function doInit() {
+  const { initPluginTranslations } = await import('@grafana/i18n');
+  const { loadResources: scenesLoadResources } = await import('@grafana/scenes');
+  await initPluginTranslations('grafana-scenes', [scenesLoadResources]);
+
+  const { loadResources } = await import('./loadResources');
+  await initPluginTranslations(
+    pluginJson.id,
+    lt(config?.buildInfo?.version || '0.0.0', '12.1.0') ? [loadResources] : []
+  );
+}

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -1,27 +1,20 @@
 import { lazy } from 'react';
 import { AppPlugin } from '@grafana/data';
-import { config } from '@grafana/runtime';
-import { lt } from 'semver';
 
 import { EmbeddedTraceExplorationState, OpenInExploreTracesButtonProps } from 'exposedComponents/types';
 import { SuspendedEmbeddedTraceExploration, SuspendedOpenInExploreTracesButton } from 'exposedComponents';
+import { initPluginI18n } from './i18n/initPluginI18n';
 import { linkConfigs } from 'utils/links';
 import { JsonData } from './components/AppConfig/AppConfig';
-import pluginJson from './plugin.json';
 
 const App = lazy(async () => {
-  const { initPluginTranslations } = await import('@grafana/i18n');
-
-  const { loadResources: scenesLoadResources } = await import('@grafana/scenes');
-  await initPluginTranslations('grafana-scenes', [scenesLoadResources]);
-
-  const { loadResources } = await import('./i18n/loadResources');
-  const pluginLoaders = lt(config?.buildInfo?.version || '0.0.0', '12.1.0') ? [loadResources] : [];
-  await initPluginTranslations(pluginJson.id, pluginLoaders);
-
+  await initPluginI18n();
   return import('./components/App/App');
 });
-const AppConfig = lazy(() => import('./components/AppConfig/AppConfig'));
+const AppConfig = lazy(async () => {
+  await initPluginI18n();
+  return import('./components/AppConfig/AppConfig');
+});
 
 export const plugin = new AppPlugin<JsonData>()
   .setRootPage(App)

--- a/src/pages/Explore/TraceExploration.modes.test.ts
+++ b/src/pages/Explore/TraceExploration.modes.test.ts
@@ -1,0 +1,51 @@
+import { DataSourceVariable } from '@grafana/scenes';
+
+import { newTracesExploration } from '../../utils/utils';
+import { VAR_DATASOURCE } from '../../utils/shared';
+import { TraceExploration } from './TraceExploration';
+
+jest.mock('@grafana/i18n', () => {
+  const actual = jest.requireActual('@grafana/i18n');
+  return {
+    ...actual,
+    t: (id: string, fallback: string, values?: Record<string, unknown>) => {
+      if ((globalThis as { __tracesI18nNotReady?: boolean }).__tracesI18nNotReady) {
+        throw new Error('t() was called before i18n was initialized');
+      }
+      return actual.t(id, fallback, values);
+    },
+  };
+});
+
+describe('TraceExploration i18n during construction', () => {
+  afterEach(() => {
+    delete (globalThis as { __tracesI18nNotReady?: boolean }).__tracesI18nNotReady;
+  });
+
+  it('throws for app and embedded scenes when t() runs before i18n init', () => {
+    (globalThis as { __tracesI18nNotReady?: boolean }).__tracesI18nNotReady = true;
+
+    expect(() => newTracesExploration('tempo')).toThrow('t() was called before i18n was initialized');
+    expect(() => new TraceExploration({ embedded: true, initialDS: 'tempo' })).toThrow(
+      't() was called before i18n was initialized'
+    );
+  });
+
+  it('builds the non-embedded app scene after i18n init', () => {
+    const exploration = newTracesExploration('tempo');
+    const ds = exploration.state.$variables?.getByName(VAR_DATASOURCE) as DataSourceVariable | undefined;
+
+    expect(exploration.state.embedded).toBeUndefined();
+    expect(ds?.state.isReadOnly).toBeFalsy();
+    expect(ds?.state.label).toBe('Data source');
+  });
+
+  it('builds the embedded scene after i18n init', () => {
+    const exploration = new TraceExploration({ embedded: true, initialDS: 'tempo' });
+    const ds = exploration.state.$variables?.getByName(VAR_DATASOURCE) as DataSourceVariable | undefined;
+
+    expect(exploration.state.embedded).toBe(true);
+    expect(ds?.state.isReadOnly).toBe(true);
+    expect(ds?.state.label).toBe('Data source');
+  });
+});


### PR DESCRIPTION
### ✨ Description

Follow-up to #879 (create-plugin 7.10.0). That bump marked `i18next` as a webpack external while `@grafana/i18n` stays bundled, so `t()` can run against an uninitialized wrapper. The embed path never called `initPluginTranslations` (only the App lazy load did).

- Exposed components (and the App page) now await a shared `initPluginI18n()` before rendering, so `t()` is not called in the `TraceExploration` constructor before translations are ready.
- Fixes `t() was called before i18n was initialized` when Grafana loads Embedded Trace Exploration without opening the full app.

### 🧪 How to test?

- [ ] Open a host that embeds Trace Exploration without visiting Traces Drilldown first — no i18n console error, view loads.
- [ ] Open Traces Drilldown (non-embedded) — should load.
