### PR TITLE
fix(deps): resolve pnpm audit vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ overrides:
   js-cookie: ^3.0.7
   ws: 8.21.3
   js-yaml: 4.3.1
-  qs: ^6.15.3
+  qs: ^6.16.0
   brace-expansion@^1: 1.1.18
   brace-expansion@^5: '>=5.0.9'
   fast-uri: '>=4.1.3'
@@ -4575,8 +4575,8 @@ packages:
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -10893,7 +10893,7 @@ snapshots:
 
   pure-rand@7.0.1: {}
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
@@ -11784,7 +11784,7 @@ snapshots:
       faye-websocket: 0.10.0
       livereload-js: 2.4.0
       object-assign: 4.1.1
-      qs: 6.15.3
+      qs: 6.16.0
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ overrides:
   js-cookie: ^3.0.7
   ws: 8.21.3
   js-yaml: 4.3.1
-  qs: ^6.15.3
+  qs: ^6.16.0
   brace-expansion@^1: 1.1.18
   brace-expansion@^5: '>=5.0.9'
   fast-uri: '>=4.1.3'


### PR DESCRIPTION
## Summary

- Bump the existing `qs` override from `^6.15.3` to `^6.16.0`.
- Refresh the lockfile from `qs` 6.15.3 to 6.16.0.
- Resolve `qs` advisories GHSA-x5fp-wj9c-mxmx and GHSA-4mjr-xmp4-gh2g.

## Validation

- `npm view qs@6.16.0 version` → `6.16.0`
- `npm view qs@6.16.0 peerDependencies --json` → no peer dependencies
- `pnpm install --no-frozen-lockfile` → passed, including supply-chain policy verification
- `pnpm typecheck` → passed
- `pnpm lint` → passed with 0 errors and 9 pre-existing warnings
- `pnpm test:ci` → passed (50 suites, 484 tests)
- `pnpm build` → passed with the existing asset-size warning
- `pnpm audit` → non-zero: 2 moderate React Router vulnerabilities remain

## React Router v8-core experiment

The metrics-drilldown alignment was tested here: direct `react-router@^8.3.0` and `react-router-dom@^7.18.1`, with overrides for `react-router@^8.3.0` and `react-router-dom@^6` to the published v7 line. Installation passed supply-chain verification, produced one shared router core (currently 8.3.1 with DOM 7.18.3), and made `pnpm audit` clean. It was not retained because `pnpm typecheck` then failed: this app's `Navigate`, `Route`, and `Routes` imports from `react-router-dom` were no longer exported with the overridden v8 core. The experiment was reverted before final validation.

There is also a residual compatibility risk in that approach: `react-router` 8.3.x declares `react` and `react-dom` peer requirements of `>=19.2.7`, while this plugin currently uses React 18.3.1. `pnpm peers check` reported both peers as unmet. A runtime import smoke check against the metrics-drilldown reference's installed `react-router@8.3.0` and React 18.3.1 also threw because React 18 does not export `useOptimistic`. This risk is not suppressed.

## Known remaining

- GHSA-wrjc-x8rr-h8h6 — `react-router` 6.30.6: patched only in `>=7.18.0`; no 6.x backport is published. The tested v8-core override does not compile in this repository, as documented above.
- GHSA-337j-9hxr-rhxg — `react-router` 6.30.6: patched only in `>=7.18.0`; no 6.x backport is published. The tested v8-core override does not compile in this repository, as documented above.

